### PR TITLE
ci: adapt workflows and keep publish disabled until v1

### DIFF
--- a/.github/workflows/pr-xunit-tests.yml
+++ b/.github/workflows/pr-xunit-tests.yml
@@ -1,0 +1,55 @@
+name: PR .NET Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  dotnet-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Discover test projects
+        id: discover
+        shell: bash
+        run: |
+          mapfile -t projects < <(git ls-files '*.csproj' | grep -Ei '(test|tests)' || true)
+
+          if [[ ${#projects[@]} -eq 0 ]]; then
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "has_tests=true"
+            echo "projects<<EOF"
+            printf '%s\n' "${projects[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore and run tests
+        if: ${{ steps.discover.outputs.has_tests == 'true' }}
+        shell: bash
+        run: |
+          while IFS= read -r project; do
+            [[ -z "$project" ]] && continue
+            echo "Testing: $project"
+            dotnet restore "$project"
+            dotnet test "$project" --configuration Release --no-restore --verbosity minimal
+          done <<< "${{ steps.discover.outputs.projects }}"
+
+      - name: No test projects found
+        if: ${{ steps.discover.outputs.has_tests != 'true' }}
+        run: echo "::notice::No .NET test projects were found. Skipping tests."

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,115 @@
+name: Publish NuGet Package (Disabled Until v1)
+
+on:
+  workflow_dispatch:
+    inputs:
+      enable_release:
+        description: "Set true to run publish intentionally"
+        required: true
+        default: "false"
+      project_path:
+        description: "Path to .csproj to pack/publish (optional)"
+        required: false
+      package_version:
+        description: "Package version override (optional)"
+        required: false
+
+jobs:
+  publish:
+    if: ${{ github.event.inputs.enable_release == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Resolve package project
+        id: project
+        shell: bash
+        run: |
+          input_project="${{ github.event.inputs.project_path }}"
+          if [[ -n "$input_project" ]]; then
+            if [[ ! -f "$input_project" ]]; then
+              echo "project_path was provided but not found: $input_project"
+              exit 1
+            fi
+            project="$input_project"
+          else
+            mapfile -t candidates < <(git ls-files '*.csproj' | grep -Evi '(test|tests)' || true)
+            if [[ ${#candidates[@]} -eq 0 ]]; then
+              echo "No publishable .csproj found. Provide workflow_dispatch input: project_path"
+              exit 1
+            fi
+            if [[ ${#candidates[@]} -gt 1 ]]; then
+              echo "Multiple .csproj candidates found. Provide workflow_dispatch input: project_path"
+              printf ' - %s\n' "${candidates[@]}"
+              exit 1
+            fi
+            project="${candidates[0]}"
+          fi
+
+          echo "project=$project" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve package version
+        id: version
+        shell: bash
+        run: |
+          project="${{ steps.project.outputs.project }}"
+          manual_version="${{ github.event.inputs.package_version }}"
+
+          if [[ -n "$manual_version" ]]; then
+            package_version="$manual_version"
+          else
+            version_prefix=$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' "$project" || true)
+            if [[ -z "$version_prefix" ]]; then
+              version_prefix="0.1.0"
+            fi
+            package_version="${version_prefix}-ci.${GITHUB_RUN_NUMBER}"
+          fi
+
+          if [[ -z "$package_version" ]]; then
+            echo "Failed to resolve package version."
+            exit 1
+          fi
+
+          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Restore
+        run: dotnet restore "${{ steps.project.outputs.project }}"
+
+      - name: Build
+        run: dotnet build "${{ steps.project.outputs.project }}" --configuration Release --no-restore
+
+      - name: Pack
+        run: |
+          dotnet pack "${{ steps.project.outputs.project }}" \
+            --configuration Release \
+            --no-build \
+            --output ./artifacts \
+            -p:ContinuousIntegrationBuild=true \
+            -p:PackageVersion=${{ steps.version.outputs.package_version }}
+
+      - name: Validate NuGet API key
+        if: ${{ env.NUGET_API_KEY == '' }}
+        run: |
+          echo "NUGET_API_KEY secret is not set."
+          exit 1
+
+      - name: Publish to NuGet.org
+        if: ${{ env.NUGET_API_KEY != '' }}
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "${{ env.NUGET_API_KEY }}" \
+            --source "https://api.nuget.org/v3/index.json" \
+            --skip-duplicate

--- a/reports/2026-04-03-github-workflow-adaptation.md
+++ b/reports/2026-04-03-github-workflow-adaptation.md
@@ -1,0 +1,27 @@
+# GitHub Workflow 適合化レポート
+
+- Date: 2026-04-03
+- Scope: `.github/workflows/*.yml`
+
+## 実施内容
+
+1. PR テスト workflow (`pr-xunit-tests.yml`)
+- `master` 前提を `main` へ変更
+- 固定テストプロジェクト参照を廃止
+- リポジトリ内の `*test*.csproj` / `*tests*.csproj` を自動検出して実行
+- テストプロジェクトが無い場合は notice を出して成功終了
+
+2. NuGet publish workflow (`publish-nuget.yml`)
+- 初版まで無効化するため `release` トリガーを廃止
+- `workflow_dispatch` のみ残し、`enable_release=true` 指定時だけ実行
+- 固定 csproj パス依存を廃止
+- `workflow_dispatch` 入力で `project_path` / `package_version` 指定可能化
+- 未指定時はリポジトリ内 csproj から候補解決
+  - 候補なし: fail
+  - 候補複数: fail（明示指定を要求）
+
+## 目的
+
+- 現在のリポジトリ構成に依存しない CI/CD 基盤にする
+- 将来の実装追加時にも workflow を再利用可能にする
+- 初版までは「テストのみ有効」の運用を徹底する

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -65,3 +65,11 @@
 - 対応:
   - AGENTS.md に運用ルールを追記
   - 既存PR本文を body-file 指定で再設定
+- ユーザー指摘: release方法や自動テストは `.github` を参考に、このリポジトリ向けに修正すること。
+- 対応:
+  - PRテスト workflow を `main` 対応 + テストプロジェクト自動検出へ修正
+  - publish workflow を固定パス依存から解放し、project/version を解決可能に修正
+- ユーザー指摘: 初版が出るまではテストのみ有効にし、release は実行しないこと。
+- 対応:
+  - publish workflow の `release` トリガーを廃止
+  - `workflow_dispatch` でも `enable_release=true` 指定時のみ実行

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -30,7 +30,10 @@
 
 ## Phase 3: 実装
 
-- Status: Not Started
+- Status: In Progress
+- Notes:
+  - 実装着手前に CI/CD 基盤（.github workflows）をリポジトリ構成へ適合化
+  - 初版まではテスト workflow のみ有効、release publish は無効化
 
 ## Phase 4: 検証・受け入れ
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -98,4 +98,10 @@
   - Output:
     - `doc/design/detail/03-ContainerRules.md`（7.3）
     - `reports/2026-04-03-composite-key-clarification.md`
+- T-013: GitHub Actions のリポジトリ適合化
+  - Status: 完了（テスト有効化 + 初版までrelease無効化を反映）
+  - Output:
+    - `.github/workflows/pr-xunit-tests.yml`
+    - `.github/workflows/publish-nuget.yml`
+    - `reports/2026-04-03-github-workflow-adaptation.md`
 


### PR DESCRIPTION
## Summary
- enable PR test workflow for `main`
- auto-discover .NET test projects in CI instead of fixed project path
- keep NuGet publish workflow disabled until first release (`enable_release=true` required)
- record workflow adaptation in tasks/reports

## Why
PR #1 was merged before the latest workflow commit. This PR carries only the remaining CI/release workflow adjustments.

## Testing
- workflow YAML update only
- no runtime code changes
