### PR TITLE
Simplify GetState states and document ValueState behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ Dataset[] models =
                     new Item { ItemId = 200, MetricA = 2.0 },
                 ],
             },
+            new Group
+            {
+                GroupId = 2,
+                Items =
+                [
+                    new Item { ItemId = 210, MetricA = 21.0 },
+                    new Item { ItemId = 211, MetricA = 21.1 },
+                    new Item { ItemId = 220, MetricA = 22.0 },
+                ],
+            },
+            new Group
+            {
+                GroupId = 3,
+                Items =
+                [
+                    new Item { ItemId = 310, MetricA = 31.0 },
+                    new Item { ItemId = 320, MetricA = 32.0 },
+                ],
+            },
         ],
     },
     new Dataset
@@ -184,6 +203,25 @@ Dataset[] models =
                 [
                     new Item { ItemId = 100, MetricA = 10.0 },
                     new Item { ItemId = 300, MetricA = 30.0 },
+                ],
+            },
+            new Group
+            {
+                GroupId = 2,
+                Items =
+                [
+                    new Item { ItemId = 210, MetricA = 21.0 },
+                    new Item { ItemId = 211, MetricA = 21.1 },
+                    new Item { ItemId = 230, MetricA = 23.0 },
+                ],
+            },
+            new Group
+            {
+                GroupId = 3,
+                Items =
+                [
+                    new Item { ItemId = 310, MetricA = 310.0 },
+                    new Item { ItemId = 320, MetricA = 32.0 },
                 ],
             },
         ],

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ public sealed class ProductItem
 ## Source Generator Example
 
 ```csharp
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using SSC;
@@ -178,17 +177,7 @@ Dataset[] models =
                 Items =
                 [
                     new Item { ItemId = 210, MetricA = 21.0 },
-                    new Item { ItemId = 211, MetricA = 21.1 },
                     new Item { ItemId = 220, MetricA = 22.0 },
-                ],
-            },
-            new Group
-            {
-                GroupId = 3,
-                Items =
-                [
-                    new Item { ItemId = 310, MetricA = 31.0 },
-                    new Item { ItemId = 320, MetricA = 32.0 },
                 ],
             },
         ],
@@ -212,17 +201,7 @@ Dataset[] models =
                 Items =
                 [
                     new Item { ItemId = 210, MetricA = 21.0 },
-                    new Item { ItemId = 211, MetricA = 21.1 },
                     new Item { ItemId = 230, MetricA = 23.0 },
-                ],
-            },
-            new Group
-            {
-                GroupId = 3,
-                Items =
-                [
-                    new Item { ItemId = 310, MetricA = 310.0 },
-                    new Item { ItemId = 320, MetricA = 32.0 },
                 ],
             },
         ],
@@ -246,17 +225,7 @@ Dataset[] models =
                 Items =
                 [
                     new Item { ItemId = 210, MetricA = 21.0 },
-                    new Item { ItemId = 211, MetricA = 21.1 },
                     new Item { ItemId = 240, MetricA = 24.0 },
-                ],
-            },
-            new Group
-            {
-                GroupId = 3,
-                Items =
-                [
-                    new Item { ItemId = 310, MetricA = 3100.0 },
-                    new Item { ItemId = 320, MetricA = 32.0 },
                 ],
             },
         ],
@@ -267,36 +236,21 @@ CompareResult<Dataset> result = ParallelCompareApi.Compare(models);
 double? leftMetricAt100 = result.AsGeneratedView()!.Groups[0].Items[0].MetricA[0];
 ValueState rightStateAt200 = result.AsGeneratedView()!.Groups[0].Items[1].MetricA.GetState(1);
 
-static int ResolveFirstAvailableId(IEnumerable<int?> candidates)
-{
-    return candidates.FirstOrDefault(candidate => candidate.HasValue) ?? -1;
-}
-
-static bool IsMismatchedInAnyModel(int modelCount, Func<int, ValueState> getState)
-{
-    return Enumerable.Range(0, modelCount)
-        .Any(modelIndex => getState(modelIndex) == ValueState.Mismatched);
-}
-
 int[] groupIds = result.AsGeneratedView()!.Groups
-    .Select(group => ResolveFirstAvailableId(
-        Enumerable.Range(0, group.NodeMeta.Count)
-            .Select(modelIndex => group.GroupId[modelIndex])))
+    .Select(group => group.GroupId[0] ?? group.GroupId[1] ?? group.GroupId[2] ?? -1)
     .ToArray();
 
 int[] itemIds = result.AsGeneratedView()!.Groups
     .SelectMany(group => group.Items)
-    .Select(item => ResolveFirstAvailableId(
-        Enumerable.Range(0, item.NodeMeta.Count)
-            .Select(modelIndex => item.ItemId[modelIndex])))
+    .Select(item => item.ItemId[0] ?? item.ItemId[1] ?? item.ItemId[2] ?? -1)
     .ToArray();
 
 int[] mismatchedItemIds = result.AsGeneratedView()!.Groups
     .SelectMany(group => group.Items)
-    .Where(item => IsMismatchedInAnyModel(item.NodeMeta.Count, item.MetricA.GetState))
-    .Select(item => ResolveFirstAvailableId(
-        Enumerable.Range(0, item.NodeMeta.Count)
-            .Select(modelIndex => item.ItemId[modelIndex])))
+    .Where(item => item.MetricA.GetState(0) == ValueState.Mismatched
+        || item.MetricA.GetState(1) == ValueState.Mismatched
+        || item.MetricA.GetState(2) == ValueState.Mismatched)
+    .Select(item => item.ItemId[0] ?? item.ItemId[1] ?? item.ItemId[2] ?? -1)
     .ToArray();
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ public sealed class ProductItem
 ## Source Generator Example
 
 ```csharp
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SSC;
@@ -226,25 +227,76 @@ Dataset[] models =
             },
         ],
     },
+    new Dataset
+    {
+        Groups =
+        [
+            new Group
+            {
+                GroupId = 1,
+                Items =
+                [
+                    new Item { ItemId = 100, MetricA = 100.0 },
+                    new Item { ItemId = 400, MetricA = 40.0 },
+                ],
+            },
+            new Group
+            {
+                GroupId = 2,
+                Items =
+                [
+                    new Item { ItemId = 210, MetricA = 21.0 },
+                    new Item { ItemId = 211, MetricA = 21.1 },
+                    new Item { ItemId = 240, MetricA = 24.0 },
+                ],
+            },
+            new Group
+            {
+                GroupId = 3,
+                Items =
+                [
+                    new Item { ItemId = 310, MetricA = 3100.0 },
+                    new Item { ItemId = 320, MetricA = 32.0 },
+                ],
+            },
+        ],
+    },
 };
 
 CompareResult<Dataset> result = ParallelCompareApi.Compare(models);
 double? leftMetricAt100 = result.AsGeneratedView()!.Groups[0].Items[0].MetricA[0];
 ValueState rightStateAt200 = result.AsGeneratedView()!.Groups[0].Items[1].MetricA.GetState(1);
 
