### PR TITLE
[codex] Reactivate NuGet publish workflow on release

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,12 +1,11 @@
-name: Publish NuGet Package (Disabled Until v1)
+name: Publish NuGet Package
 
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
-      enable_release:
-        description: "Set true to run publish intentionally"
-        required: true
-        default: "false"
       project_path:
         description: "Path to .csproj to pack/publish (optional)"
         required: false
@@ -16,7 +15,6 @@ on:
 
 jobs:
   publish:
-    if: ${{ github.event.inputs.enable_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,9 +65,13 @@ jobs:
         run: |
           project="${{ steps.project.outputs.project }}"
           manual_version="${{ github.event.inputs.package_version }}"
+          event_name="${{ github.event_name }}"
+          release_tag="${{ github.event.release.tag_name }}"
 
           if [[ -n "$manual_version" ]]; then
             package_version="$manual_version"
+          elif [[ "$event_name" == "release" ]]; then
+            package_version="${release_tag#v}"
           else
             version_prefix=$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' "$project" || true)
             if [[ -z "$version_prefix" ]]; then

--- a/reports/2026-04-04-nuget-workflow-reactivation.md
+++ b/reports/2026-04-04-nuget-workflow-reactivation.md
@@ -1,0 +1,23 @@
+# NuGet Publish Workflow Reactivation (2026-04-04)
+
+## Summary
+
+Re-enabled GitHub Actions workflow for NuGet publishing.
+
+## Changes
+
+- File: `.github/workflows/publish-nuget.yml`
+- Updated workflow name:
+  - `Publish NuGet Package (Disabled Until v1)` -> `Publish NuGet Package`
+- Re-enabled release trigger:
+  - Added `on.release.types: [published]`
+- Kept manual trigger:
+  - `workflow_dispatch` remains available with optional `project_path` and `package_version`
+- Removed disable guard:
+  - Deleted `enable_release` input
+  - Deleted job-level `if: github.event.inputs.enable_release == 'true'`
+
+## Resulting Behavior
+
+- Publishing now runs automatically when a GitHub Release is published.
+- Publishing can also be run manually from Actions UI via `workflow_dispatch`.

--- a/reports/2026-04-04-nuget-workflow-release-version-alignment.md
+++ b/reports/2026-04-04-nuget-workflow-release-version-alignment.md
@@ -1,0 +1,19 @@
+# NuGet Workflow: Release Version Alignment (2026-04-04)
+
+## Background
+
+- Subagent review on workflow reactivation reported a medium issue:
+  - Release-triggered publish used CI-style version (`<VersionPrefix>-ci.<run_number>`) instead of release tag version.
+
+## Fix
+
+- File: `.github/workflows/publish-nuget.yml`
+- `Resolve package version` step updated:
+  - Priority 1: `workflow_dispatch` input `package_version`
+  - Priority 2: when `event_name == release`, use `github.event.release.tag_name` (strip leading `v`)
+  - Priority 3: fallback to existing CI suffix generation (`<VersionPrefix>-ci.<run_number>`)
+
+## Result
+
+- Release publish now aligns NuGet package version with GitHub Release tag.
+- Manual dispatch behavior remains unchanged.

--- a/reports/2026-04-04-subagent-code-review-nuget-workflow.md
+++ b/reports/2026-04-04-subagent-code-review-nuget-workflow.md
@@ -1,0 +1,36 @@
+# Subagent Code Review Report: NuGet Workflow Reactivation (2026-04-04)
+
+## Scope
+
+- `.github/workflows/publish-nuget.yml` の再有効化差分
+- 関連管理更新（`tasks/*.md`, `reports/2026-04-04-nuget-workflow-reactivation.md`）
+
+## Findings (by severity)
+
+### Critical
+
+- No critical findings.
+
+### High
+
+- No high findings.
+
+### Medium
+
+- Release トリガー時のパッケージバージョンが release/tag と連動していない。
+  - Target: `.github/workflows/publish-nuget.yml`
+  - Evidence: `Resolve package version` は `package_version` 未指定時に `<VersionPrefix>-ci.${GITHUB_RUN_NUMBER}` を生成するため、`release: published` 実行でもタグ版数を採用しない。
+  - Impact: GitHub Release 名/タグと NuGet 公開版数が一致しない運用になり、追跡性や再現性が下がる。
+
+### Low
+
+- No low findings.
+
+## Residual Risks
+
+- 期待運用が「Release タグ = NuGet 版数」の場合、現在のままでは運用ミスマッチが継続する。
+
+## Recommended Actions
+
+1. `release` イベント時は `github.ref_name`（タグ）を優先して `package_version` として採用する条件分岐を追加する。
+2. 手動実行 (`workflow_dispatch`) は現行どおり `package_version` 入力優先 + 未指定時 CI サフィックス生成を維持する。

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -114,3 +114,7 @@
 - ユーザー指摘: README を作成すること。
 - 対応:
   - トップレベル `README.md` を新規作成し、概要・API・実行手順・最小サンプルを記載
+- ユーザー指摘: NuGet に push する workflow を復活させること。
+- 対応:
+  - `publish-nuget.yml` の disable 条件を撤去し、`release: published` トリガーで publish を再有効化
+  - サブエージェントレビューで指摘された版数不整合を修正し、release タグ版数を優先採用するよう更新

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -45,6 +45,8 @@
   - 厳密化差分に対してサブエージェント再レビューを実施し、Low リスクのみ記録
   - モデル直下 List メンバーについて、両 model 複数要素ケースの E2E を追加し、union/slot を明示検証
   - トップレベル README を整備し、実装状況・利用導線・基本例を明文化
+  - NuGet publish workflow を再有効化し、`release` 公開時の自動配布を復帰
+  - 再有効化差分をサブエージェントレビューし、release タグ版数と NuGet 版数の整合ロジックを追加
   - `dotnet test SSC.sln --configuration Release` は成功（E2E 18件 / Unit 2件）
 
 ## Phase 4: 検証・受け入れ

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -155,3 +155,14 @@
   - Output:
     - `README.md`
     - `reports/2026-04-04-readme-bootstrap.md`
+- T-022: NuGet publish workflow の再有効化
+  - Status: 完了（release 公開時の自動 publish と手動実行を有効化）
+  - Output:
+    - `.github/workflows/publish-nuget.yml`
+    - `reports/2026-04-04-nuget-workflow-reactivation.md`
+- T-023: NuGet workflow 再有効化差分のレビュー反映
+  - Status: 完了（release タグと package version の整合を修正）
+  - Output:
+    - `.github/workflows/publish-nuget.yml`
+    - `reports/2026-04-04-subagent-code-review-nuget-workflow.md`
+    - `reports/2026-04-04-nuget-workflow-release-version-alignment.md`


### PR DESCRIPTION
## Summary
- Reactivate NuGet publish workflow for `release: published` events.
- Keep `workflow_dispatch` path for manual publish.
- Align package version resolution with release tags (`v` prefix stripped) to avoid release/version mismatch.

## Changes
- `.github/workflows/publish-nuget.yml`
  - Restore release trigger.
  - Remove disable gate (`enable_release` input and job-level conditional).
  - Update version resolution priority:
    1. `workflow_dispatch` input `package_version`
    2. release tag (`github.event.release.tag_name`, strip leading `v`)
    3. fallback CI suffix (`<VersionPrefix>-ci.<run_number>`)
- Add work reports and task tracking updates for this reactivation.

## Why
- NuGet publish had been intentionally disabled for initial phase.
- Current request is to restore release publishing while keeping traceability between GitHub Release tags and NuGet package versions.

## Validation
- Workflow logic review by subagent:
  - `reports/2026-04-04-subagent-code-review-nuget-workflow.md`
- No runtime/library code changes in this PR.