### PR TITLE
docs: rewrite README samples in full form without var

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ dotnet test SSC.sln -c Release --verbosity minimal
 ## Minimal Example
 
 ```csharp
+using System.Collections.Generic;
 using SSC;
 
-var models = new[]
+ProductModel[] models =
 {
     new ProductModel
     {
@@ -96,7 +97,7 @@ var models = new[]
     },
 };
 
-var result = ParallelCompareApi.Compare(models);
+CompareResult<ProductModel> result = ParallelCompareApi.Compare(models);
 dynamic root = result.AsDynamic()!;
 
 // item keys are normalized as union: 1, 2, 3
@@ -104,7 +105,7 @@ decimal? leftPriceAtKey1 = root.Items[0].Price[0];   // 100
 decimal? rightPriceAtKey1 = root.Items[0].Price[1];  // null (missing)
 decimal? leftPriceAtKey2 = root.Items[1].Price[0];   // 200
 decimal? rightPriceAtKey2 = root.Items[1].Price[1];  // 250
-var stateAtKey3Left = (ValueState)root.Items[2].GetState(0); // Missing
+ValueState stateAtKey3Left = (ValueState)root.Items[2].GetState(0); // Missing
 
 public sealed class ProductModel
 {
@@ -123,6 +124,7 @@ public sealed class ProductItem
 ## Source Generator Example
 
 ```csharp
+using System.Collections.Generic;
 using SSC;
 using SSC.Generated;
 
@@ -148,9 +150,43 @@ public sealed class Item
     public double MetricA { get; init; }
 }
 
-var result = ParallelCompareApi.Compare(models);
-var root = result.AsGeneratedView();
-var leftMetricAt100 = root!.Groups[0].Items[0].MetricA[0];
+Dataset[] models =
+{
+    new Dataset
+    {
+        Groups =
+        [
+            new Group
+            {
+                GroupId = 1,
+                Items =
+                [
+                    new Item { ItemId = 100, MetricA = 1.0 },
+                    new Item { ItemId = 200, MetricA = 2.0 },
+                ],
+            },
+        ],
+    },
+    new Dataset
+    {
+        Groups =
+        [
+            new Group
+            {
+                GroupId = 1,
+                Items =
+                [
+                    new Item { ItemId = 100, MetricA = 10.0 },
+                    new Item { ItemId = 300, MetricA = 30.0 },
+                ],
+            },
+        ],
+    },
+};
+
+CompareResult<Dataset> result = ParallelCompareApi.Compare(models);
+double? leftMetricAt100 = result.AsGeneratedView()!.Groups[0].Items[0].MetricA[0];
+ValueState rightStateAt200 = result.AsGeneratedView()!.Groups[0].Items[1].MetricA.GetState(1);
 ```
 
 ## Documentation

--- a/reports/2026-04-04-readme-sample-full-form-no-var.md
+++ b/reports/2026-04-04-readme-sample-full-form-no-var.md
@@ -1,0 +1,18 @@
+# README Samples: Full Form And No `var`
+
+- Date: 2026-04-04
+- Goal: README のコードサンプルを省略なし・`var` なしへ統一する
+
+## Changes
+
+- `README.md` の `Minimal Example` を更新
+  - `ProductModel[]` / `CompareResult<ProductModel>` / `ValueState` を明示
+  - クラス定義を含む完全形を維持
+- `README.md` の `Source Generator Example` を更新
+  - `Dataset[]` 入力データ定義を追加
+  - `CompareResult<Dataset>` を明示
+  - `AsGeneratedView()` 利用例を `double?` / `ValueState` で明示
+
+## Verification
+
+- `README.md` 全体で `var` の使用がないことを確認

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -255,3 +255,8 @@
 - 対応:
   - `README.md` の Minimal Example を `result.AsDynamic()` ベースへ更新
   - `root.Items[index].Price[modelIndex]` と `GetState(modelIndex)` の参照例へ差し替え
+- ユーザー指摘: README のコードサンプルはクラス定義を省略せず、`var` も使わないこと。
+- 対応:
+  - `README.md` の Minimal/Source Generator サンプルを完全形へ更新
+  - `ProductModel[]` / `Dataset[]` / `CompareResult<T>` / `ValueState` など型を明示
+  - `README.md` 全体で `var` 不使用を確認

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -81,6 +81,7 @@
   - ルート README に Source Generator 対応と2パッケージ利用導線を追記し、`SSC.Generators` パッケージにも README を同梱
   - NuGet metadata（repository/license）を両パッケージへ追加し、README に generator downloads バッジを追加
   - README の Minimal Example を `result.AsDynamic()` 入口の最新 dynamic 導線へ更新
+  - README のコードサンプルを省略なし・`var` なしの完全形へ統一
 
 ## Phase 4: 検証・受け入れ
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -16,6 +16,12 @@
 
 ## Done
 
+- T-052: README サンプルを省略なし・`var` なしへ統一
+  - Status: 完了（Minimal/Source Generator サンプルを完全形へ更新し、`var` を排除）
+  - Output:
+    - `README.md`
+    - `reports/2026-04-04-readme-sample-full-form-no-var.md`
+
 - T-051: README Minimal Example を最新 dynamic 導線へ更新
   - Status: 完了（`ParallelCompareApi.Compare(models)` の結果に対して `result.AsDynamic()` を使う例へ更新）
   - Output:


### PR DESCRIPTION
## Summary
- rewrite README code samples in fully expanded form
- remove `var` usage from README sample code
- add complete model definitions and typed variable declarations in examples

## Changes
- `README.md`
- `tasks/tasks-status.md`
- `tasks/phases-status.md`
- `tasks/feedback-points.md`
- `reports/2026-04-04-readme-sample-full-form-no-var.md`

## Validation
- verified `README.md` has no `var` token remaining in code samples