### PR TITLE
[codex] Reuse publish workflow for main prerelease flow

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       project_path:
@@ -17,7 +20,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: read
     env:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
@@ -66,12 +70,54 @@ jobs:
           project="${{ steps.project.outputs.project }}"
           manual_version="${{ github.event.inputs.package_version }}"
           event_name="${{ github.event_name }}"
+          ref_name="${{ github.ref_name }}"
           release_tag="${{ github.event.release.tag_name }}"
+          release_is_prerelease="${{ github.event.release.prerelease }}"
 
           if [[ -n "$manual_version" ]]; then
             package_version="$manual_version"
           elif [[ "$event_name" == "release" ]]; then
-            package_version="${release_tag#v}"
+            base_version="${release_tag#v}"
+            if [[ "$release_is_prerelease" == "true" ]]; then
+              if [[ "$base_version" == *-* ]]; then
+                package_version="$base_version"
+              else
+                package_version="${base_version}-pre"
+              fi
+            else
+              if [[ "$base_version" == *-* ]]; then
+                echo "Release is not pre-release, but tag contains pre-release suffix: $release_tag"
+                exit 1
+              fi
+              package_version="$base_version"
+            fi
+          elif [[ "$event_name" == "push" && "$ref_name" == "main" ]]; then
+            version_prefix=$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' "$project" || true)
+            if [[ -z "$version_prefix" ]]; then
+              version_prefix="0.1.0"
+            fi
+
+            latest_stable_tag=$(git tag --sort=-v:refname | grep -E '^(v)?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+            if [[ -n "$latest_stable_tag" ]]; then
+              base_version="${latest_stable_tag#v}"
+              commits_since_base=$(git rev-list --count "${latest_stable_tag}..HEAD")
+            else
+              base_version="$version_prefix"
+              commits_since_base=$(git rev-list --count HEAD)
+            fi
+
+            if [[ ! "$base_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid base version format: $base_version"
+              exit 1
+            fi
+
+            IFS='.' read -r major minor patch <<< "$base_version"
+            if [[ "$commits_since_base" -lt 1 ]]; then
+              commits_since_base=1
+            fi
+
+            next_patch=$((patch + commits_since_base))
+            package_version="${major}.${minor}.${next_patch}-pre"
           else
             version_prefix=$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' "$project" || true)
             if [[ -z "$version_prefix" ]]; then
@@ -115,3 +161,45 @@ jobs:
             --api-key "${{ env.NUGET_API_KEY }}" \
             --source "https://api.nuget.org/v3/index.json" \
             --skip-duplicate
+
+      - name: Verify gh CLI
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        run: gh --version
+
+      - name: Create GitHub Pre-release
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          repo="${{ github.repository }}"
+          sha="${{ github.sha }}"
+          tag="${{ steps.version.outputs.package_version }}"
+
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "GitHub pre-release already exists: $tag"
+            exit 0
+          fi
+
+          notes_file=$(mktemp)
+          {
+            echo "Automated pre-release from main push."
+            echo
+            pr_numbers=$(gh api -H "Accept: application/vnd.github+json" "/repos/${repo}/commits/${sha}/pulls" --jq '.[].number' 2>/dev/null || true)
+            if [[ -n "${pr_numbers}" ]]; then
+              echo "Related pull requests:"
+              while IFS= read -r pr; do
+                [[ -z "${pr}" ]] && continue
+                echo "- #${pr}"
+              done <<< "${pr_numbers}"
+            else
+              echo "Related pull request: not found."
+            fi
+          } > "$notes_file"
+
+          gh release create "$tag" \
+            --repo "$repo" \
+            --target "$sha" \
+            --title "$tag" \
+            --notes-file "$notes_file" \
+            --prerelease

--- a/reports/2026-04-04-publish-workflow-reuse-main-prerelease.md
+++ b/reports/2026-04-04-publish-workflow-reuse-main-prerelease.md
@@ -1,0 +1,27 @@
+# Publish Workflow Reuse and Main-PreRelease Automation (2026-04-04)
+
+## Summary
+
+Reused logic from `workflows/publish-nuget.yml` and integrated it into `.github/workflows/publish-nuget.yml`.
+
+## What Changed
+
+- Added `push` trigger for `main`.
+- Added `create-prerelease` job (runs only on `push` to `main`):
+  - Resolves publishable project path.
+  - Calculates pre-release version from latest stable tag and commit distance.
+  - Creates GitHub pre-release (`gh release create ... --prerelease`) if it does not exist.
+- Kept `publish` job and constrained it to:
+  - `release` event (published)
+  - `workflow_dispatch`
+
+## Publish Flow After Change
+
+1. Merge to `main` -> `create-prerelease` creates a GitHub pre-release tag.
+2. Release published event triggers `publish` job.
+3. `publish` packs and pushes package to NuGet.
+
+## Notes
+
+- Release version resolution still strips leading `v` from release tags.
+- Manual publish via `workflow_dispatch` remains supported.

--- a/reports/2026-04-04-publish-workflow-reuse-review-fix.md
+++ b/reports/2026-04-04-publish-workflow-reuse-review-fix.md
@@ -1,0 +1,24 @@
+# Publish Workflow Reuse: Review Fixes (2026-04-04)
+
+## Background
+
+- Subagent review (`reports/2026-04-04-subagent-code-review-publish-workflow-reuse.md`) reported a high risk:
+  - Release created with `GITHUB_TOKEN` may not trigger downstream release workflow reliably.
+
+## Fix Applied
+
+- Refactored `.github/workflows/publish-nuget.yml` to a single `publish` job that runs on:
+  - `push` to `main`
+  - `release: published`
+  - `workflow_dispatch`
+- On `push` to `main`:
+  - Compute pre-release package version.
+  - Build/pack/publish to NuGet directly in the same run.
+  - Create GitHub pre-release after publish.
+- Added `gh --version` guard before release creation step.
+
+## Effect
+
+- Main-merge path no longer depends on release-event propagation for NuGet publish.
+- Pre-release publish occurs deterministically in the same run as `push` to `main`.
+- Existing release/manual publish paths remain available.

--- a/reports/2026-04-04-publish-workflow-vtag-compatibility-fix.md
+++ b/reports/2026-04-04-publish-workflow-vtag-compatibility-fix.md
@@ -1,0 +1,16 @@
+# Publish Workflow v-Tag Compatibility Fix (2026-04-04)
+
+## Background
+
+- Re-review reported that stable tag detection ignored `v`-prefixed tags.
+
+## Fix
+
+- File: `.github/workflows/publish-nuget.yml`
+- In pre-release version resolution (`push` to `main`):
+  - Stable tag regex now accepts both `1.2.3` and `v1.2.3`.
+  - Base version uses normalized value with leading `v` stripped.
+
+## Effect
+
+- Pre-release version lineage now follows latest stable tag regardless of `v` prefix convention.

--- a/reports/2026-04-04-subagent-code-review-publish-workflow-reuse-fix.md
+++ b/reports/2026-04-04-subagent-code-review-publish-workflow-reuse-fix.md
@@ -1,0 +1,25 @@
+# Subagent Code Review Report: Publish Workflow Reuse Fix (2026-04-04)
+
+## Findings (by severity)
+
+### Critical
+- No critical findings.
+
+### High
+- No high findings.
+
+### Medium
+- Stable tag detection for pre-release base version excludes `v`-prefixed tags.
+  - Target: `.github/workflows/publish-nuget.yml`
+  - Evidence: `latest_stable_tag` uses regex `^[0-9]+\.[0-9]+\.[0-9]+$`, so tags like `v1.2.3` are ignored.
+  - Impact: If repository tags are `v`-prefixed, pre-release version base may fall back to `<VersionPrefix>` instead of latest stable tag.
+
+### Low
+- No low findings.
+
+## Residual Risks
+- If future tag naming policy changes (e.g., all tags become `v`-prefixed), pre-release version progression may diverge from expected stable lineage.
+
+## Recommended Actions
+1. Accept both `1.2.3` and `v1.2.3` patterns when selecting `latest_stable_tag`.
+2. Document tag naming policy in repository release process notes to avoid ambiguity.

--- a/reports/2026-04-04-subagent-code-review-publish-workflow-reuse.md
+++ b/reports/2026-04-04-subagent-code-review-publish-workflow-reuse.md
@@ -1,0 +1,28 @@
+# Subagent Code Review Report: Publish Workflow Reuse (2026-04-04)
+
+## Findings (by severity)
+
+### Critical
+- No critical findings.
+
+### High
+- `main` push で作成した pre-release が後続 publish を起動しない可能性が高い。
+  - Target: `.github/workflows/publish-nuget.yml`
+  - Evidence: `create-prerelease` は `GH_TOKEN: ${{ github.token }}` で `gh release create` を実行し、`publish` は `event_name == release || workflow_dispatch` の場合のみ実行される。`GITHUB_TOKEN` で生成したイベントは別 workflow を起動しない制約により、release run が発火せず publish がスキップされうる。
+  - Impact: 「main マージで pre-release -> NuGet publish」の要件が満たされない可能性。
+
+### Medium
+- `create-prerelease` ジョブが `gh` CLI 前提だが、明示的な導入/検証ステップがない。
+  - Target: `.github/workflows/publish-nuget.yml`
+  - Evidence: `gh release view/create` を直接実行しており、CLI 利用可否を事前確認していない。
+  - Impact: ランナーイメージ変更時に失敗するリスク。
+
+### Low
+- No low findings.
+
+## Residual Risks
+- release イベント伝播条件に依存したままだと、環境差異やトークン種別差異で publish 連携が不安定になる。
+
+## Recommended Actions
+1. `main` push run 内で publish まで完結させるか、release 作成を PAT ベースにして release workflow 発火を保証する。
+2. `gh --version` などの事前チェック、または `actions/create-release` / `actions/github-script` 等の action ベース実装へ置換する。

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -118,3 +118,8 @@
 - 対応:
   - `publish-nuget.yml` の disable 条件を撤去し、`release: published` トリガーで publish を再有効化
   - サブエージェントレビューで指摘された版数不整合を修正し、release タグ版数を優先採用するよう更新
+- ユーザー指摘: `workflows/publish-nuget.yml` を流用すること。
+- 対応:
+  - 既存流用ロジックを `.github/workflows/publish-nuget.yml` に統合し、`main` push 時 pre-release 作成を追加
+  - サブエージェントの High 指摘を反映し、`main` push ラン内で NuGet publish を完結させる構成へ修正
+  - 再レビュー Medium 指摘を反映し、stable tag 解決で `v` プレフィックス付きタグを許容

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -47,6 +47,9 @@
   - トップレベル README を整備し、実装状況・利用導線・基本例を明文化
   - NuGet publish workflow を再有効化し、`release` 公開時の自動配布を復帰
   - 再有効化差分をサブエージェントレビューし、release タグ版数と NuGet 版数の整合ロジックを追加
+  - `publish-nuget.yml` を流用し、`main` への push から pre-release 作成 -> publish 連携を自動化
+  - レビュー指摘に基づき、`main` push ラン内で pre-release publish を完結する構成へ修正
+  - stable tag 解決で `v` プレフィックス付きタグ互換を追加
   - `dotnet test SSC.sln --configuration Release` は成功（E2E 18件 / Unit 2件）
 
 ## Phase 4: 検証・受け入れ

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -166,3 +166,20 @@
     - `.github/workflows/publish-nuget.yml`
     - `reports/2026-04-04-subagent-code-review-nuget-workflow.md`
     - `reports/2026-04-04-nuget-workflow-release-version-alignment.md`
+- T-024: publish workflow 流用による main pre-release 自動化
+  - Status: 完了（`push: main` で pre-release 作成し、既存 publish job へ連携）
+  - Output:
+    - `.github/workflows/publish-nuget.yml`
+    - `reports/2026-04-04-publish-workflow-reuse-main-prerelease.md`
+- T-025: publish workflow 流用差分のレビュー指摘対応
+  - Status: 完了（releaseイベント依存を解消し、main push ランで publish を完結）
+  - Output:
+    - `.github/workflows/publish-nuget.yml`
+    - `reports/2026-04-04-subagent-code-review-publish-workflow-reuse.md`
+    - `reports/2026-04-04-publish-workflow-reuse-review-fix.md`
+- T-026: publish workflow の vタグ互換性補正
+  - Status: 完了（stable tag 検出で `v1.2.3` 形式を許容）
+  - Output:
+    - `.github/workflows/publish-nuget.yml`
+    - `reports/2026-04-04-subagent-code-review-publish-workflow-reuse-fix.md`
+    - `reports/2026-04-04-publish-workflow-vtag-compatibility-fix.md`


### PR DESCRIPTION
## Summary
- Reuse and integrate logic from `workflows/publish-nuget.yml` into `.github/workflows/publish-nuget.yml`.
- Enable pre-release packaging flow on `push` to `main`.
- Keep release/manual publish paths while making main-merge path deterministic.

## Changes
- `.github/workflows/publish-nuget.yml`
  - Add `push` trigger on `main`.
  - Extend version resolution for `push` to produce pre-release version from stable-tag lineage.
  - Publish to NuGet in the same `push` run.
  - Create GitHub pre-release after publish in `push` flow.
  - Keep `release: published` and `workflow_dispatch` behaviors.
- Add implementation/review reports and task tracking updates.

## Review-driven fixes
- Addressed high-risk issue about relying on release-event propagation by completing publish in the same `main` push run.
- Added compatibility for stable tag detection with `v`-prefixed and non-prefixed tags.

## Validation
- Subagent reviews:
  - `reports/2026-04-04-subagent-code-review-publish-workflow-reuse.md`
  - `reports/2026-04-04-subagent-code-review-publish-workflow-reuse-fix.md`
- Scope is workflow and project management docs only.