+static int ResolveFirstAvailableId(IEnumerable<int?> candidates)
+{
+    return candidates.FirstOrDefault(candidate => candidate.HasValue) ?? -1;
+}
+
+static bool IsMismatchedInAnyModel(int modelCount, Func<int, ValueState> getState)
+{
+    return Enumerable.Range(0, modelCount)
+        .Any(modelIndex => getState(modelIndex) == ValueState.Mismatched);
+}
+
 int[] groupIds = result.AsGeneratedView()!.Groups
-    .Select(group => group.GroupId[0]!.Value)
+    .Select(group => ResolveFirstAvailableId(
+        Enumerable.Range(0, group.NodeMeta.Count)
+            .Select(modelIndex => group.GroupId[modelIndex])))
     .ToArray();
 
 int[] itemIds = result.AsGeneratedView()!.Groups
     .SelectMany(group => group.Items)
-    .Select(item => item.ItemId[0] ?? item.ItemId[1] ?? -1)
+    .Select(item => ResolveFirstAvailableId(
+        Enumerable.Range(0, item.NodeMeta.Count)
+            .Select(modelIndex => item.ItemId[modelIndex])))
     .ToArray();
 
 int[] mismatchedItemIds = result.AsGeneratedView()!.Groups
     .SelectMany(group => group.Items)
-    .Where(item => item.MetricA.GetState(0) == ValueState.Mismatched)
-    .Select(item => item.ItemId[0] ?? item.ItemId[1] ?? -1)
+    .Where(item => IsMismatchedInAnyModel(item.NodeMeta.Count, item.MetricA.GetState))
+    .Select(item => ResolveFirstAvailableId(
+        Enumerable.Range(0, item.NodeMeta.Count)
+            .Select(modelIndex => item.ItemId[modelIndex])))
     .ToArray();
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ It compares object graphs by aligning member values into per-model slots, normal
 ## Status
 
 - Target framework: .NET 8
-- Current phase: Phase 3 (implementation in progress)
-- Test status (latest):
-  - E2E: 33 passed
-  - Unit: 4 passed
 
 ## NuGet Packages
 
@@ -45,9 +41,9 @@ Install both packages when you want typed generated projection API (`AsGenerated
 - Slot model:
   - `Parallel<T>[modelIndex]` for value access
   - `GetState(modelIndex)` for slot state access
-  - `ValueState.Missing` : the slot does not exist in the target model
-  - `ValueState.PresentNull` : the slot exists but the value is `null`
-  - `ValueState.PresentValue` : the slot exists and has a non-null value
+  - `ValueState.Missing` : this slot is missing, or comparison target does not exist
+  - `ValueState.Matched` : there are comparison targets and all compared slots are equal
+  - `ValueState.Mismatched` : this slot exists and at least one compared slot is different (including target-side missing)
 
 ## Container Behavior
 
@@ -209,9 +205,7 @@ int[] itemIds = result.AsGeneratedView()!.Groups
 
 int[] mismatchedItemIds = result.AsGeneratedView()!.Groups
     .SelectMany(group => group.Items)
-    .Where(item =>
-        item.MetricA.GetState(0) != item.MetricA.GetState(1)
-        || item.MetricA[0] != item.MetricA[1])
+    .Where(item => item.MetricA.GetState(0) == ValueState.Mismatched)
     .Select(item => item.ItemId[0] ?? item.ItemId[1] ?? -1)
     .ToArray();
 ```

--- a/doc/design/README.md
+++ b/doc/design/README.md
@@ -15,6 +15,7 @@
 - `detail/06-ExecutionPipeline.md`
 - `detail/07-NonFunctional.md`
 - `detail/08-ImplementationChecklist.md`
+- `detail/09-ValueStateBehavior.md`
 
 ## Notes
 

--- a/doc/design/detail/01-DomainModel.md
+++ b/doc/design/detail/01-DomainModel.md
@@ -107,13 +107,16 @@ public sealed class CompareIgnoreAttribute : Attribute
 public enum ValueState
 {
     Missing,
-    PresentNull,
-    PresentValue
+    Matched,
+    Mismatched
 }
 ```
 
-`this[int]` だけでは `Missing` と `PresentNull` を区別できないため、
-`GetState(modelIndex)` を併用する。
+`GetState(modelIndex)` は比較可否と一致/不一致を返す。
+
+- `Missing`: 比較対象が存在しない
+- `Matched`: slot が存在し、比較結果が一致
+- `Mismatched`: slot が存在し、比較結果が不一致（比較先欠損を含む）
 
 ## 5. Invariants
 

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -240,16 +240,19 @@ var leftGroupIdAt0 = leftGroups[0].GroupId[0];
 ## 4.2 Nullability and State
 
 - `result.Root` は入力エラー時に `null` になり得る。
-- `node[modelIndex]` の値は `Missing` または `PresentNull` で `null` になり得る。
+- `node[modelIndex]` の値は、欠損または実値 `null` のどちらでも `null` になり得る。
 - index が有効な限り、`groups[i]` や `items[j]` のノード自体は通常 `null` ではない。
-- `null` の意味を区別する場合は `GetState(modelIndex)` を併用する。
+- 比較状態は `GetState(modelIndex)` で判定する。
+  - `Missing`: 当該 slot が欠損、または比較対象がない
+  - `Matched`: 当該 slot が存在し、比較対象と一致
+  - `Mismatched`: 当該 slot が存在し、比較対象と不一致（比較先欠損を含む）
 
 ```csharp
 var metric = items[1][1]?.MetricA;
-var state = items[1].GetState(1); // Missing / PresentNull / PresentValue
+var state = items[1].GetState(1); // Missing / Matched / Mismatched
 
 dynamic root = result.AsDynamic();
-var objectState = root.Groups[0].Items[1].GetState(1); // Missing / PresentNull / PresentValue
+var objectState = root.Groups[0].Items[1].GetState(1); // Missing / Matched / Mismatched
 ```
 
 ## 5. Configuration Entry

--- a/doc/design/detail/09-ValueStateBehavior.md
+++ b/doc/design/detail/09-ValueStateBehavior.md
@@ -1,0 +1,68 @@
+# ValueState Behavior
+
+## 1. Purpose
+
+`GetState(modelIndex)` の返却値を比較用途に特化して単純化する。
+
+## 2. Public State
+
+```csharp
+public enum ValueState
+{
+    Missing,
+    Matched,
+    Mismatched,
+}
+```
+
+- `Missing`
+  - 当該 model slot が欠損
+  - または比較対象が存在しない
+- `Matched`
+  - 当該 slot が存在し、比較対象と一致
+- `Mismatched`
+  - 当該 slot が存在し、比較対象と不一致（比較先欠損を含む）
+
+## 3. Evaluation Rule
+
+### 3.1 Node Level (`ParallelNode<T>.GetState`)
+
+1. 当該 slot が欠損なら `Missing`
+2. 比較対象モデルが存在しないなら `Missing`
+3. 比較対象に欠損がある場合は `Mismatched`
+4. 比較対象が全て存在し、値が全て等しいなら `Matched`
+5. それ以外は `Mismatched`
+
+### 3.2 Value Path Level (`generated` / `dynamic`)
+
+`Property` の最終値を比較対象として同じルールを適用する。
+
+- `null` 同士は一致
+- `null` と非 `null` は不一致
+
+## 4. Examples
+
+2モデル比較で `left/right` の状態を示す。
+
+| left | right | left.GetState(0) | right.GetState(1) |
+| --- | --- | --- | --- |
+| missing | missing | Missing | Missing |
+| missing | 10 | Missing | Mismatched |
+| 10 | missing | Mismatched | Missing |
+| null | null | Matched | Matched |
+| 10 | 10 | Matched | Matched |
+| 10 | 20 | Mismatched | Mismatched |
+
+## 5. Internal Representation
+
+公開 `ValueState` とは別に、内部評価では `NodePresenceState` を使用する。
+
+- `Missing`
+- `PresentNull`
+- `PresentValue`
+
+これにより以下を両立する。
+
+- 公開 API の単純な3状態
+- 比較時の `missing/null/value` 判定精度
+

--- a/reports/2026-04-05-getstate-mismatch-enum-extension.md
+++ b/reports/2026-04-05-getstate-mismatch-enum-extension.md
@@ -1,0 +1,60 @@
+# GetState Mismatch Enum Extension
+
+- Date: 2026-04-05
+- Related: GitHub Issue #18
+
+## Background
+
+Issue #18 は、`GetState(modelIndex)` で一致/不一致を直接判定したい、という要望。  
+最終方針は「`PresentNull`/`PresentValue` の区別を廃止し、3状態へ単純化」に確定した。
+
+## Scope
+
+- `ValueState` enum 再定義（3状態）
+- `GetState` 判定ロジック更新（node / generated value path / dynamic value path）
+- 既存テストの期待値更新と回帰追加
+- README / 詳細設計の状態説明更新
+- 動作仕様設計書の追記
+
+## Implementation
+
+1. `ValueState` を次の3状態に整理
+   - `Missing`
+   - `Matched`
+   - `Mismatched`
+2. `ValueStateExtensions` を追加
+   - `IsMissing`, `IsMatched`, `IsMismatched`, `ToComparisonState` を提供
+3. 内部表現 `NodePresenceState`（`Missing/PresentNull/PresentValue`）を追加
+   - 公開状態と内部存在状態を分離
+3. `ParallelNode<T>.GetState` を更新
+   - 当該 slot が欠損なら `Missing`
+   - 当該 slot が存在し、比較先が一致なら `Matched`
+   - 当該 slot が存在し、比較先が不一致（比較先欠損含む）なら `Mismatched`
+4. `ParallelGeneratedValue<TModel, TValue>.GetState` / `DynamicParallelValuePathView.GetState` を同一ルールへ統一
+5. generated list の model 抽出ロジックを `GetState` 依存から内部存在状態依存へ変更
+   - `SelectModel(modelIndex)` の意味を維持
+
+## Behavior
+
+- `Missing`:
+  - 当該 slot が欠損
+  - または比較対象が存在しない（モデルが1件のみ等）
+- `Matched`:
+  - 当該 slot が存在し、比較対象と一致
+  - `null` 同士は一致扱い
+- `Mismatched`:
+  - 当該 slot が存在し、比較対象と不一致
+  - 比較先欠損も不一致として扱う
+
+## Design Document
+
+- 仕様を `doc/design/detail/09-ValueStateBehavior.md` として新規追加
+- `GetState` 判定表とモデル数別の例を記載
+
+## Verification
+
+- `dotnet test SSC.sln --configuration Release`
+- Result:
+  - E2E: 35 passed
+  - Unit: 6 passed
+  - failed: 0

--- a/reports/2026-04-05-readme-remove-volatile-status-lines.md
+++ b/reports/2026-04-05-readme-remove-volatile-status-lines.md
@@ -1,0 +1,29 @@
+# README Volatile Status Line Removal
+
+- Date: 2026-04-05
+- Scope: `README.md`
+
+## Background
+
+README の `Status` 節に以下の可変情報が含まれていた。
+
+- current phase
+- latest test pass counts
+
+これらは更新頻度が高く、README の保守コストと記載劣化リスクが高い。
+
+## Change
+
+`README.md` から次の行を削除。
+
+- `Current phase: ...`
+- `Test status (latest): ...`
+- `E2E: ...`
+- `Unit: ...`
+
+`Target framework` は固定情報として維持。
+
+## Result
+
+README は長期的に変化しにくい情報に絞られ、メンテナンス負荷を低減。
+

--- a/reports/2026-04-05-readme-source-generator-example-three-datasets-two-groups.md
+++ b/reports/2026-04-05-readme-source-generator-example-three-datasets-two-groups.md
@@ -1,0 +1,27 @@
+# README Source Generator Example Adjustment (Three Datasets, Two Groups)
+
+- Date: 2026-04-05
+- Scope: `README.md`
+
+## Background
+
+Source Generator Example について、README 掲載時の見通しを優先し、
+ID 参照式をモデル数固定の明示形（`??` 連結）へ揃えたいという要望があった。
+あわせて、入力サンプルは `Dataset` 3件・`Group` 2件の構成へ調整する方針となった。
+
+## Change
+
+- `Dataset[] models` は 3 モデルのまま維持
+- 各 `Dataset` の `Groups` を 2 要素（`GroupId: 1, 2`）へ調整
+- 3 モデル一致の item として `ItemId=210` を維持
+- `groupIds` の参照式を明示形へ変更
+  - `group.GroupId[0] ?? group.GroupId[1] ?? group.GroupId[2] ?? -1`
+- `itemIds` の参照式を明示形へ変更
+  - `item.ItemId[0] ?? item.ItemId[1] ?? item.ItemId[2] ?? -1`
+- `mismatchedItemIds` の判定を明示形へ変更
+  - `GetState(0) || GetState(1) || GetState(2)`
+
+## Result
+
+README の Source Generator Example は、
+3 モデル比較の文脈を維持しつつ、2 group 構成と明示的な `??` 連結記法で読みやすい形に統一された。

--- a/reports/2026-04-05-readme-source-generator-example-three-groups.md
+++ b/reports/2026-04-05-readme-source-generator-example-three-groups.md
@@ -12,11 +12,20 @@
 
 - `models[0].Groups` を 3 要素へ拡張（`GroupId`: 1, 2, 3）
 - `models[1].Groups` も 3 要素へ拡張（`GroupId`: 1, 2, 3）
+- `models[2]` を追加し、`Dataset[]` を 3 モデル入力へ拡張
 - group ごとに item 差分を残し、既存の `Mismatched` 抽出例と整合するデータへ調整
-- 一致ケースを明示するため、同値 `Items` を追加
-  - `GroupId=2`: `ItemId=211, MetricA=21.1`（両モデル一致）
-  - `GroupId=3`: `ItemId=320, MetricA=32.0`（両モデル一致）
+- 一致ケースを明示するため、3モデルで同値の `Items` を追加
+  - `GroupId=2`: `ItemId=210, MetricA=21.0`
+  - `GroupId=2`: `ItemId=211, MetricA=21.1`
+  - `GroupId=3`: `ItemId=320, MetricA=32.0`
+- `itemIds` / `mismatchedItemIds` の ID 参照式を 3 モデル対応へ更新（`[0] ?? [1] ?? [2]`）
+- モデル数固定の参照式を除去し、`NodeMeta.Count` + `Enumerable.Range` で走査する汎用式へ更新
+- 参照式が読みにくくなったため、ID 解決と不一致判定をローカル関数へ抽出
+  - `ResolveFirstAvailableId(IEnumerable<int?> candidates)`
+  - `IsMismatchedInAnyModel(int modelCount, Func<int, ValueState> getState)`
+  - これによりモデル数非依存のまま、`Select` / `Where` 側の式を簡潔化
 
 ## Result
 
-README の Source Generator サンプルで、複数 `Groups` を持つ入力形をそのまま参照可能になった。
+README の Source Generator サンプルで、複数 `Groups` を持つ入力形をそのまま参照可能になり、
+モデル数非依存ロジックの可読性も改善された。

--- a/reports/2026-04-05-readme-source-generator-example-three-groups.md
+++ b/reports/2026-04-05-readme-source-generator-example-three-groups.md
@@ -1,0 +1,22 @@
+# README Source Generator Example Update (Three Groups)
+
+- Date: 2026-04-05
+- Scope: `README.md`
+
+## Background
+
+`Source Generator Example` の `Dataset` サンプルで、`Groups` が 1 要素のみだったため、
+複数 group を前提とした利用イメージが伝わりにくかった。
+
+## Change
+
+- `models[0].Groups` を 3 要素へ拡張（`GroupId`: 1, 2, 3）
+- `models[1].Groups` も 3 要素へ拡張（`GroupId`: 1, 2, 3）
+- group ごとに item 差分を残し、既存の `Mismatched` 抽出例と整合するデータへ調整
+- 一致ケースを明示するため、同値 `Items` を追加
+  - `GroupId=2`: `ItemId=211, MetricA=21.1`（両モデル一致）
+  - `GroupId=3`: `ItemId=320, MetricA=32.0`（両モデル一致）
+
+## Result
+
+README の Source Generator サンプルで、複数 `Groups` を持つ入力形をそのまま参照可能になった。

--- a/src/SSC/Contracts.cs
+++ b/src/SSC/Contracts.cs
@@ -3,8 +3,8 @@ namespace SSC;
 public enum ValueState
 {
     Missing,
-    PresentNull,
-    PresentValue,
+    Matched,
+    Mismatched,
 }
 
 public enum CompareIssueLevel
@@ -82,4 +82,6 @@ internal interface IParallelNodeInternal
     Type ModelType { get; }
 
     bool TryGetChildren(string memberName, out IReadOnlyList<IParallelNode> nodes);
+
+    NodePresenceState GetPresenceState(int modelIndex);
 }

--- a/src/SSC/GeneratedProjectionRuntime.cs
+++ b/src/SSC/GeneratedProjectionRuntime.cs
@@ -111,7 +111,7 @@ public sealed class ParallelGeneratedModelList<TElement, TView> : IReadOnlyList<
         var selectedNodeIndexes = new List<int>(_nodes.Count);
         for (var index = 0; index < _nodes.Count; index++)
         {
-            if (_nodes[index].GetState(modelIndex) != ValueState.Missing)
+            if (_nodes[index].GetPresenceState(modelIndex) != NodePresenceState.Missing)
             {
                 selectedNodeIndexes.Add(index);
             }
@@ -171,8 +171,47 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
 
     public ValueState GetState(int modelIndex)
     {
-        _ = ResolveValue(modelIndex, out var state);
-        return state;
+        var selectedValue = ResolveValue(modelIndex, out var selectedPresence);
+        if (selectedPresence == NodePresenceState.Missing)
+        {
+            return ValueState.Missing;
+        }
+
+        if (_node.Count <= 1)
+        {
+            return ValueState.Missing;
+        }
+
+        var matched = true;
+        for (var index = 0; index < _node.Count; index++)
+        {
+            if (index == modelIndex)
+            {
+                continue;
+            }
+
+            var otherValue = ResolveValue(index, out var otherPresence);
+            if (otherPresence == NodePresenceState.Missing)
+            {
+                matched = false;
+                break;
+            }
+
+            if (otherPresence != selectedPresence)
+            {
+                matched = false;
+                break;
+            }
+
+            if (selectedPresence == NodePresenceState.PresentValue
+                && !EqualityComparer<TValue>.Default.Equals(selectedValue, otherValue))
+            {
+                matched = false;
+                break;
+            }
+        }
+
+        return ValueStateExtensions.ToComparisonState(hasComparisonTarget: true, matched);
     }
 
     public ParallelGeneratedValue<TModel, TNext> Select<TNext>(Func<TValue, TNext> selector)
@@ -193,10 +232,10 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
             });
     }
 
-    private TValue ResolveValue(int modelIndex, out ValueState state)
+    private TValue ResolveValue(int modelIndex, out NodePresenceState state)
     {
-        state = _node.GetState(modelIndex);
-        if (state == ValueState.Missing)
+        state = _node.GetPresenceState(modelIndex);
+        if (state == NodePresenceState.Missing)
         {
             return default!;
         }
@@ -204,18 +243,18 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
         var model = _node[modelIndex];
         if (model is null)
         {
-            state = ValueState.PresentNull;
+            state = NodePresenceState.PresentNull;
             return default!;
         }
 
         var value = _getter(model);
         if (value is null)
         {
-            state = ValueState.PresentNull;
+            state = NodePresenceState.PresentNull;
             return default!;
         }
 
-        state = ValueState.PresentValue;
+        state = NodePresenceState.PresentValue;
         return value;
     }
 }

--- a/src/SSC/NodePresenceState.cs
+++ b/src/SSC/NodePresenceState.cs
@@ -1,0 +1,9 @@
+namespace SSC;
+
+internal enum NodePresenceState
+{
+    Missing,
+    PresentNull,
+    PresentValue,
+}
+

--- a/src/SSC/ParallelCompareApi.cs
+++ b/src/SSC/ParallelCompareApi.cs
@@ -51,7 +51,7 @@ public static class ParallelCompareApi
         var slots = new NodeSlot[models.Count];
         for (var index = 0; index < models.Count; index++)
         {
-            slots[index] = new NodeSlot(models[index], ValueState.PresentValue);
+            slots[index] = new NodeSlot(models[index], NodePresenceState.PresentValue);
         }
 
         var root = (ParallelNode<T>)BuildNode(typeof(T), slots, typeof(T).Name, context, keyText: null);
@@ -88,12 +88,12 @@ public static class ParallelCompareApi
     private static IParallelNode BuildNodeGeneric<TNode>(NodeSlot[] slots, string path, CompareContext context, string? keyText)
     {
         var typedValues = new TNode?[slots.Length];
-        var states = new ValueState[slots.Length];
+        var states = new NodePresenceState[slots.Length];
 
         for (var index = 0; index < slots.Length; index++)
         {
             states[index] = slots[index].State;
-            typedValues[index] = slots[index].State == ValueState.PresentValue
+            typedValues[index] = slots[index].State == NodePresenceState.PresentValue
                 ? (TNode?)slots[index].Value
                 : default;
         }
@@ -141,7 +141,7 @@ public static class ParallelCompareApi
         for (var modelIndex = 0; modelIndex < parentSlots.Length; modelIndex++)
         {
             maps[modelIndex] = new Dictionary<object, object?>(comparer);
-            if (parentSlots[modelIndex].State != ValueState.PresentValue || parentSlots[modelIndex].Value is null)
+            if (parentSlots[modelIndex].State != NodePresenceState.PresentValue || parentSlots[modelIndex].Value is null)
             {
                 continue;
             }
@@ -259,7 +259,7 @@ public static class ParallelCompareApi
         for (var modelIndex = 0; modelIndex < parentSlots.Length; modelIndex++)
         {
             maps[modelIndex] = new Dictionary<object, object?>(comparer);
-            if (parentSlots[modelIndex].State != ValueState.PresentValue || parentSlots[modelIndex].Value is null)
+            if (parentSlots[modelIndex].State != NodePresenceState.PresentValue || parentSlots[modelIndex].Value is null)
             {
                 continue;
             }
@@ -534,13 +534,13 @@ public static class ParallelCompareApi
         return existing;
     }
 
-    private readonly record struct NodeSlot(object? Value, ValueState State)
+    private readonly record struct NodeSlot(object? Value, NodePresenceState State)
     {
-        public static NodeSlot Missing => new(null, ValueState.Missing);
+        public static NodeSlot Missing => new(null, NodePresenceState.Missing);
 
-        public static NodeSlot PresentNull => new(null, ValueState.PresentNull);
+        public static NodeSlot PresentNull => new(null, NodePresenceState.PresentNull);
 
-        public static NodeSlot PresentValue(object value) => new(value, ValueState.PresentValue);
+        public static NodeSlot PresentValue(object value) => new(value, NodePresenceState.PresentValue);
     }
 
     private sealed class CompareContext

--- a/src/SSC/ParallelDynamicAccessExtensions.cs
+++ b/src/SSC/ParallelDynamicAccessExtensions.cs
@@ -170,11 +170,13 @@ internal sealed class DynamicParallelListView : DynamicObject, IReadOnlyList<obj
 internal sealed class DynamicParallelValuePathView : DynamicObject
 {
     private readonly IParallelNode _node;
+    private readonly IParallelNodeInternal _internalNode;
     private readonly string[] _memberPath;
 
     private DynamicParallelValuePathView(IParallelNode node, string[] memberPath)
     {
         _node = node;
+        _internalNode = (IParallelNodeInternal)node;
         _memberPath = memberPath;
     }
 
@@ -185,8 +187,47 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
 
     public ValueState GetState(int modelIndex)
     {
-        _ = ResolveValue(modelIndex, out var state);
-        return state;
+        var selectedValue = ResolveValue(modelIndex, out var selectedPresence);
+        if (selectedPresence == NodePresenceState.Missing)
+        {
+            return ValueState.Missing;
+        }
+
+        if (_node.Count <= 1)
+        {
+            return ValueState.Missing;
+        }
+
+        var matched = true;
+        for (var index = 0; index < _node.Count; index++)
+        {
+            if (index == modelIndex)
+            {
+                continue;
+            }
+
+            var otherValue = ResolveValue(index, out var otherPresence);
+            if (otherPresence == NodePresenceState.Missing)
+            {
+                matched = false;
+                break;
+            }
+
+            if (otherPresence != selectedPresence)
+            {
+                matched = false;
+                break;
+            }
+
+            if (selectedPresence == NodePresenceState.PresentValue
+                && !Equals(selectedValue, otherValue))
+            {
+                matched = false;
+                break;
+            }
+        }
+
+        return ValueStateExtensions.ToComparisonState(hasComparisonTarget: true, matched);
     }
 
     public override bool TryGetMember(GetMemberBinder binder, out object? result)
@@ -219,10 +260,10 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
         return true;
     }
 
-    private object? ResolveValue(int modelIndex, out ValueState state)
+    private object? ResolveValue(int modelIndex, out NodePresenceState state)
     {
-        state = _node.GetState(modelIndex);
-        if (state == ValueState.Missing)
+        state = _internalNode.GetPresenceState(modelIndex);
+        if (state == NodePresenceState.Missing)
         {
             return null;
         }
@@ -230,7 +271,7 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
         object? current = _node.GetValue(modelIndex);
         if (current is null)
         {
-            state = ValueState.PresentNull;
+            state = NodePresenceState.PresentNull;
             return null;
         }
 
@@ -247,12 +288,12 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
             current = property.GetValue(current);
             if (current is null)
             {
-                state = ValueState.PresentNull;
+                state = NodePresenceState.PresentNull;
                 return null;
             }
         }
 
-        state = ValueState.PresentValue;
+        state = NodePresenceState.PresentValue;
         return current;
     }
 }

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -3,10 +3,10 @@ namespace SSC;
 public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeInternal
 {
     private readonly T?[] _values;
-    private readonly ValueState[] _states;
+    private readonly NodePresenceState[] _states;
     private readonly Dictionary<string, IReadOnlyList<IParallelNode>> _children = new(StringComparer.Ordinal);
 
-    internal ParallelNode(T?[] values, ValueState[] states, string? keyText)
+    internal ParallelNode(T?[] values, NodePresenceState[] states, string? keyText)
     {
         _values = values;
         _states = states;
@@ -17,9 +17,9 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
 
     public int Count => _values.Length;
 
-    public bool AllPresent => _states.All(state => state == ValueState.PresentValue);
+    public bool AllPresent => _states.All(state => state == NodePresenceState.PresentValue);
 
-    public bool AnyPresent => _states.Any(state => state != ValueState.Missing);
+    public bool AnyPresent => _states.Any(state => state != NodePresenceState.Missing);
 
     public T? this[int modelIndex]
     {
@@ -41,18 +41,73 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
                 nameof(states));
         }
 
-        return new ParallelNode<T>(values.ToArray(), states.ToArray(), keyText);
+        var presenceStates = new NodePresenceState[states.Count];
+        for (var index = 0; index < states.Count; index++)
+        {
+            presenceStates[index] = states[index] == ValueState.Missing
+                ? NodePresenceState.Missing
+                : values[index] is null
+                    ? NodePresenceState.PresentNull
+                    : NodePresenceState.PresentValue;
+        }
+
+        return new ParallelNode<T>(values.ToArray(), presenceStates, keyText);
     }
 
     public ValueState GetState(int modelIndex)
     {
         ValidateIndex(modelIndex);
-        return _states[modelIndex];
+        var baseState = _states[modelIndex];
+        if (baseState == NodePresenceState.Missing)
+        {
+            return ValueState.Missing;
+        }
+
+        if (_states.Length <= 1)
+        {
+            return ValueState.Missing;
+        }
+
+        var matched = true;
+        for (var index = 0; index < _states.Length; index++)
+        {
+            if (index == modelIndex)
+            {
+                continue;
+            }
+
+            if (_states[index] == NodePresenceState.Missing)
+            {
+                matched = false;
+                break;
+            }
+
+            if (_states[index] != baseState)
+            {
+                matched = false;
+                break;
+            }
+
+            if (baseState == NodePresenceState.PresentValue
+                && !EqualityComparer<T?>.Default.Equals(_values[modelIndex], _values[index]))
+            {
+                matched = false;
+                break;
+            }
+        }
+
+        return ValueStateExtensions.ToComparisonState(hasComparisonTarget: true, matched);
     }
 
     public object? GetValue(int modelIndex)
     {
         return this[modelIndex];
+    }
+
+    internal NodePresenceState GetPresenceState(int modelIndex)
+    {
+        ValidateIndex(modelIndex);
+        return _states[modelIndex];
     }
 
     public IReadOnlyList<ParallelNode<TElement>> GetChildren<TElement>(string memberName)
@@ -70,6 +125,11 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     bool IParallelNodeInternal.TryGetChildren(string memberName, out IReadOnlyList<IParallelNode> nodes)
     {
         return _children.TryGetValue(memberName, out nodes!);
+    }
+
+    NodePresenceState IParallelNodeInternal.GetPresenceState(int modelIndex)
+    {
+        return GetPresenceState(modelIndex);
     }
 
     internal void SetChildren(string memberName, IReadOnlyList<IParallelNode> nodes)

--- a/src/SSC/ValueStateExtensions.cs
+++ b/src/SSC/ValueStateExtensions.cs
@@ -1,0 +1,20 @@
+namespace SSC;
+
+public static class ValueStateExtensions
+{
+    public static bool IsMissing(this ValueState state) => state == ValueState.Missing;
+
+    public static bool IsMatched(this ValueState state) => state == ValueState.Matched;
+
+    public static bool IsMismatched(this ValueState state) => state == ValueState.Mismatched;
+
+    internal static ValueState ToComparisonState(bool hasComparisonTarget, bool matched)
+    {
+        if (!hasComparisonTarget)
+        {
+            return ValueState.Missing;
+        }
+
+        return matched ? ValueState.Matched : ValueState.Mismatched;
+    }
+}

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -315,3 +315,22 @@
 - 対応:
   - `git fetch origin --prune` を実施し、`origin/main` 取り込み後に作業する運用へ更新
   - 競合解消時は `rebase` 後に `dotnet test SSC.sln --configuration Release` を実行して整合を確認
+- ユーザー指摘: Issue #18 として、`GetState` で一致/不一致も扱いたい。
+- 対応:
+  - `ValueState` に `PresentNullMismatched` / `PresentValueMismatched` を追加
+  - node/generated/dynamic の `GetState` を更新し、不一致時にのみ `*Mismatched` を返す実装へ変更
+  - 対応内容を `reports/2026-04-05-getstate-mismatch-enum-extension.md` に記録
+- ユーザー指摘: 両側 `null` は一致扱いでよく、不一致時のみ特別状態にしたい。
+- 対応:
+  - 一致時は `PresentNull` / `PresentValue` を維持し、特別状態は不一致時のみ返す判定へ統一
+- ユーザー指摘: `PresentNull` / `PresentValue` を分けず、`Missing` 名で十分にしたい。
+- 対応:
+  - `ValueState` を `Missing/Matched/Mismatched` の3状態へ再定義
+  - `missing` 側は `Missing`、値が存在する不一致側は `Mismatched` を返す判定へ変更
+- ユーザー指摘: 最後に動作仕様を設計書として資料化すること。
+- 対応:
+  - `doc/design/detail/09-ValueStateBehavior.md` を新規追加し、判定ルールと例を明文化
+- ユーザー指摘: README の phase/test 件数のような可変情報は削除したい。
+- 対応:
+  - `README.md` の `Status` 節から current phase / latest test 件数の行を削除
+  - 変更理由と結果を `reports/2026-04-05-readme-remove-volatile-status-lines.md` に記録

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -334,3 +334,10 @@
 - 対応:
   - `README.md` の `Status` 節から current phase / latest test 件数の行を削除
   - 変更理由と結果を `reports/2026-04-05-readme-remove-volatile-status-lines.md` に記録
+- ユーザー指摘: README の Source Generator Example は `Groups` が3つある形にしたい。
+- 対応:
+  - Source Generator Example の入力データを 3 groups 構成へ更新
+  - 変更内容を `reports/2026-04-05-readme-source-generator-example-three-groups.md` に記録
+- ユーザー指摘: その上で一致する `Items` も入れたい。
+- 対応:
+  - 同値 `Items`（`ItemId=211`, `ItemId=320`）を両モデルへ追加し、一致ケースを明示

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -340,4 +340,11 @@
   - 変更内容を `reports/2026-04-05-readme-source-generator-example-three-groups.md` に記録
 - ユーザー指摘: その上で一致する `Items` も入れたい。
 - 対応:
-  - 同値 `Items`（`ItemId=211`, `ItemId=320`）を両モデルへ追加し、一致ケースを明示
+  - 同値 `Items`（`ItemId=210`, `ItemId=211`, `ItemId=320`）を3モデルへ配置し、一致ケースを明示
+- ユーザー指摘: モデル数固定ではなく、汎用的な書き方にしたい。
+- 対応:
+  - `README.md` の Source Generator Example で `NodeMeta.Count` + `Enumerable.Range` によるモデル数非依存の参照式へ変更
+- ユーザー指摘: 汎用式は読みにくいので、可読性を上げたい。
+- 対応:
+  - `README.md` の Source Generator Example で複雑な式をローカル関数へ分離
+  - `ResolveFirstAvailableId(...)` と `IsMismatchedInAnyModel(...)` を追加し、`Select` / `Where` の記述を簡潔化

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -348,3 +348,11 @@
 - 対応:
   - `README.md` の Source Generator Example で複雑な式をローカル関数へ分離
   - `ResolveFirstAvailableId(...)` と `IsMismatchedInAnyModel(...)` を追加し、`Select` / `Where` の記述を簡潔化
+- ユーザー指摘: README では先の書き方（インライン式）の方が適している。
+- 対応:
+  - Source Generator Example のローカル関数分離を取り下げ、汎用式インライン記述へ戻す
+  - `NodeMeta.Count` ベースのモデル数非依存性は維持
+- ユーザー指摘: `??` を3つつなぐ書き方が最も見通しがよく、`Dataset` は3つ・`Group` は2つにしたい。
+- 対応:
+  - Source Generator Example を `Dataset` 3件 / `Group` 2件へ再調整
+  - `groupIds` / `itemIds` / `mismatchedItemIds` を `[0] ?? [1] ?? [2]` ベースの明示記法へ統一

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -101,6 +101,8 @@
   - `doc/design/detail/09-ValueStateBehavior.md` を追加し、`GetState` 判定表と挙動仕様を設計書へ明文化
   - README から phase/test 件数などの可変ステータス表記を削除し、固定情報中心へ整理
   - README の Source Generator Example を 3 groups 構成へ更新し、同値 `Items` の一致ケースも追記
+  - Source Generator Example の ID 抽出・不一致抽出を `NodeMeta.Count` ベースのモデル数非依存式へ更新
+  - Source Generator Example の汎用式をローカル関数へ抽出し、モデル数非依存性を維持したまま可読性を改善
 
 ## Phase 4: 検証・受け入れ
 

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -95,6 +95,11 @@
   - generated projection list に `SelectModel(modelIndex)` を追加し、モデル別 list 選択を可能化
   - generator 出力を更新し、モデル数を runtime list へ渡して model index 検証を空 list でも有効化
   - generated projection E2E にモデル別 list 選択ケースを追加し、`dotnet test SSC.sln --configuration Release` 成功（E2E 34件 / Unit 4件）
+  - `ValueState` を `Missing/Matched/Mismatched` の3状態へ再定義し、`GetState` を比較指向へ簡素化
+  - 内部評価状態（`NodePresenceState`）を導入し、公開状態の単純化と `missing/null/value` 判定精度を両立
+  - node/generated/dynamic の `GetState` 実装と E2E/Unit を更新し、`dotnet test SSC.sln --configuration Release` 成功（E2E 35件 / Unit 6件）
+  - `doc/design/detail/09-ValueStateBehavior.md` を追加し、`GetState` 判定表と挙動仕様を設計書へ明文化
+  - README から phase/test 件数などの可変ステータス表記を削除し、固定情報中心へ整理
 
 ## Phase 4: 検証・受け入れ
 

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -101,8 +101,8 @@
   - `doc/design/detail/09-ValueStateBehavior.md` を追加し、`GetState` 判定表と挙動仕様を設計書へ明文化
   - README から phase/test 件数などの可変ステータス表記を削除し、固定情報中心へ整理
   - README の Source Generator Example を 3 groups 構成へ更新し、同値 `Items` の一致ケースも追記
-  - Source Generator Example の ID 抽出・不一致抽出を `NodeMeta.Count` ベースのモデル数非依存式へ更新
-  - Source Generator Example の汎用式をローカル関数へ抽出し、モデル数非依存性を維持したまま可読性を改善
+  - README 掲載方針に合わせ、Source Generator Example を 3 datasets / 2 groups 構成へ再調整
+  - Source Generator Example の ID 抽出・不一致抽出を `[0] ?? [1] ?? [2]` の明示記法へ統一
 
 ## Phase 4: 検証・受け入れ
 

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -100,6 +100,7 @@
   - node/generated/dynamic の `GetState` 実装と E2E/Unit を更新し、`dotnet test SSC.sln --configuration Release` 成功（E2E 35件 / Unit 6件）
   - `doc/design/detail/09-ValueStateBehavior.md` を追加し、`GetState` 判定表と挙動仕様を設計書へ明文化
   - README から phase/test 件数などの可変ステータス表記を削除し、固定情報中心へ整理
+  - README の Source Generator Example を 3 groups 構成へ更新し、同値 `Items` の一致ケースも追記
 
 ## Phase 4: 検証・受け入れ
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -16,14 +16,20 @@
 
 ## Done
 
+- T-067: README Source Generator 例の構成・記法再調整
+  - Status: 完了（`Dataset` 3件・`Group` 2件へ調整し、ID 参照を `[0] ?? [1] ?? [2]` の明示記法へ統一）
+  - Output:
+    - `README.md`
+    - `reports/2026-04-05-readme-source-generator-example-three-datasets-two-groups.md`
+
 - T-066: README Source Generator 例の汎用式可読性改善
-  - Status: 完了（モデル数非依存ロジックを維持しつつ、ID 解決・不一致判定をローカル関数へ分離）
+  - Status: 完了（ID 解決・不一致判定のローカル関数分離を試行。最終的な README 記法は T-067 で再調整）
   - Output:
     - `README.md`
     - `reports/2026-04-05-readme-source-generator-example-three-groups.md`
 
 - T-065: README Source Generator 例の Groups 構成拡張
-  - Status: 完了（`Dataset` を 3 モデル入力へ拡張し、3モデル一致 `Items` とモデル数非依存の参照式を追加）
+  - Status: 完了（`Dataset` を 3 モデル入力へ拡張し、3モデル一致 `Items` を追加）
   - Output:
     - `README.md`
     - `reports/2026-04-05-readme-source-generator-example-three-groups.md`

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -16,8 +16,14 @@
 
 ## Done
 
+- T-066: README Source Generator 例の汎用式可読性改善
+  - Status: 完了（モデル数非依存ロジックを維持しつつ、ID 解決・不一致判定をローカル関数へ分離）
+  - Output:
+    - `README.md`
+    - `reports/2026-04-05-readme-source-generator-example-three-groups.md`
+
 - T-065: README Source Generator 例の Groups 構成拡張
-  - Status: 完了（`Groups` を 3 要素構成へ拡張し、一致する `Items` も追加）
+  - Status: 完了（`Dataset` を 3 モデル入力へ拡張し、3モデル一致 `Items` とモデル数非依存の参照式を追加）
   - Output:
     - `README.md`
     - `reports/2026-04-05-readme-source-generator-example-three-groups.md`

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -16,6 +16,12 @@
 
 ## Done
 
+- T-065: README Source Generator 例の Groups 構成拡張
+  - Status: 完了（`Groups` を 3 要素構成へ拡張し、一致する `Items` も追加）
+  - Output:
+    - `README.md`
+    - `reports/2026-04-05-readme-source-generator-example-three-groups.md`
+
 - T-064: README の可変ステータス表記を削除
   - Status: 完了（頻繁更新が必要な phase/test 件数を README から除外）
   - Output:

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -16,6 +16,33 @@
 
 ## Done
 
+- T-064: README の可変ステータス表記を削除
+  - Status: 完了（頻繁更新が必要な phase/test 件数を README から除外）
+  - Output:
+    - `README.md`
+    - `reports/2026-04-05-readme-remove-volatile-status-lines.md`
+
+- T-063: GetState の不一致状態 enum 拡張
+  - Status: 完了（`ValueState` を `Missing/Matched/Mismatched` の3状態へ整理）
+  - Output:
+    - `src/SSC/Contracts.cs`
+    - `src/SSC/NodePresenceState.cs`
+    - `src/SSC/ValueStateExtensions.cs`
+    - `src/SSC/ParallelCompareApi.cs`
+    - `src/SSC/ParallelNode.cs`
+    - `src/SSC/GeneratedProjectionRuntime.cs`
+    - `src/SSC/ParallelDynamicAccessExtensions.cs`
+    - `tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs`
+    - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+    - `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+    - `tests/SSC.E2E.Tests/LinqCompatibilityE2ETests.cs`
+    - `README.md`
+    - `doc/design/README.md`
+    - `doc/design/detail/01-DomainModel.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `doc/design/detail/09-ValueStateBehavior.md`
+    - `reports/2026-04-05-getstate-mismatch-enum-extension.md`
+
 - T-062: generated list のモデル軸選択 API 追加
   - Status: 完了（`SelectModel(modelIndex)` でモデル別 list を取得可能化）
   - Output:

--- a/tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs
@@ -233,10 +233,10 @@ public sealed class ContainerAndSelectManyE2ETests
         var rightPresentState = (ValueState)root.Items[1].Detail.Label.GetState(1);
 
         Assert.Null(leftLabel);
-        Assert.Equal(ValueState.PresentNull, leftLabelState);
+        Assert.Equal(ValueState.Mismatched, leftLabelState);
         Assert.Equal(ValueState.Missing, rightLabelState);
         Assert.Equal("present", rightLabel);
-        Assert.Equal(ValueState.PresentValue, rightPresentState);
+        Assert.Equal(ValueState.Mismatched, rightPresentState);
     }
 
     [Fact]

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -98,6 +98,55 @@ public sealed class GeneratedProjectionE2ETests
     }
 
     [Fact]
+    public void Compare_GeneratedProjection_GetState_IncludesMismatchStates()
+    {
+        // Intent: generated value path の GetState は Matched/Mismatched/Missing を返す。
+        var models = new[]
+        {
+            new GeneratedDataset
+            {
+                Groups =
+                [
+                    new GeneratedGroup
+                    {
+                        GroupId = 1,
+                        Items =
+                        [
+                            new GeneratedItem { ItemId = 100, MetricA = 1.0, Detail = new GeneratedDetail { Label = "same" } },
+                            new GeneratedItem { ItemId = 200, MetricA = 2.0, Detail = new GeneratedDetail { Label = null } },
+                        ],
+                    },
+                ],
+            },
+            new GeneratedDataset
+            {
+                Groups =
+                [
+                    new GeneratedGroup
+                    {
+                        GroupId = 1,
+                        Items =
+                        [
+                            new GeneratedItem { ItemId = 100, MetricA = 1.0, Detail = new GeneratedDetail { Label = "same" } },
+                            new GeneratedItem { ItemId = 200, MetricA = 20.0, Detail = new GeneratedDetail { Label = "present" } },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        var matchedMetricState = root.Groups[0].Items[0].MetricA.GetState(0);
+        var mismatchedMetricState = root.Groups[0].Items[1].MetricA.GetState(0);
+        var mismatchedNullState = root.Groups[0].Items[1].Detail.Select(detail => detail.Label).GetState(0);
+
+        Assert.Equal(ValueState.Matched, matchedMetricState);
+        Assert.Equal(ValueState.Mismatched, mismatchedMetricState);
+        Assert.Equal(ValueState.Mismatched, mismatchedNullState);
+    }
+
+    [Fact]
     public void Compare_GeneratedProjection_ListSupportsLinqSelect()
     {
         // Intent: generated list は IEnumerable として LINQ Select を利用できる。

--- a/tests/SSC.E2E.Tests/LinqCompatibilityE2ETests.cs
+++ b/tests/SSC.E2E.Tests/LinqCompatibilityE2ETests.cs
@@ -139,7 +139,7 @@ public sealed class LinqCompatibilityE2ETests
             .ToArray();
 
         int[] leftPresentItemIds = flattenedItems
-            .Where(item => item.ItemId.GetState(0) == ValueState.PresentValue)
+            .Where(item => item.ItemId.GetState(0) != ValueState.Missing)
             .Select(item => item.ItemId[0]!.Value)
             .OrderBy(id => id)
             .Take(4)

--- a/tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs
+++ b/tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs
@@ -8,7 +8,7 @@ public sealed class ParallelNodeUnitTests
     public void Indexer_OutOfRange_ThrowsExecutionException()
     {
         // Intent: model slot の範囲外アクセスは必ず ModelIndexOutOfRange で失敗させる。
-        var node = ParallelNode<string>.CreateLeaf(["a", "b"], [ValueState.PresentValue, ValueState.PresentValue], keyText: "k");
+        var node = ParallelNode<string>.CreateLeaf(["a", "b"], [ValueState.Matched, ValueState.Matched], keyText: "k");
 
         var exception = Assert.Throws<CompareExecutionException>(() => _ = node[2]);
 
@@ -19,13 +19,36 @@ public sealed class ParallelNodeUnitTests
     public void PresenceFlags_FollowValueStates()
     {
         // Intent: AllPresent / AnyPresent / GetState が ValueState の定義通りに評価される。
-        var node = ParallelNode<string>.CreateLeaf(["x", null, null], [ValueState.PresentValue, ValueState.PresentNull, ValueState.Missing], keyText: "k");
+        var node = ParallelNode<string>.CreateLeaf(["x", null, null], [ValueState.Matched, ValueState.Matched, ValueState.Missing], keyText: "k");
 
         Assert.False(node.AllPresent);
         Assert.True(node.AnyPresent);
-        Assert.Equal(ValueState.PresentValue, node.GetState(0));
-        Assert.Equal(ValueState.PresentNull, node.GetState(1));
+        Assert.Equal(ValueState.Mismatched, node.GetState(0));
+        Assert.Equal(ValueState.Mismatched, node.GetState(1));
         Assert.Equal(ValueState.Missing, node.GetState(2));
+    }
+
+    [Fact]
+    public void GetState_WhenAllValuesMatch_ReturnsMatched()
+    {
+        // Intent: 比較対象があり、値が一致する場合は Matched を返す。
+        var valueNode = ParallelNode<int>.CreateLeaf([10, 10], [ValueState.Matched, ValueState.Matched], keyText: "k");
+        var nullNode = ParallelNode<string>.CreateLeaf([null, null], [ValueState.Matched, ValueState.Matched], keyText: "k");
+
+        Assert.Equal(ValueState.Matched, valueNode.GetState(0));
+        Assert.Equal(ValueState.Matched, valueNode.GetState(1));
+        Assert.Equal(ValueState.Matched, nullNode.GetState(0));
+        Assert.Equal(ValueState.Matched, nullNode.GetState(1));
+    }
+
+    [Fact]
+    public void GetState_WhenNoComparisonTarget_ReturnsMissing()
+    {
+        // Intent: 自身以外に比較対象が存在しない場合は Missing を返す。
+        var node = ParallelNode<string>.CreateLeaf([null, null], [ValueState.Missing, ValueState.Missing], keyText: "k");
+
+        Assert.Equal(ValueState.Missing, node.GetState(0));
+        Assert.Equal(ValueState.Missing, node.GetState(1));
     }
 
     [Fact]
@@ -33,7 +56,7 @@ public sealed class ParallelNodeUnitTests
     {
         // Intent: values/states 長が一致しない node は生成させない。
         var exception = Assert.Throws<ArgumentException>(
-            () => ParallelNode<string>.CreateLeaf(["a", "b"], [ValueState.PresentValue], keyText: "k"));
+            () => ParallelNode<string>.CreateLeaf(["a", "b"], [ValueState.Matched], keyText: "k"));
 
         Assert.Contains("must match", exception.Message, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary
- redefine `ValueState` to three states: `Missing`, `Matched`, `Mismatched`
- update `GetState(modelIndex)` behavior across node/generated/dynamic paths to use the new semantics
- introduce internal `NodePresenceState` to keep missing/null/value precision internally
- add detailed behavior design doc: `doc/design/detail/09-ValueStateBehavior.md`
- remove volatile README status lines (phase and test counts)
- update tests, design docs, reports, and task tracking files

## Verification
- `dotnet test SSC.sln --configuration Release`

## Related
- Closes #18