### PR TITLE
Draft: Add XPath-like path access and diff display helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,64 @@ public sealed class ProductItem
 }
 ```
 
+## XPath-like Path Access and Diff Entries
+
+Use XPath-like paths when you want to read a node, value, or state without using dynamic or generated projections.
+Paths are root-relative by default, and a root type prefix is optional.
+
+```csharp
+IParallelNode? priceNode = result.GetNodeByPath("Items[2].Price");
+
+object? leftPrice = result.GetValueByPath("ProductModel.Items[2].Price", 0); // 200
+object? rightPrice = result.GetValueByPath("Items[2].Price", 1);             // 250
+ValueState rightState = result.GetStateByPath("Items[1].Price", 1);          // Missing
+```
+
+`GetDiffEntries()` returns structured diff entries with path, kind, node, and per-model values.
+For `ParallelDiffEntryKind.Node`, `GetNodeByPath(entry.Path)` resolves the same node.
+
+```csharp
+IReadOnlyList<ParallelDiffEntry> entries = result.GetDiffEntries();
+
+ParallelDiffEntry priceDiff = entries.Single(entry => entry.Path == "Items[2].Price");
+
+IParallelNode? sameNode = result.GetNodeByPath(priceDiff.Path);
+bool resolvesSameNode = ReferenceEquals(priceDiff.Node, sameNode); // true
+
+foreach (ParallelDiffValue value in priceDiff.Values)
+{
+    Console.WriteLine(value);
+}
+
+Console.WriteLine(priceDiff);
+// Items[2].Price: [0]=200(Mismatched), [1]=250(Mismatched)
+```
+
+For `ParallelDiffEntryKind.ContainerPresence`, `Node` is `null`; the path identifies the container member for display, but `GetNodeByPath(entry.Path)` is not guaranteed to resolve a node.
+`ValueState` distinguishes a missing slot from an actual `null` value.
+
+```csharp
+CompareResult<OptionalProductModel> emptyContainerResult = ParallelCompareApi.Compare(
+[
+    new OptionalProductModel { Items = [] },
+    new OptionalProductModel { Items = null },
+]);
+
+IReadOnlyList<ParallelDiffEntry> containerEntries = emptyContainerResult.GetDiffEntries();
+ParallelDiffEntry containerDiff = containerEntries.Single(entry =>
+    entry.Kind == ParallelDiffEntryKind.ContainerPresence);
+
+IParallelNode? unresolved = emptyContainerResult.GetNodeByPath(containerDiff.Path); // null
+
+Console.WriteLine(containerDiff);
+// Items: [0]=null(Mismatched), [1]=null(Mismatched)
+
+public sealed class OptionalProductModel
+{
+    public List<ProductItem>? Items { get; init; }
+}
+```
+
 ## Source Generator Example
 
 ```csharp

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -340,18 +340,18 @@ XML XPath の完全実装ではなく、SSC の object member / container node /
 
 #### 4.2.2.1 Public API Contract
 
-`GetNodeByPath(path)` は、XPath-like path に一致する `IParallelNode` を返す。
+`GetNodeByPath<T>(this CompareResult<T> result, string path)` は、XPath-like path に一致する `IParallelNode` を返す。
 path が解決できない場合は `null` を返す。
 
-`GetValueByPath(path, modelIndex)` は、`GetNodeByPath(path)` で取得した node の `GetValue(modelIndex)` を返す。
+`GetValueByPath<T>(this CompareResult<T> result, string path, int modelIndex)` は、`GetNodeByPath(path)` で取得した node の `GetValue(modelIndex)` を返す。
 path が解決できない場合は `null` を返す。
 model index が範囲外の場合は、既存 node indexer と同じく `ModelIndexOutOfRange` の `CompareExecutionException` を返す。
 
-`GetStateByPath(path, modelIndex)` は、`GetNodeByPath(path)` で取得した node の `GetState(modelIndex)` を返す。
+`GetStateByPath<T>(this CompareResult<T> result, string path, int modelIndex)` は、`GetNodeByPath(path)` で取得した node の `GetState(modelIndex)` を返す。
 path が解決できない場合は `Missing` を返す。
 model index が範囲外の場合は、既存 node indexer と同じく `ModelIndexOutOfRange` の `CompareExecutionException` を返す。
 
-`GetDiffEntries()` は、差分のある node を leaf/value path 単位で列挙する。
+`GetDiffEntries<T>(this CompareResult<T> result)` は、差分のある node を leaf/value path 単位で列挙し、child node を持たない container presence mismatch を container member path で列挙する。
 返却値は構造化データとし、表示専用 string API にはしない。
 ただし `ParallelDiffEntry` と `ParallelDiffValue` は人間確認用の `ToString()` を必ず実装する。
 
@@ -487,6 +487,7 @@ object/container node で child 側に差分があるだけの場合は、親 no
 ```text
 Groups[1].Items[100].MetricA: [0]=1(Mismatched), [1]=10(Mismatched)
 Groups[1].Items[200].Name: [0]="left"(Mismatched), [1]=<missing>(Missing)
+Items: [0]=null(Mismatched), [1]=<missing>(Missing)
 ```
 
 `ParallelDiffValue.ToString()` は `[modelIndex]=value(state)` 形式を返す。

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -93,6 +93,51 @@ internal static class DatasetGeneratedViewExtensions
 }
 ```
 
+```csharp
+public static class ParallelPathAccessExtensions
+{
+    public static IParallelNode? GetNodeByPath<T>(this CompareResult<T> result, string path);
+
+    public static object? GetValueByPath<T>(
+        this CompareResult<T> result,
+        string path,
+        int modelIndex);
+
+    public static ValueState GetStateByPath<T>(
+        this CompareResult<T> result,
+        string path,
+        int modelIndex);
+
+    public static IReadOnlyList<ParallelDiffEntry> GetDiffEntries<T>(
+        this CompareResult<T> result);
+}
+
+public sealed class ParallelDiffEntry
+{
+    public string Path { get; }
+    public ParallelDiffEntryKind Kind { get; }
+    public IParallelNode? Node { get; }
+    public IReadOnlyList<ParallelDiffValue> Values { get; }
+
+    public override string ToString();
+}
+
+public enum ParallelDiffEntryKind
+{
+    Node,
+    ContainerPresence,
+}
+
+public sealed class ParallelDiffValue
+{
+    public int ModelIndex { get; }
+    public object? Value { get; }
+    public ValueState State { get; }
+
+    public override string ToString();
+}
+```
+
 ## 4. Behavior Contract
 
 - indexer の範囲外アクセスは `ModelIndexOutOfRange`
@@ -276,7 +321,195 @@ static IEnumerable<(string Path, IParallelNode Node)> Walk(IParallelNode node, s
 - scalar/object member は `Name` だけで一意化し、container member は `Name[discriminator]` で一意化する
 - container child の discriminator は `KeyText` を優先し、`KeyText == null` のときだけ `#<ordinal>` を代替識別子として使う
 
-### 4.2.2 Dynamic `GetState` の保証範囲
+### 4.2.2 XPath-like Path Access And Diff Helper
+
+XPath-like path access は、比較結果 tree 内の node を文字列 path で取得する helper である。
+XML XPath の完全実装ではなく、SSC の object member / container node / model slot に必要な最小 grammar を定義する。
+
+目的:
+
+- dynamic / generated projection を使わない利用者にも、path 文字列で値を取得する導線を提供する
+- 差分表示 helper が、path と model 別 value/state を併記できるようにする
+- `GetDirectChildren()` で利用者が自前実装していた再帰 traversal と path 組み立てを、標準 helper として提供する
+
+非目的:
+
+- XML XPath の axis、attribute、namespace、function、predicate 全般を実装すること
+- 任意条件で node set を検索する query language を提供すること
+- `CompareIssue.Path` の既存診断形式を置き換えること
+
+#### 4.2.2.1 Public API Contract
+
+`GetNodeByPath(path)` は、XPath-like path に一致する `IParallelNode` を返す。
+path が解決できない場合は `null` を返す。
+
+`GetValueByPath(path, modelIndex)` は、`GetNodeByPath(path)` で取得した node の `GetValue(modelIndex)` を返す。
+path が解決できない場合は `null` を返す。
+model index が範囲外の場合は、既存 node indexer と同じく `ModelIndexOutOfRange` の `CompareExecutionException` を返す。
+
+`GetStateByPath(path, modelIndex)` は、`GetNodeByPath(path)` で取得した node の `GetState(modelIndex)` を返す。
+path が解決できない場合は `Missing` を返す。
+model index が範囲外の場合は、既存 node indexer と同じく `ModelIndexOutOfRange` の `CompareExecutionException` を返す。
+
+`GetDiffEntries()` は、差分のある node を leaf/value path 単位で列挙する。
+返却値は構造化データとし、表示専用 string API にはしない。
+ただし `ParallelDiffEntry` と `ParallelDiffValue` は人間確認用の `ToString()` を必ず実装する。
+
+#### 4.2.2.2 Path Grammar
+
+XPath-like path は root からの相対 path を基本とする。
+root type 名の prefix は任意であり、指定された場合は比較 root の型名と一致する必要がある。
+
+```text
+path             = [ root-name "." ] segment *( "." segment )
+segment          = member-name [ selector ]
+selector         = "[" discriminator "]"
+discriminator    = key-discriminator / ordinal-discriminator
+ordinal-discriminator = "#" 1*DIGIT
+key-discriminator     = 1*( key-char / escape-sequence )
+escape-sequence       = "\]" / "\\" / "\#"
+```
+
+`member-name` は比較対象 model の public property 名である。
+大文字小文字は区別し、`StringComparer.Ordinal` 相当で解決する。
+
+例:
+
+- `Groups`
+- `Groups[1]`
+- `Groups[1].Items[100].MetricA`
+- `Dataset.Groups[1].Items[100].MetricA`
+- `Items[#0].Name`
+
+segment の意味:
+
+- `Name`
+  - scalar/object member を表す
+  - `ParallelChildSet.Nodes.Count == 1` の member に対応する
+- `Name[key]`
+  - container member の child node を key text で選択する
+  - child node の `KeyText` と完全一致する child を選ぶ
+- `Name[#ordinal]`
+  - key text を持たない container child を ordinal で選択する
+  - ordinal は同一 `ParallelChildSet.Nodes` 内の 0-based index である
+
+selector を持つ segment は container member に対してだけ有効である。
+scalar/object member に selector が指定された場合は未解決扱いとする。
+
+selector を持たない container member は、その container 全体を表す node ではなく child set を表すため、
+`GetNodeByPath` の最終 segment としては解決できない。
+container child を取得する場合は `Items[100]` または `Items[#0]` のように selector を指定する。
+
+#### 4.2.2.3 Escaping Rule
+
+`.` は bracket 外では segment 区切りである。
+bracket 内では key discriminator の一部として扱う。
+
+bracket 内で `]` または `\` を key text として含める場合は escape する。
+key text が `#<digits>` 形式そのものの場合は、先頭の `#` を escape して ordinal discriminator と区別する。
+
+```text
+\]  => ]
+\\  => \
+\#  => #（bracket 先頭で ordinal discriminator と区別する場合）
+```
+
+例:
+
+- key text `A.B` は `Items[A.B]`
+- key text `A]B` は `Items[A\]B]`
+- key text `A\B` は `Items[A\\B]`
+- key text `#0` は `Items[\#0]`
+
+#### 4.2.2.4 Path Generation Rule
+
+`GetDiffEntries()` が生成する path は、`GetDirectChildren()` と同じ direct child traversal を基にする。
+
+- scalar/object member は `Name`
+- container child は `Name[discriminator]`
+- discriminator は `child.KeyText` を優先する
+- `child.KeyText == null` の場合だけ `#<ordinal>` を使う
+- root type 名は生成 path には含めない
+
+`Kind == Node` の diff entry で生成される path は、同一 `CompareResult<T>` 内で `GetNodeByPath(path)` に渡すと同じ node を解決できなければならない。
+
+empty container の presence mismatch のように child node が存在しない差分は、
+特定 child path を生成できない。
+この場合は container member 名の path を持つ `Kind == ContainerPresence` の diff entry として表す。
+`ContainerPresence` entry は public node に対応しないため、`Node == null` とし、`GetNodeByPath(Path)` による node 解決は保証しない。
+それでも `Path` には該当 container member 名を入れ、差分表示で位置を失わない。
+
+#### 4.2.2.5 Diff Entry Contract
+
+`ParallelDiffEntry` は 1 つの差分箇所を表す。
+
+- `Path`
+  - XPath-like path
+  - `Kind == Node` では `GetNodeByPath(Path)` で同じ node を解決できる
+  - `Kind == ContainerPresence` では container member の位置を表すが、node 解決は保証しない
+- `Kind`
+  - `Node`: `IParallelNode` に対応する差分
+  - `ContainerPresence`: child node を持たない container presence mismatch
+- `Node`
+  - `Kind == Node` では差分が観測された `IParallelNode`
+  - `Kind == ContainerPresence` では `null`
+- `Values`
+  - model slot ごとの value/state
+  - `Values.Count == result.Root.Count`
+
+`ParallelDiffValue` は 1 model slot の表示単位である。
+
+- `ModelIndex`
+  - model slot の index
+- `Value`
+  - `Kind == Node` では `Node.GetValue(ModelIndex)` の値
+  - `Kind == ContainerPresence` では `null`
+  - `Missing` と実値 `null` は `State` で区別する
+- `State`
+  - `Kind == Node` では `Node.GetState(ModelIndex)` の値
+  - `Kind == ContainerPresence` では該当 container member の presence mismatch から導いた値
+
+`GetDiffEntries()` は次の node を返す。
+
+- `HasDifferences() == true` の leaf/value node
+- object/container node 自身の presence mismatch
+- empty container など child node を持たないが `ParallelChildSet.HasDifferences == true` の差分
+
+object/container node で child 側に差分があるだけの場合は、親 node の diff entry を重複して返さない。
+親自身の presence mismatch がある場合だけ親 node の diff entry を返す。
+
+#### 4.2.2.6 ToString Contract
+
+`ParallelDiffEntry.ToString()` は、path と model 別 value/state を 1 行で表す。
+
+例:
+
+```text
+Groups[1].Items[100].MetricA: [0]=1(Mismatched), [1]=10(Mismatched)
+Groups[1].Items[200].Name: [0]="left"(Mismatched), [1]=<missing>(Missing)
+```
+
+`ParallelDiffValue.ToString()` は `[modelIndex]=value(state)` 形式を返す。
+
+value 表示:
+
+- `Missing` の slot は `<missing>`
+- 実値 `null` は `null`
+- string は `"` で囲む
+- その他は `Convert.ToString(value, CultureInfo.InvariantCulture)` 相当
+
+`ToString()` は人間確認用の便利表示であり、機械処理の安定契約は `Path` / `Values` / `State` / `Value` を使う。
+ただし、同じライブラリ version 内では deterministic な表示を保つ。
+
+#### 4.2.2.7 CompareIssue.Path との違い
+
+`CompareIssue.Path` は issue 診断用の property path であり、既存どおり container key / ordinal を含めない。
+一方、XPath-like path は比較結果 tree の node 解決用であり、container child を `Items[100]` / `Items[#0]` のように識別する。
+
+この 2 つは互換変換を保証しない。
+issue から詳細 node を辿る必要がある場合は、`CompareIssue.Path` と `KeyText` を組み合わせて利用者側で判断する。
+
+### 4.2.3 Dynamic `GetState` の保証範囲
 
 この節で扱うのは、`AsDynamic()` から辿る値経路の `GetState(modelIndex)` である。
 
@@ -391,7 +624,7 @@ foreach (dynamic child in root.Items[0].Detail.Children)
 - これは `a.b.c.d` の `d` が実行時専用 `List` でも `foreach` / index access できる、という意味である
 - ただし container 正規化の前提（例: sequence element に `[CompareKey]` が必要）を満たさない場合は、silent に欠落させず access 時に `CompareExecutionException` を返す
 
-### 4.2.3 実行時専用メンバーで `GetState` が判定される仕組み
+### 4.2.4 実行時専用メンバーで `GetState` が判定される仕組み
 
 この節では、`root.Items[0].Detail.Label.GetState(0)` のような dynamic value path が、
 保存済み state を読む通常経路と、呼び出し時に反射で値を辿る代替経路のどちらへ入るかを説明する。

--- a/doc/design/detail/05-ResultAndErrors.md
+++ b/doc/design/detail/05-ResultAndErrors.md
@@ -66,7 +66,7 @@ public enum CompareIssueLevel { Error, Warning }
 
 ### 5.1 Path Format
 
-`Path` は `.` 区切りでプロパティチェーンを表現する。
+`CompareIssue.Path` は `.` 区切りでプロパティチェーンを表現する。
 
 例:
 
@@ -75,6 +75,18 @@ public enum CompareIssueLevel { Error, Warning }
 - `Dataset.Groups.Items.MetricA`
 
 キー関係の補助情報は `KeyText` に出し、`Path` にインデックス番号は含めない。
+
+`CompareIssue.Path` は診断対象のプロパティ位置を示すための簡易 path であり、
+差分表示 helper が返す XPath-like path とは別契約である。
+
+- `CompareIssue.Path`:
+  - issue の発生位置を表す
+  - container の key / ordinal discriminator は含めない
+  - key 関係の補助情報は `KeyText` で表す
+- XPath-like path:
+  - 比較結果 tree 内の node を一意に辿るために使う
+  - container segment に `Items[100]` / `Items[#0]` のような discriminator を含める
+  - 詳細 grammar は `02-PublicApi.md` の XPath-like path access 契約で定義する
 
 ## 6. Recommended Error Response
 

--- a/reports/task-t-077-implementation-20260623091447.md
+++ b/reports/task-t-077-implementation-20260623091447.md
@@ -1,0 +1,67 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-077 XPath-like path parser と public result 型の追加
+- タスク種別: TDD 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示により、コード実装はサブエージェントへ委譲するため。実装 worker は `gpt-5.5 medium` を使う。
+
+## 対象範囲
+
+- 対象:
+  - `ParallelDiffEntry`
+  - `ParallelDiffEntryKind`
+  - `ParallelDiffValue`
+  - XPath-like path parser の internal 実装
+  - parser / `ToString()` の unit test
+
+## 対象外
+
+- 対象外:
+  - `GetNodeByPath<T>()`
+  - `GetValueByPath<T>()`
+  - `GetStateByPath<T>()`
+  - `GetDiffEntries<T>()`
+  - node 解決
+  - 差分列挙
+  - README 更新
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`: 失敗（実装前）。`XPathLikePath` が未実装のため `CS0246` でコンパイル失敗し、追加テストが現在の gap を検出することを確認。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`: 成功（実装後）。17 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release`: 成功。23 件成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/Internal/XPathLikePathParser.cs`
+  - `src/SSC/Properties/AssemblyInfo.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`
+  - `tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs`
+  - `reports/task-t-077-implementation-20260623091447.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `tasks/tasks-status.md`
+  - `AGENTS.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `ParallelDiffEntryKind`、`ParallelDiffEntry`、`ParallelDiffValue` を追加し、`ToString()` 契約を実装した。
+  - internal の XPath-like path parser を追加し、root prefix、segment、key selector、ordinal selector、escape、invalid grammar を unit test で確認した。
+  - `GetNodeByPath<T>()`、`GetValueByPath<T>()`、`GetStateByPath<T>()`、`GetDiffEntries<T>()`、node 解決、差分列挙には踏み込んでいない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - root prefix は parser に expected root 名が渡された場合だけ prefix として保持する。実際の root type 名をどの呼び出しで渡すかは T-078 以降の path 解決側で扱う必要がある。

--- a/reports/task-t-077-review-20260623091556.md
+++ b/reports/task-t-077-review-20260623091556.md
@@ -1,0 +1,79 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-077 XPath-like path parser と public result 型のコードレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示により、コードレビューはサブエージェントへ委譲するため。レビュー worker は `gpt-5.5 high` を使う。
+
+## 対象範囲
+
+- 対象:
+  - T-077 実装差分
+  - parser / public result 型 / `ToString()` / unit test
+  - T-077 の scope 境界逸脱の有無
+
+## 対象外
+
+- 対象外:
+  - T-078 以降の path 解決 API
+  - T-079 以降の diff entry 列挙
+  - README 更新
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`: 成功。17 件成功。
+  - 再レビュー: `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`: 成功。20 件成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/Internal/XPathLikePathParser.cs`
+  - `src/SSC/Properties/AssemblyInfo.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`
+  - `tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs`
+  - `reports/task-t-077-implementation-20260623091447.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `tasks/tasks-status.md`
+  - `AGENTS.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - 再レビューで追加確認:
+    - `reports/task-t-077-review-fix-20260623092446.md`
+    - `src/SSC/Internal/XPathLikePathParser.cs`
+    - `tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`
+    - `src/SSC/ParallelDiffContracts.cs`
+    - `tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - [P2] `XPathLikePathParser` が `Items[A][B]` のような複数 selector 形式を invalid grammar として拒否できない。設計 grammar は `segment = member-name [ selector ]` で 1 segment あたり selector は 0 または 1 個であり、`]` は bracket 内 key text では escape が必要な文字として定義されている。しかし `TrySplitSegments` は最初の `]` で selector を閉じた後、同一 segment 内の次の `[` を新しい selector 開始として扱い、`TryParseSegment` は最初の `[` から末尾 `]` までを selector text として切り出すため、`A][B` のような unescaped `]` を key text として受理し得る。該当箇所: `src/SSC/Internal/XPathLikePathParser.cs:140`, `src/SSC/Internal/XPathLikePathParser.cs:148`, `src/SSC/Internal/XPathLikePathParser.cs:190`, `src/SSC/Internal/XPathLikePathParser.cs:203`。
+  - 重大な normal-path blocker: なし。valid path、root prefix、key selector、ordinal selector、escape、`ToString()` の既存 focused test は成功している。
+  - user-confirmation-required capability gap: なし。T-078 以降の node 解決 / diff 列挙には踏み込んでいない。
+  - 再レビュー: 指摘なし。前回 P2 は `selectorClosedInSegment` による同一 segment 内の追加 selector 拒否と regression test 追加により解消済み。新しい blocker は確認していない。
+
+## 結果
+
+- 結果:
+  - T-077 実装差分をレビューした。
+  - public result 型の shape と `ToString()` は設計契約と整合している。
+  - parser は valid grammar の root prefix、segment、key selector、ordinal selector、escape を概ね設計どおり扱っている。
+  - scope 外の `GetNodeByPath<T>()`、`GetValueByPath<T>()`、`GetStateByPath<T>()`、`GetDiffEntries<T>()`、node 解決、差分列挙には踏み込んでいないことを確認した。
+  - 上記 P2 指摘のため、invalid grammar の拒否条件と unit test の追加が必要。
+  - 再レビュー:
+    - `Items[A][B]`、`Items[#0][B]`、`Items[A]B]` の invalid grammar test が追加されていることを確認した。
+    - `XPathLikePathParser` は selector が閉じた後、同一 segment 内の追加 `[` を拒否し、unescaped `]` も引き続き拒否していることを確認した。
+    - public result 型、`ToString()`、T-077 scope 境界に新しい blocker は確認していない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - Markdown lint はユーザー指示により未実施。Markdown 検査未実施の残リスクのみ記録し、finding にはしていない。
+  - 複数 selector / unescaped `]` を含む invalid grammar の focused test が不足している。
+  - 再レビュー: Markdown lint はユーザー指示により未実施。前回の invalid grammar test 不足リスクは解消済み。

--- a/reports/task-t-077-review-fix-20260623092446.md
+++ b/reports/task-t-077-review-fix-20260623092446.md
@@ -1,0 +1,57 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-077 review P2 指摘対応
+- タスク種別: TDD 修正
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示により、コード実装修正はサブエージェントへ委譲するため。実装 worker は `gpt-5.5 medium` を使う。
+
+## 対象範囲
+
+- 対象:
+  - `XPathLikePathParser` の invalid grammar 拒否条件修正
+  - 複数 selector / unescaped `]` の focused unit test 追加
+  - review 指摘の report 記録
+
+## 対象外
+
+- 対象外:
+  - T-078 以降の path 解決 API
+  - T-079 以降の diff entry 列挙
+  - README 更新
+  - review report の書き換え
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`: 失敗（修正前）。追加した `Items[A][B]` regression test が `Assert.False` で失敗し、複数 selector が受理される P2 を再現。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`: 成功（修正後）。20 件成功。
+  - `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `reports/task-t-077-review-20260623091556.md`
+  - `reports/task-t-077-review-fix-20260623092446.md`
+  - `src/SSC/Internal/XPathLikePathParser.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - [P2] `XPathLikePathParser` が `Items[A][B]` のような複数 selector grammar を invalid として拒否できない。
+
+## 結果
+
+- 結果:
+  - `Items[A][B]`、`Items[#0][B]`、`Items[A]B]` を invalid grammar として拒否する regression test を追加した。
+  - `TrySplitSegments` で selector が閉じた後、同一 segment 内の追加 `[` または unescaped `]` を invalid として拒否するように修正した。
+  - focused test と `git diff --check` が成功し、P2 指摘は修正済み。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。今回の修正は parser の invalid grammar 拒否条件に限定し、public result 型や path 解決 API には触れていない。

--- a/reports/task-t-078-implementation-20260623093152.md
+++ b/reports/task-t-078-implementation-20260623093152.md
@@ -1,0 +1,66 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-078 XPath-like path による node/value/state 解決 API の追加
+- タスク種別: TDD 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示により、コード実装はサブエージェントへ委譲するため。実装 worker は `gpt-5.5 medium` を使う。
+
+## 対象範囲
+
+- 対象:
+  - `GetNodeByPath<T>()`
+  - `GetValueByPath<T>()`
+  - `GetStateByPath<T>()`
+  - scalar/object member と keyed / ordinal container child の解決
+  - root prefix あり/なし、未解決 path、範囲外 model index の test
+
+## 対象外
+
+- 対象外:
+  - `GetDiffEntries<T>()`
+  - diff entry 列挙
+  - `ContainerPresence`
+  - README 更新
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessE2ETests"`: 失敗（実装前）。`GetNodeByPath` / `GetValueByPath` / `GetStateByPath` が未実装のため `CS1061` でコンパイル失敗し、追加 E2E が現在の gap を検出することを確認。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessUnitTests"`: 失敗（実装前）。同じく path access API 未実装のため `CS1061` でコンパイル失敗し、ordinal selector unit test が現在の gap を検出することを確認。
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessE2ETests"`: 成功（実装後）。4 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessUnitTests"`: 成功（実装後）。1 件成功。
+  - `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/Internal/XPathLikePathParser.cs`
+  - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+  - `reports/task-t-078-implementation-20260623093152.md`
+  - `tasks/tasks-status.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `AGENTS.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `CompareResult<T>` 向けに `GetNodeByPath`、`GetValueByPath`、`GetStateByPath` を追加した。
+  - root prefix あり/なしの keyed path、未解決 path、範囲外 model index を実 compare E2E で検証した。
+  - ordinal selector `#0` は現行 compare graph が sequence element に `[CompareKey]` を要求し、自然な `KeyText == null` container child を作りにくいため、fake `IParallelNode` / fake `CompareResult<T>` の unit test で keyless container child の traversal を検証した。
+  - `GetDiffEntries<T>()`、diff entry 列挙、`ContainerPresence` には踏み込んでいない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。T-078 の path 解決 API 追加に限定して実装した。

--- a/reports/task-t-078-review-20260623093200.md
+++ b/reports/task-t-078-review-20260623093200.md
@@ -1,0 +1,71 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-078 XPath-like path による node/value/state 解決 API のコードレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示により、コードレビューはサブエージェントへ委譲するため。レビュー worker は `gpt-5.5 high` を使う。
+
+## 対象範囲
+
+- 対象:
+  - T-078 実装差分
+  - path 解決 API
+  - keyed / ordinal traversal
+  - 未解決 path / model index 範囲外の挙動
+  - T-078 の scope 境界逸脱の有無
+
+## 対象外
+
+- 対象外:
+  - T-079 以降の diff entry 列挙
+  - T-080 の `ContainerPresence`
+  - README 更新
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessE2ETests"`: 成功。4 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessUnitTests"`: 成功。1 件成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/Internal/XPathLikePathParser.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/Contracts.cs`
+  - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+  - `reports/task-t-078-implementation-20260623093152.md`
+  - `tasks/tasks-status.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `AGENTS.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/references/session-review-shape-policy.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-documentation-policy.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `GetNodeByPath<T>()`、`GetValueByPath<T>()`、`GetStateByPath<T>()` は T-078 の設計契約と整合していることを確認した。
+  - root prefix あり/なし、keyed selector、ordinal selector、未解決 path、model index 範囲外の挙動を確認した。
+  - selector なし container member は `TryGetMemberNode` 経由でのみ解決され、container child set を node として誤解決しないことを確認した。
+  - `GetStateByPath` の unresolved path は `ValueState.Missing` を返し、解決済み node の範囲外 model index は既存 node と同じ `CompareExecutionException` / `ModelIndexOutOfRange` になることを確認した。
+  - `GetDiffEntries<T>()`、diff entry 列挙、`ContainerPresence` には踏み込んでいないことを確認した。
+  - ordinal selector は fake unit test で keyless container child の traversal を検証しており、現行 compare graph が sequence element に `[CompareKey]` を要求する制約下では T-078 の normal-path blocker ではないと判断した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - Markdown lint はユーザー指示により未実施。Markdown 検査未実施の残リスクのみ記録し、finding にはしていない。
+  - ordinal selector の自然な E2E coverage は現行 compare graph の `[CompareKey]` 要求により未追加。fake unit test で keyless child traversal は確認済みで、T-078 の blocker ではない。

--- a/reports/task-t-079-implementation-20260623094407.md
+++ b/reports/task-t-079-implementation-20260623094407.md
@@ -1,0 +1,61 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-079 通常 node 差分の `GetDiffEntries()` 追加
+- タスク種別: TDD 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示によりコード実装は `gpt-5.5 medium` の sub-agent に委譲する。対象は public helper API と E2E test の両方にまたがるため、親 agent は scope 管理と Git 操作に専念する。
+
+## 対象範囲
+
+- 対象: `Kind == Node` の `ParallelDiffEntry` 列挙、leaf/value node 差分、object/container node 自身の presence mismatch、keyed path / ordinal path 生成、生成 path の `GetNodeByPath()` 解決検証、代表 `ToString()` 検証
+
+## 対象外
+
+- 対象外: empty container の `ContainerPresence` entry、README/API docs 同期、破壊的変更、Markdown 検査、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`: 失敗（実装前）。`GetDiffEntries` が未実装のため `CS1061` でコンパイル失敗し、追加 E2E が現在の gap を検出することを確認。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests"`: 失敗（実装前）。同じく `GetDiffEntries` 未実装のため `CS1061` でコンパイル失敗し、ordinal path unit test が現在の gap を検出することを確認。
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`: 成功（実装後）。4 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests"`: 成功（実装後）。1 件成功。
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests|FullyQualifiedName~XPathLikePathAccessE2ETests"`: 成功。8 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~XPathLikePathAccessUnitTests"`: 成功。2 件成功。
+  - `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+  - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+  - `reports/task-t-079-implementation-20260623094407.md`
+  - `tasks/tasks-status.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `AGENTS.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `CompareResult<T>` 向けに `GetDiffEntries()` を追加し、`Kind == Node` の通常 node 差分を `ParallelDiffEntry` として列挙するようにした。
+  - leaf/value node 差分、object/container node 自身の presence mismatch、keyed path、keyless container child の ordinal path、key escape、生成 path の `GetNodeByPath()` 解決、代表 `ToString()` を test で検証した。
+  - object/container node で child 側に差分があるだけの場合は親 node entry を重複して返さず、親自身の presence mismatch がある場合だけ親 node entry を返すようにした。
+  - empty container の `ContainerPresence` entry、README/API docs 同期、Markdown 検査、commit/push/PR 操作には踏み込んでいない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。child node を持たない empty container presence mismatch は T-080 の対象として、T-079 では列挙しない。

--- a/reports/task-t-079-review-20260623094407.md
+++ b/reports/task-t-079-review-20260623094407.md
@@ -1,0 +1,63 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-079 通常 node 差分の `GetDiffEntries()` 追加のコードレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer とユーザー指示により、コードレビューは `gpt-5.5 high` の sub-agent に委譲する。実装者とは別 agent による独立レビューを行う。
+
+## 対象範囲
+
+- 対象: T-079 の task-scoped diff、`GetDiffEntries()` の `Kind == Node` 契約、生成 path の解決可能性、presence mismatch の扱い、TDD test coverage、設計書 `doc/design/detail/02-PublicApi.md` との整合
+
+## 対象外
+
+- 対象外: T-080 の `ContainerPresence`、T-081 の README/API docs 同期、Markdown 検査、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`: 成功。4 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests"`: 成功。1 件成功。
+  - `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/ParallelCompareApi.cs`
+  - `src/SSC/Contracts.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+  - `reports/task-t-079-implementation-20260623094407.md`
+  - `tasks/tasks-status.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `AGENTS.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/references/session-review-shape-policy.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-documentation-policy.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `GetDiffEntries()` は `Kind == ParallelDiffEntryKind.Node` の通常 node 差分を構造化 entry として返しており、T-079 の設計契約と整合していることを確認した。
+  - leaf/value node 差分、object/container node 自身の presence mismatch、child-only diff の親重複除外、keyed path / ordinal path 生成を確認した。
+  - generated path は escaping を含めて `GetNodeByPath(path)` で同じ node に round-trip できることを確認した。
+  - empty container の `ContainerPresence` entry は返しておらず、T-080 scope へ踏み込んでいないことを確認した。
+  - 代表 `ToString()` 表示と TDD evidence は T-079 exit criteria を満たしている。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - Markdown 検査はユーザー指示により未実施。Markdown wording / whitelist / tooling はレビュー対象外として扱った。
+  - child node を持たない empty container presence mismatch は T-080 対象として未実装。T-079 の blocker ではない。

--- a/reports/task-t-080-implementation-20260623095422.md
+++ b/reports/task-t-080-implementation-20260623095422.md
@@ -1,0 +1,61 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-080 empty container 差分の `ContainerPresence` entry 追加
+- タスク種別: TDD 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示によりコード実装は `gpt-5.5 medium` の sub-agent に委譲する。T-080 は `GetDiffEntries()` の残り契約である `ContainerPresence` を TDD で閉じる作業であり、親 agent は scope 管理と Git 操作に専念する。
+
+## 対象範囲
+
+- 対象: child node を持たない container presence mismatch の `Kind == ContainerPresence` entry、`Node == null`、container member path、`Values` と `ToString()` による Missing / null の区別、empty list / empty dictionary E2E
+
+## 対象外
+
+- 対象外: 通常 `Kind == Node` entry の再設計、README/API docs 同期、破壊的変更、Markdown 検査、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`: 失敗（実装前）。empty list / empty dictionary の `ContainerPresence` entry が返らず `Assert.Single` で失敗し、T-080 の gap を確認。
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`: 成功（実装後）。5 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~XPathLikePathAccessUnitTests"`: 成功（実装後）。3 件成功。
+  - `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/Contracts.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+  - `reports/task-t-080-implementation-20260623095422.md`
+  - `tasks/tasks-status.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `AGENTS.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `GetDiffEntries()` が `ParallelChildSet.HasDifferences == true` かつ `Nodes.Count == 0` の container member 差分を `Kind == ContainerPresence` entry として返すようにした。
+  - `ContainerPresence` entry は container member path、`Node == null`、model slot ごとの `Values` を持つ。`Value` は `null` 固定で、`State` により present/null と Missing を区別する。
+  - empty list / empty dictionary の E2E で `Path`、`Kind`、`Node == null`、`Values`、`ToString()`、`GetNodeByPath(Path) == null` を検証した。
+  - unit test で `PresentValue` / `Missing` の container presence states を直接作り、`null(Mismatched)` と `<missing>(Missing)` が `ToString()` で区別されることを検証した。
+  - T-079 の通常 `Kind == Node` entry behavior は維持している。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。README/API docs 同期、Markdown 検査、commit/push/PR 操作には踏み込んでいない。

--- a/reports/task-t-080-review-20260623095422.md
+++ b/reports/task-t-080-review-20260623095422.md
@@ -1,0 +1,68 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-080 empty container 差分の `ContainerPresence` entry 追加のコードレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer とユーザー指示により、コードレビューは `gpt-5.5 high` の sub-agent に委譲する。実装者とは別 agent による独立レビューを行う。
+
+## 対象範囲
+
+- 対象: T-080 の task-scoped diff、`ContainerPresence` 契約、empty list / empty dictionary の片側欠損、`Node == null`、`Values` / `ToString()` の Missing と null の区別、`GetNodeByPath(Path)` 非保証の扱い、設計書 `doc/design/detail/02-PublicApi.md` との整合
+
+## 対象外
+
+- 対象外: T-081 の README/API docs 同期、Markdown 検査、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`: 成功。5 件成功。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~XPathLikePathAccessUnitTests"`: 成功。3 件成功。
+  - `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/Contracts.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/ParallelCompareApi.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+  - `reports/task-t-080-implementation-20260623095422.md`
+  - `tasks/tasks-status.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `AGENTS.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/references/session-review-shape-policy.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-documentation-policy.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `ContainerPresence` implementation は T-080 の設計契約と task exit criteria を満たしていることを確認した。
+  - `ParallelChildSet.HasDifferences == true` かつ `Nodes.Count == 0` の empty list / empty dictionary presence mismatch を `Kind == ContainerPresence` entry として返している。
+  - `Path` は container member path、root type prefix なし、`Node == null`、`Values.Count == result.Root.Count`、`Value == null` の契約を確認した。
+  - `State` と `ToString()` により present 側の `null(Mismatched)` と Missing 側の `<missing>(Missing)` を区別できることを確認した。
+  - `GetNodeByPath(Path)` による node 解決を保証しないことは test で `null` として明確化されている。
+  - T-079 の `Kind == Node` behavior と generated path round-trip は維持されている。
+  - internal helper 追加は `IParallelNodeInternal` 内の変更であり、public breaking change は確認していない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - Markdown 検査はユーザー指示により未実施。Markdown wording / whitelist / tooling はレビュー対象外として扱った。
+  - README/API docs 同期は T-081 対象のため未実施。T-080 の blocker ではない。

--- a/reports/task-t-081-implementation-20260623100427.md
+++ b/reports/task-t-081-implementation-20260623100427.md
@@ -1,0 +1,65 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-081 README 利用例と public API ドキュメントの同期
+- タスク種別: docs 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示により docs 更新は `gpt-5.5 medium` の sub-agent に委譲する。親 agent は scope 管理、report 確認、Git 操作を担当する。
+
+## 対象範囲
+
+- 対象: README の XPath-like path access / diff entry 最小利用例、public API 設計書と実装後 API 名・例外・表示例の同期、必要に応じた package readme 同期
+
+## 対象外
+
+- 対象外: コード実装変更、Markdown 検査、Markdown whitelist/tooling、破壊的変更、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `rg -n "PackageReadmeFile|README.md" src/SSC/SSC.csproj src/SSC.Generators/SSC.Generators.csproj`: 成功。runtime / source generator package とも root `README.md` を package readme として同梱する設定を確認。
+  - `git diff --check`: 成功。
+  - `git diff --check`: 成功（review fix 後）。
+  - `git diff --check`: 成功（再レビュー fix 後）。
+  - Markdown 検査: ユーザー指示により未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `README.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `reports/task-t-081-implementation-20260623100427.md`
+  - `tasks/tasks-status.md`
+  - `AGENTS.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+  - review fix: [P2] `README.md` の `ContainerPresence` example が前段の `entries = result.GetDiffEntries()` を再利用しているように読め、Minimal Example の data では `ContainerPresence` entry が存在しない。
+  - 再レビュー fix: [P2] `README.md` の「parent node が missing の場合に `Items: [0]=null(Mismatched), [1]=<missing>(Missing)` が表示される」という説明は、通常 `GetDiffEntries()` 経路では parent `Kind == Node` entry で return する実装と一致しない。
+
+## 結果
+
+- 結果:
+  - `README.md` に XPath-like path access の最小例を追加し、`GetNodeByPath`、`GetValueByPath`、`GetStateByPath` の使い方を記載した。
+  - `README.md` に `GetDiffEntries()` の最小例を追加し、`Path`、`Kind`、`Values`、`ToString()`、`Kind == Node` の path round-trip、`Kind == ContainerPresence` の `Node == null` と node 解決保証なしを記載した。
+  - `README.md` の diff entry 例に、`ValueState` で Missing と実値 `null` を区別する表示例を追加した。
+  - `doc/design/detail/02-PublicApi.md` の public API contract を実装後の extension method signature に合わせ、`GetDiffEntries()` が `ContainerPresence` も返す説明と表示例を補足した。
+  - package readme は root `README.md` が `src/SSC/SSC.csproj` と `src/SSC.Generators/SSC.Generators.csproj` で同梱されるため、追加ファイルは不要と確認した。
+  - review fix として、`ContainerPresence` example を `emptyContainerResult` / `containerEntries` を使う別 comparison の self-contained snippet に修正し、前段の `entries` と誤読されないようにした。
+  - root-level property null の実装挙動と整合するよう、実行 snippet の表示例を `Items: [0]=null(Mismatched), [1]=null(Mismatched)` に変更し、`<missing>(Missing)` は親 node missing 由来の一般表示例として別の text block に分離した。
+  - 再レビュー fix として、parent node missing 由来の `Items: [0]=null(Mismatched), [1]=<missing>(Missing)` text block を `README.md` から削除し、実装と一致する self-contained `ContainerPresence` example だけを残した。
+  - コード実装変更、BreakingChanges 追記、Markdown 検査、commit/push/PR 操作には踏み込んでいない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。Markdown 検査はユーザー指示により未実行。

--- a/reports/task-t-081-review-20260623100427.md
+++ b/reports/task-t-081-review-20260623100427.md
@@ -1,0 +1,90 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-081 README 利用例と public API ドキュメント同期のレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer とユーザー指示により、レビューは `gpt-5.5 high` の sub-agent に委譲する。docs 更新者とは別 agent による独立レビューを行う。
+
+## 対象範囲
+
+- 対象: T-081 の docs-only diff、README の XPath-like path access / diff entry 例、public API 設計書と実装後 API 名・例外・表示例の整合、package readme 同期の要否
+
+## 対象外
+
+- 対象外: Markdown 検査、Markdown whitelist/tooling、コード実装変更、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `git diff --check`: 成功。
+  - `rg -n "PackageReadmeFile|README.md" src/SSC/SSC.csproj src/SSC.Generators/SSC.Generators.csproj`: 成功。runtime / source generator package とも root `README.md` を package readme として同梱する設定を確認。
+  - 再レビュー: `git diff --check`: 成功。
+  - 最終再レビュー: `git diff --check`: 成功。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `README.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `reports/task-t-081-implementation-20260623100427.md`
+  - `tasks/tasks-status.md`
+  - `AGENTS.md`
+  - `/home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `/home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - 再レビューで追加確認:
+    - `README.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `reports/task-t-081-implementation-20260623100427.md`
+    - `tasks/tasks-status.md`
+    - `src/SSC/ParallelPathAccessExtensions.cs`
+    - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+  - 最終再レビューで追加確認:
+    - `README.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `reports/task-t-081-implementation-20260623100427.md`
+    - `tasks/tasks-status.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - [P2] `README.md:190`: `ContainerPresence` example reuses the earlier `entries = result.GetDiffEntries()` from the Minimal Example, but that model data has `Items` children for keys `1`, `2`, and `3`, so it produces `Kind == Node` entries and no `ParallelDiffEntryKind.ContainerPresence` entry. As written, `entries.Single(entry => entry.Kind == ParallelDiffEntryKind.ContainerPresence)` throws instead of demonstrating the documented behavior, and the following `Items: [0]=null(Mismatched), [1]=<missing>(Missing)` output cannot come from the shown `result`. Make the `ContainerPresence` snippet self-contained with empty-container-vs-missing data, or clearly mark it as output from a separate comparison.
+  - 再レビュー disposition: 前回 P2 は解消済み。`ContainerPresence` example は `emptyContainerResult` / `containerEntries` を使う別 comparison になり、表示例も root-level `Items = []` / `Items = null` の実装挙動に合っている。
+  - [P2] `README.md:211`: 追加 text block の「container member is missing because its parent node is missing」という説明は、実際の `GetDiffEntries()` の通常経路と一致しない。実装は parent node 自身に presence mismatch がある場合、`AddNodeDiffEntries` で parent の `Kind == Node` entry を追加して return し、child container member へは降りない。そのため親 node missing に由来する `ContainerPresence` 表示として `Items: [0]=null(Mismatched), [1]=<missing>(Missing)` が出るとは読ませない方がよい。`<missing>(Missing)` は fake unit test では container presence states を直接 `Missing` にして検証されているが、README の normal-path 説明としては実データと対応する scenario に直す必要がある。
+  - 最終再レビュー disposition: 既存 2 件の P2 は解消済み。README は self-contained `ContainerPresence` example のみを残し、実装経路と一致しない parent node missing 由来の text block を削除している。
+  - 最終再レビュー: 指摘なし。
+
+## 結果
+
+- 結果:
+  - README の XPath-like path access 例は実装済み API 名と Minimal Example の key-based path に整合していることを確認した。
+  - README の `Kind == Node` diff entry 例は `GetDiffEntries()` / `GetNodeByPath()` round-trip と `ToString()` 表示に整合していることを確認した。
+  - README の `ContainerPresence` 例には、同じ `entries` に存在しない entry を取得する normal-path docs bug があるため修正が必要。
+  - public API 設計書は extension method signature、unresolved path、model index 範囲外例外、`ContainerPresence`、`ToString()` 表示例と概ね整合していることを確認した。
+  - root `README.md` が runtime / source generator package readme として同梱されるため、追加 package readme は不要と確認した。
+  - docs-only diff であり、コード実装変更は確認していない。
+  - 再レビュー:
+    - 前回 P2 の self-contained 化は確認した。
+    - README の追加 text block には、親 node missing と `ContainerPresence` `<missing>(Missing)` 表示の関係について実装と一致しない説明が残っている。
+    - `git diff --check` は再レビューでも成功した。
+  - 最終再レビュー:
+    - README の XPath-like path access 例、`Kind == Node` diff entry 例、self-contained `ContainerPresence` 例は実装済み API と整合していることを確認した。
+    - README から不正確な parent node missing text block が削除されていることを確認した。
+    - public API 設計書は extension method signature、`ContainerPresence` contract、`ToString()` 表示例と実装の契約に矛盾していないことを確認した。
+    - docs-only diff であり、コード実装変更は確認していない。
+    - `git diff --check` は最終再レビューでも成功した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - Markdown 検査はユーザー指示により未実施。Markdown wording / whitelist / tooling はレビュー対象外として扱った。
+  - 上記 P2 finding の修正後、README の `ContainerPresence` snippet が示す data と output の対応を再確認する必要がある。
+  - 再レビュー: Markdown 検査はユーザー指示により未実施。追加 P2 finding の修正後、`<missing>(Missing)` の text block が実装で起こる scenario と対応しているか再確認する必要がある。
+  - 最終再レビュー: 未解決リスクなし。Markdown 検査はユーザー指示により未実施。

--- a/reports/task-t-082-final-review-20260623101834.md
+++ b/reports/task-t-082-final-review-20260623101834.md
@@ -1,0 +1,70 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-082 T-076 系 API の最終レビュー
+- タスク種別: final review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer とユーザー指示により、最終レビューは `gpt-5.5 high` の sub-agent に委譲する。T-076 から T-082 の最終差分と PR 仕上げ状態を独立確認する。
+
+## 対象範囲
+
+- 対象: T-076 から T-082 の branch diff、full validation report、PR body、task / phase tracking、残リスク
+
+## 対象外
+
+- 対象外: Markdown 検査、コード実装変更、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `git diff origin/main...HEAD --stat`: 成功。T-076 から T-082 scope の設計、実装、テスト、レポート、tracking 差分を確認。
+  - `gh pr view 32 --json body --jq .body`: 成功。PR body の scope、完了 task、変更点、validation、reports、risk 記載を確認。
+  - `git diff --check`: 成功。
+  - Markdown 検査: ユーザー指示により未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `tasks/tasks-status.md`
+  - `tasks/phases-status.md`
+  - `reports/task-t-082-verification-20260623101834.md`
+  - `reports/task-t-082-final-review-20260623101834.md`
+  - `README.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `doc/design/detail/05-ResultAndErrors.md`
+  - `src/SSC/Contracts.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/Internal/XPathLikePathParser.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/Properties/AssemblyInfo.cs`
+  - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+  - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`
+  - `tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+  - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - XPath-like parser / path access / diff entry / ContainerPresence / docs の統合差分を確認し、設計契約と矛盾する normal-path blocker は見つからなかった。
+  - README の XPath-like path access / diff entry examples は現在の実装挙動と矛盾していない。
+  - T-082 verification report に `dotnet test SSC.sln --configuration Release` 成功（Unit tests 29 件、E2E tests 61 件）と `git diff --check` 成功が記録されていることを確認した。
+  - PR #32 body は T-076 から T-082 の変更、validation、report references、残リスクを反映していることを確認した。
+  - T-076 から T-081 は `tasks/tasks-status.md` で Done に反映済みで、T-082 は final review 中のため In Progress として妥当。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決の実装・docs blocker はなし。
+  - Markdown 検査はユーザー指示により未実行。
+  - T-082 完了後に、予定どおり task / phase tracking の最終同期と final tracking commit/push が必要。

--- a/reports/task-t-082-verification-20260623101834.md
+++ b/reports/task-t-082-verification-20260623101834.md
@@ -1,0 +1,49 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-082 T-076 系 API の統合検証
+- タスク種別: verification
+
+## sub-agentを使う理由
+
+- 理由: codex-delegation-executor により検証実行は mandatory sub-agent work であり、T-082 の exit criteria として full test evidence が必要なため。
+
+## 対象範囲
+
+- 対象: `dotnet test SSC.sln --configuration Release`、必要に応じた `git diff --check`、T-076 系 API の full validation evidence
+
+## 対象外
+
+- 対象外: コード/docs 変更、Markdown 検査、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test SSC.sln --configuration Release`: 成功。Unit tests 29 件、E2E tests 61 件成功。
+  - `git diff --check`: 成功。
+  - Markdown 検査: ユーザー指示により未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `AGENTS.md`
+  - `tasks/tasks-status.md`
+  - `reports/task-t-082-verification-20260623101834.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - T-076 系 API の統合検証として `dotnet test SSC.sln --configuration Release` が成功した。
+  - `git diff --check` が成功した。
+  - コード/docs 変更、Markdown 検査、PR 操作、commit/push には踏み込んでいない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。Markdown 検査はユーザー指示により未実行。

--- a/src/SSC/Contracts.cs
+++ b/src/SSC/Contracts.cs
@@ -109,5 +109,7 @@ internal interface IParallelNodeInternal
 
     bool TryGetMemberNode(string memberName, out IParallelNode node);
 
+    bool TryGetContainerPresenceStates(string memberName, out IReadOnlyList<NodePresenceState> states);
+
     NodePresenceState GetPresenceState(int modelIndex);
 }

--- a/src/SSC/Internal/XPathLikePathParser.cs
+++ b/src/SSC/Internal/XPathLikePathParser.cs
@@ -1,0 +1,285 @@
+namespace SSC.Internal;
+
+internal enum XPathLikePathSelectorKind
+{
+    Key,
+    Ordinal,
+}
+
+internal sealed class XPathLikePath
+{
+    public XPathLikePath(string? rootName, IReadOnlyList<XPathLikePathSegment> segments)
+    {
+        RootName = rootName;
+        Segments = segments;
+    }
+
+    public string? RootName { get; }
+
+    public IReadOnlyList<XPathLikePathSegment> Segments { get; }
+}
+
+internal sealed class XPathLikePathSegment
+{
+    public XPathLikePathSegment(string memberName, XPathLikePathSelector? selector)
+    {
+        MemberName = memberName;
+        Selector = selector;
+    }
+
+    public string MemberName { get; }
+
+    public XPathLikePathSelector? Selector { get; }
+}
+
+internal sealed class XPathLikePathSelector
+{
+    private XPathLikePathSelector(XPathLikePathSelectorKind kind, string? keyText, int? ordinal)
+    {
+        Kind = kind;
+        KeyText = keyText;
+        Ordinal = ordinal;
+    }
+
+    public XPathLikePathSelectorKind Kind { get; }
+
+    public string? KeyText { get; }
+
+    public int? Ordinal { get; }
+
+    public static XPathLikePathSelector Key(string keyText)
+    {
+        return new XPathLikePathSelector(XPathLikePathSelectorKind.Key, keyText, null);
+    }
+
+    public static XPathLikePathSelector FromOrdinal(int ordinal)
+    {
+        return new XPathLikePathSelector(XPathLikePathSelectorKind.Ordinal, null, ordinal);
+    }
+}
+
+internal static class XPathLikePathParser
+{
+    public static bool TryParse(string path, out XPathLikePath? parsedPath)
+    {
+        return TryParse(path, rootName: null, out parsedPath);
+    }
+
+    public static bool TryParse(string path, string? rootName, out XPathLikePath? parsedPath)
+    {
+        parsedPath = null;
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        if (!TrySplitSegments(path, out var rawSegments))
+        {
+            return false;
+        }
+
+        var parsedRootName = GetRootName(rawSegments, rootName);
+        var segmentStartIndex = parsedRootName is null ? 0 : 1;
+        var segments = new List<XPathLikePathSegment>(rawSegments.Count - segmentStartIndex);
+        for (var index = segmentStartIndex; index < rawSegments.Count; index++)
+        {
+            if (!TryParseSegment(rawSegments[index], out var segment))
+            {
+                return false;
+            }
+
+            segments.Add(segment);
+        }
+
+        if (segments.Count == 0)
+        {
+            return false;
+        }
+
+        parsedPath = new XPathLikePath(parsedRootName, segments);
+        return true;
+    }
+
+    private static string? GetRootName(IReadOnlyList<string> rawSegments, string? rootName)
+    {
+        if (rootName is null
+            || rawSegments.Count <= 1
+            || rawSegments[0].Contains('[', StringComparison.Ordinal)
+            || !string.Equals(rawSegments[0], rootName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return rootName;
+    }
+
+    private static bool TrySplitSegments(string path, out List<string> segments)
+    {
+        segments = [];
+        var segmentStart = 0;
+        var inSelector = false;
+        var escaping = false;
+        var selectorClosedInSegment = false;
+
+        for (var index = 0; index < path.Length; index++)
+        {
+            var current = path[index];
+            if (inSelector)
+            {
+                if (escaping)
+                {
+                    escaping = false;
+                    continue;
+                }
+
+                if (current == '\\')
+                {
+                    escaping = true;
+                    continue;
+                }
+
+                if (current == ']')
+                {
+                    inSelector = false;
+                    selectorClosedInSegment = true;
+                }
+
+                continue;
+            }
+
+            if (current == '[')
+            {
+                if (selectorClosedInSegment)
+                {
+                    return false;
+                }
+
+                inSelector = true;
+                continue;
+            }
+
+            if (current == ']')
+            {
+                return false;
+            }
+
+            if (current != '.')
+            {
+                continue;
+            }
+
+            if (index == segmentStart)
+            {
+                return false;
+            }
+
+            segments.Add(path[segmentStart..index]);
+            segmentStart = index + 1;
+            selectorClosedInSegment = false;
+        }
+
+        if (inSelector || escaping || segmentStart == path.Length)
+        {
+            return false;
+        }
+
+        segments.Add(path[segmentStart..]);
+        return true;
+    }
+
+    private static bool TryParseSegment(string rawSegment, out XPathLikePathSegment segment)
+    {
+        segment = null!;
+        if (string.IsNullOrEmpty(rawSegment))
+        {
+            return false;
+        }
+
+        var selectorStart = rawSegment.IndexOf('[', StringComparison.Ordinal);
+        if (selectorStart < 0)
+        {
+            segment = new XPathLikePathSegment(rawSegment, null);
+            return true;
+        }
+
+        if (selectorStart == 0 || !rawSegment.EndsWith(']'))
+        {
+            return false;
+        }
+
+        var memberName = rawSegment[..selectorStart];
+        var selectorText = rawSegment[(selectorStart + 1)..^1];
+        if (memberName.Length == 0 || selectorText.Length == 0)
+        {
+            return false;
+        }
+
+        if (!TryParseSelector(selectorText, out var selector))
+        {
+            return false;
+        }
+
+        segment = new XPathLikePathSegment(memberName, selector);
+        return true;
+    }
+
+    private static bool TryParseSelector(string selectorText, out XPathLikePathSelector selector)
+    {
+        selector = null!;
+        if (selectorText[0] == '#')
+        {
+            if (selectorText.Length == 1 || !selectorText[1..].All(char.IsDigit))
+            {
+                return false;
+            }
+
+            if (!int.TryParse(selectorText[1..], out var ordinal))
+            {
+                return false;
+            }
+
+            selector = XPathLikePathSelector.FromOrdinal(ordinal);
+            return true;
+        }
+
+        if (!TryUnescapeKey(selectorText, out var keyText) || keyText.Length == 0)
+        {
+            return false;
+        }
+
+        selector = XPathLikePathSelector.Key(keyText);
+        return true;
+    }
+
+    private static bool TryUnescapeKey(string selectorText, out string keyText)
+    {
+        var builder = new System.Text.StringBuilder(selectorText.Length);
+        for (var index = 0; index < selectorText.Length; index++)
+        {
+            var current = selectorText[index];
+            if (current != '\\')
+            {
+                builder.Append(current);
+                continue;
+            }
+
+            if (index + 1 >= selectorText.Length)
+            {
+                keyText = string.Empty;
+                return false;
+            }
+
+            var escaped = selectorText[++index];
+            if (escaped is not (']' or '\\' or '#'))
+            {
+                keyText = string.Empty;
+                return false;
+            }
+
+            builder.Append(escaped);
+        }
+
+        keyText = builder.ToString();
+        return true;
+    }
+}

--- a/src/SSC/ParallelDiffContracts.cs
+++ b/src/SSC/ParallelDiffContracts.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+
+namespace SSC;
+
+public enum ParallelDiffEntryKind
+{
+    Node,
+    ContainerPresence,
+}
+
+public sealed class ParallelDiffEntry
+{
+    public string Path { get; init; } = string.Empty;
+
+    public ParallelDiffEntryKind Kind { get; init; }
+
+    public IParallelNode? Node { get; init; }
+
+    public IReadOnlyList<ParallelDiffValue> Values { get; init; } = Array.Empty<ParallelDiffValue>();
+
+    public override string ToString()
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{Path}: {string.Join(", ", Values.Select(value => value.ToString()))}");
+    }
+}
+
+public sealed class ParallelDiffValue
+{
+    public int ModelIndex { get; init; }
+
+    public object? Value { get; init; }
+
+    public ValueState State { get; init; }
+
+    public override string ToString()
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"[{ModelIndex}]={FormatValue()}({State})");
+    }
+
+    private string FormatValue()
+    {
+        if (State == ValueState.Missing)
+        {
+            return "<missing>";
+        }
+
+        if (Value is null)
+        {
+            return "null";
+        }
+
+        if (Value is string text)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"\"{text}\"");
+        }
+
+        return Convert.ToString(Value, CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+}

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -247,6 +247,18 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         return _memberNodes.TryGetValue(memberName, out node!);
     }
 
+    bool IParallelNodeInternal.TryGetContainerPresenceStates(string memberName, out IReadOnlyList<NodePresenceState> states)
+    {
+        if (_containerPresenceStates.TryGetValue(memberName, out var containerStates))
+        {
+            states = containerStates;
+            return true;
+        }
+
+        states = Array.Empty<NodePresenceState>();
+        return false;
+    }
+
     NodePresenceState IParallelNodeInternal.GetPresenceState(int modelIndex)
     {
         return GetPresenceState(modelIndex);

--- a/src/SSC/ParallelPathAccessExtensions.cs
+++ b/src/SSC/ParallelPathAccessExtensions.cs
@@ -141,7 +141,7 @@ public static class ParallelPathAccessExtensions
         string parentPath,
         IParallelNode parentNode)
     {
-        if (!childSet.HasDifferences || childSet.Nodes.Count == 0)
+        if (!childSet.HasDifferences)
         {
             return;
         }
@@ -150,6 +150,17 @@ public static class ParallelPathAccessExtensions
             && internalParent.TryGetMemberNode(childSet.Name, out var memberNode))
         {
             AddNodeDiffEntries(entries, memberNode, CombinePath(parentPath, childSet.Name));
+            return;
+        }
+
+        if (childSet.Nodes.Count == 0)
+        {
+            if (parentNode is IParallelNodeInternal containerParent
+                && containerParent.TryGetContainerPresenceStates(childSet.Name, out var states))
+            {
+                entries.Add(CreateContainerPresenceEntry(CombinePath(parentPath, childSet.Name), states));
+            }
+
             return;
         }
 
@@ -181,6 +192,32 @@ public static class ParallelPathAccessExtensions
             Path = path,
             Kind = ParallelDiffEntryKind.Node,
             Node = node,
+            Values = values,
+        };
+    }
+
+    private static ParallelDiffEntry CreateContainerPresenceEntry(
+        string path,
+        IReadOnlyList<NodePresenceState> states)
+    {
+        var values = new ParallelDiffValue[states.Count];
+        for (var modelIndex = 0; modelIndex < states.Count; modelIndex++)
+        {
+            values[modelIndex] = new ParallelDiffValue
+            {
+                ModelIndex = modelIndex,
+                Value = null,
+                State = states[modelIndex] == NodePresenceState.Missing
+                    ? ValueState.Missing
+                    : ValueState.Mismatched,
+            };
+        }
+
+        return new ParallelDiffEntry
+        {
+            Path = path,
+            Kind = ParallelDiffEntryKind.ContainerPresence,
+            Node = null,
             Values = values,
         };
     }

--- a/src/SSC/ParallelPathAccessExtensions.cs
+++ b/src/SSC/ParallelPathAccessExtensions.cs
@@ -1,0 +1,91 @@
+using SSC.Internal;
+
+namespace SSC;
+
+public static class ParallelPathAccessExtensions
+{
+    public static IParallelNode? GetNodeByPath<T>(this CompareResult<T> result, string path)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (result.Root is not IParallelNode current)
+        {
+            return null;
+        }
+
+        if (!XPathLikePathParser.TryParse(path, typeof(T).Name, out var parsedPath) || parsedPath is null)
+        {
+            return null;
+        }
+
+        foreach (var segment in parsedPath.Segments)
+        {
+            if (!TryResolveSegment(current, segment, out var next))
+            {
+                return null;
+            }
+
+            current = next;
+        }
+
+        return current;
+    }
+
+    public static object? GetValueByPath<T>(this CompareResult<T> result, string path, int modelIndex)
+    {
+        var node = result.GetNodeByPath(path);
+        return node?.GetValue(modelIndex);
+    }
+
+    public static ValueState GetStateByPath<T>(this CompareResult<T> result, string path, int modelIndex)
+    {
+        var node = result.GetNodeByPath(path);
+        return node?.GetState(modelIndex) ?? ValueState.Missing;
+    }
+
+    private static bool TryResolveSegment(IParallelNode current, XPathLikePathSegment segment, out IParallelNode next)
+    {
+        if (current is not IParallelNodeInternal internalNode)
+        {
+            next = null!;
+            return false;
+        }
+
+        if (segment.Selector is null)
+        {
+            return internalNode.TryGetMemberNode(segment.MemberName, out next!);
+        }
+
+        if (!internalNode.TryGetChildren(segment.MemberName, out var childNodes))
+        {
+            next = null!;
+            return false;
+        }
+
+        return TrySelectChild(childNodes, segment.Selector, out next);
+    }
+
+    private static bool TrySelectChild(
+        IReadOnlyList<IParallelNode> childNodes,
+        XPathLikePathSelector selector,
+        out IParallelNode next)
+    {
+        if (selector.Kind == XPathLikePathSelectorKind.Ordinal)
+        {
+            var ordinal = selector.Ordinal!.Value;
+            if (ordinal < 0 || ordinal >= childNodes.Count)
+            {
+                next = null!;
+                return false;
+            }
+
+            next = childNodes[ordinal];
+            return next.KeyText is null;
+        }
+
+        next = childNodes.FirstOrDefault(child =>
+            string.Equals(child.KeyText, selector.KeyText, StringComparison.Ordinal))!;
+        return next is not null;
+    }
+}

--- a/src/SSC/ParallelPathAccessExtensions.cs
+++ b/src/SSC/ParallelPathAccessExtensions.cs
@@ -44,6 +44,24 @@ public static class ParallelPathAccessExtensions
         return node?.GetState(modelIndex) ?? ValueState.Missing;
     }
 
+    public static IReadOnlyList<ParallelDiffEntry> GetDiffEntries<T>(this CompareResult<T> result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.Root is not IParallelNode root)
+        {
+            return Array.Empty<ParallelDiffEntry>();
+        }
+
+        var entries = new List<ParallelDiffEntry>();
+        foreach (var childSet in root.GetDirectChildren())
+        {
+            AddChildSetDiffEntries(entries, childSet, parentPath: string.Empty, root);
+        }
+
+        return entries;
+    }
+
     private static bool TryResolveSegment(IParallelNode current, XPathLikePathSegment segment, out IParallelNode next)
     {
         if (current is not IParallelNodeInternal internalNode)
@@ -87,5 +105,122 @@ public static class ParallelPathAccessExtensions
         next = childNodes.FirstOrDefault(child =>
             string.Equals(child.KeyText, selector.KeyText, StringComparison.Ordinal))!;
         return next is not null;
+    }
+
+    private static void AddNodeDiffEntries(
+        List<ParallelDiffEntry> entries,
+        IParallelNode node,
+        string path)
+    {
+        if (HasOwnPresenceMismatch(node))
+        {
+            entries.Add(CreateNodeEntry(path, node));
+            return;
+        }
+
+        var childSets = node.GetDirectChildren();
+        if (childSets.Count == 0)
+        {
+            if (node.HasDifferences())
+            {
+                entries.Add(CreateNodeEntry(path, node));
+            }
+
+            return;
+        }
+
+        foreach (var childSet in childSets)
+        {
+            AddChildSetDiffEntries(entries, childSet, path, node);
+        }
+    }
+
+    private static void AddChildSetDiffEntries(
+        List<ParallelDiffEntry> entries,
+        ParallelChildSet childSet,
+        string parentPath,
+        IParallelNode parentNode)
+    {
+        if (!childSet.HasDifferences || childSet.Nodes.Count == 0)
+        {
+            return;
+        }
+
+        if (parentNode is IParallelNodeInternal internalParent
+            && internalParent.TryGetMemberNode(childSet.Name, out var memberNode))
+        {
+            AddNodeDiffEntries(entries, memberNode, CombinePath(parentPath, childSet.Name));
+            return;
+        }
+
+        for (var ordinal = 0; ordinal < childSet.Nodes.Count; ordinal++)
+        {
+            var childNode = childSet.Nodes[ordinal];
+            var selector = childNode.KeyText is null
+                ? $"#{ordinal}"
+                : EscapeKeyText(childNode.KeyText);
+            AddNodeDiffEntries(entries, childNode, CombinePath(parentPath, $"{childSet.Name}[{selector}]"));
+        }
+    }
+
+    private static ParallelDiffEntry CreateNodeEntry(string path, IParallelNode node)
+    {
+        var values = new ParallelDiffValue[node.Count];
+        for (var modelIndex = 0; modelIndex < node.Count; modelIndex++)
+        {
+            values[modelIndex] = new ParallelDiffValue
+            {
+                ModelIndex = modelIndex,
+                Value = node.GetValue(modelIndex),
+                State = node.GetState(modelIndex),
+            };
+        }
+
+        return new ParallelDiffEntry
+        {
+            Path = path,
+            Kind = ParallelDiffEntryKind.Node,
+            Node = node,
+            Values = values,
+        };
+    }
+
+    private static bool HasOwnPresenceMismatch(IParallelNode node)
+    {
+        if (node.Count <= 1 || node is not IParallelNodeInternal internalNode)
+        {
+            return false;
+        }
+
+        var first = internalNode.GetPresenceState(0);
+        for (var modelIndex = 1; modelIndex < node.Count; modelIndex++)
+        {
+            if (internalNode.GetPresenceState(modelIndex) != first)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string CombinePath(string parentPath, string segment)
+    {
+        return string.IsNullOrEmpty(parentPath)
+            ? segment
+            : $"{parentPath}.{segment}";
+    }
+
+    private static string EscapeKeyText(string keyText)
+    {
+        var escaped = keyText.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("]", "\\]", StringComparison.Ordinal);
+
+        if (escaped.Length > 0 && escaped[0] == '#')
+        {
+            return $"\\{escaped}";
+        }
+
+        return escaped;
     }
 }

--- a/src/SSC/Properties/AssemblyInfo.cs
+++ b/src/SSC/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SSC.Unit.Tests")]

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -14,6 +14,16 @@
   - 次アクション対応:
     - T-076 のコード実装フェーズに入る前に `codex-delegation-executor` で実装サブエージェントを起動する
     - review は従来どおり `review-enforcer` 経由でサブエージェントへ委譲する
+- ユーザー指摘: 実装は TDD で進め、実装サブエージェントは `gpt-5.5 medium`、レビューサブエージェントは `gpt-5.5 high` を使うこと。
+- 対応:
+  - T-077 以降のコード実装 task は、先に test target と failing test または newly required test を確定してから実装へ進む。
+  - 実装 worker は `gpt-5.5 medium`、レビュー worker は `gpt-5.5 high` を使う。
+  - 記録起点: ユーザー明示指摘
+  - 重複判定: 2026-06-23 のサブエージェント委譲方針への詳細追記
+  - スキル化判断: 既存の `tdd-executor` / `codex-delegation-executor` / `review-enforcer` 運用で対応。新規 skill 不要
+  - 次アクション対応:
+    - T-077 着手時に `tdd-executor` で test target を決め、`codex-delegation-executor` 経由で実装サブエージェントへ渡す
+    - review gate では `gpt-5.5 high` のサブエージェントへ委譲する
 
 ## 2026-04-21
 

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -1,6 +1,19 @@
 # Feedback Points
 
-- Updated: 2026-04-21
+- Updated: 2026-06-23
+
+## 2026-06-23
+
+- ユーザー指摘: コードの実装とレビューはサブエージェントへ出すこと。
+- 対応:
+  - T-076 以後、この repo ではコード実装とコードレビューをサブエージェントへ委譲する。
+  - 親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する。
+  - 記録起点: ユーザー明示指摘
+  - 重複判定: 2026-04-21 の「実装は main agent / review は sub-agent」を上書きする新指示
+  - スキル化判断: CodexSkill 側の `manager-only-coding-delegation` 系 feedback と同趣旨のため、新規 skill は不要
+  - 次アクション対応:
+    - T-076 のコード実装フェーズに入る前に `codex-delegation-executor` で実装サブエージェントを起動する
+    - review は従来どおり `review-enforcer` 経由でサブエージェントへ委譲する
 
 ## 2026-04-21
 

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,8 @@
 
 - Status: In Progress
 - Notes:
+  - T-080 を完了し、child node を持たない empty list / dictionary の container presence mismatch を `Kind == ContainerPresence` entry として列挙できるようにした
+  - T-080 では `Node == null`、container member path、`Values` / `ToString()` による Missing と null の区別、`GetNodeByPath(Path)` 非保証を検証し、レビュー指摘なしを確認した
   - T-079 を完了し、`GetDiffEntries<T>()` で `Kind == Node` の通常 node 差分を structured entry として列挙できるようにした
   - T-079 では leaf/value node 差分、object/container node 自身の presence mismatch、keyed / ordinal path 生成、escape、generated path の `GetNodeByPath()` round-trip、代表 `ToString()` を検証し、レビュー指摘なしを確認した
   - T-078 を完了し、`GetNodeByPath<T>()` / `GetValueByPath<T>()` / `GetStateByPath<T>()` を追加した

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,8 @@
 
 - Status: In Progress
 - Notes:
+  - T-078 を完了し、`GetNodeByPath<T>()` / `GetValueByPath<T>()` / `GetStateByPath<T>()` を追加した
+  - T-078 では root prefix あり/なし、keyed path、ordinal path、未解決 path、model index 範囲外を検証し、レビュー指摘なしを確認した
   - T-077 を完了し、XPath-like path parser、`ParallelDiffEntry` / `ParallelDiffValue`、`ToString()` 契約、parser unit test を追加した
   - T-077 では review P2 指摘（複数 selector grammar の誤受理）を TDD で修正し、再レビューで指摘なしを確認した
   - T-076 系実装は T-077 から T-082 へ分割し、1 task / 1 commit / 1 push の単位で進める

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,8 @@
 
 - Status: In Progress
 - Notes:
+  - T-076 系実装は T-077 から T-082 へ分割し、1 task / 1 commit / 1 push の単位で進める
+  - コード実装・コードレビュー・検証実行はサブエージェントへ委譲し、親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する
   - T-075 を完了し、`AsDynamic()` の value path が保存済み state を読む通常経路と、実行時反射で値を辿る代替経路へどう分岐するかを設計書へ追加した
   - T-075 では、single-model `Missing` 分岐、`MissingMemberException` が対象 model / 他 model のどちらでも起こり得る条件、runtime-only container の特例も追記した
   - T-074 を完了し、dynamic `GetState` の保証範囲を issue/task 番号に依存しない日本語で説明し、runtime-only member/container の例を追記した

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -31,8 +31,9 @@
 
 ## Phase 3: 実装
 
-- Status: In Progress
+- Status: Done
 - Notes:
+  - T-076 系の XPath-like path access / diff entry helper 実装は T-077 から T-081 まで完了した
   - T-081 を完了し、README に XPath-like path access / diff entry の最小利用例を追加し、public API 設計書を実装後 API 名・契約・表示例と同期した
   - T-081 では docs review の P2 指摘 2 件を修正し、最終再レビューで指摘なしを確認した。Markdown 検査はユーザー指示により未実施
   - T-080 を完了し、child node を持たない empty list / dictionary の container presence mismatch を `Kind == ContainerPresence` entry として列挙できるようにした
@@ -132,4 +133,8 @@
 
 ## Phase 4: 検証・受け入れ
 
-- Status: Not Started
+- Status: Done
+- Notes:
+  - T-082 を完了し、`dotnet test SSC.sln --configuration Release` が成功した（Unit tests 29 件、E2E tests 61 件）
+  - T-082 では `git diff --check`、PR #32 body 確認、最終レビューを実施し、最終レビュー指摘なしを確認した
+  - Markdown 検査はユーザー指示により未実施

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -34,6 +34,7 @@
 - Status: In Progress
 - Notes:
   - T-076 系実装は T-077 から T-082 へ分割し、1 task / 1 commit / 1 push の単位で進める
+  - コード実装は TDD で進め、実装サブエージェントは `gpt-5.5 medium`、レビューサブエージェントは `gpt-5.5 high` を使う
   - コード実装・コードレビュー・検証実行はサブエージェントへ委譲し、親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する
   - T-075 を完了し、`AsDynamic()` の value path が保存済み state を読む通常経路と、実行時反射で値を辿る代替経路へどう分岐するかを設計書へ追加した
   - T-075 では、single-model `Missing` 分岐、`MissingMemberException` が対象 model / 他 model のどちらでも起こり得る条件、runtime-only container の特例も追記した

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,8 @@
 
 - Status: In Progress
 - Notes:
+  - T-079 を完了し、`GetDiffEntries<T>()` で `Kind == Node` の通常 node 差分を structured entry として列挙できるようにした
+  - T-079 では leaf/value node 差分、object/container node 自身の presence mismatch、keyed / ordinal path 生成、escape、generated path の `GetNodeByPath()` round-trip、代表 `ToString()` を検証し、レビュー指摘なしを確認した
   - T-078 を完了し、`GetNodeByPath<T>()` / `GetValueByPath<T>()` / `GetStateByPath<T>()` を追加した
   - T-078 では root prefix あり/なし、keyed path、ordinal path、未解決 path、model index 範囲外を検証し、レビュー指摘なしを確認した
   - T-077 を完了し、XPath-like path parser、`ParallelDiffEntry` / `ParallelDiffValue`、`ToString()` 契約、parser unit test を追加した

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -12,9 +12,9 @@
 
 ## Phase 2: 詳細設計確定
 
-- Status: In Progress
+- Status: Done
 - Notes:
-  - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加中
+  - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加し、実装単位を T-077 から T-082 へ分割した
   - `doc/draft/DetailDesignDraft.md` に粒度基準・章別必須項目・仕様確定結果を追記
   - Draft/非Draft を `doc/draft` と `doc/design` に分離
   - 非Draft の詳細設計を `doc/design/detail` に機能粒度で分割
@@ -33,6 +33,8 @@
 
 - Status: In Progress
 - Notes:
+  - T-077 を完了し、XPath-like path parser、`ParallelDiffEntry` / `ParallelDiffValue`、`ToString()` 契約、parser unit test を追加した
+  - T-077 では review P2 指摘（複数 selector grammar の誤受理）を TDD で修正し、再レビューで指摘なしを確認した
   - T-076 系実装は T-077 から T-082 へ分割し、1 task / 1 commit / 1 push の単位で進める
   - コード実装は TDD で進め、実装サブエージェントは `gpt-5.5 medium`、レビューサブエージェントは `gpt-5.5 high` を使う
   - コード実装・コードレビュー・検証実行はサブエージェントへ委譲し、親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -1,6 +1,6 @@
 # Phases Status
 
-- Updated: 2026-04-21
+- Updated: 2026-06-23
 
 ## Phase 1: 要件・外部仕様確定
 
@@ -12,8 +12,9 @@
 
 ## Phase 2: 詳細設計確定
 
-- Status: Done
+- Status: In Progress
 - Notes:
+  - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加中
   - `doc/draft/DetailDesignDraft.md` に粒度基準・章別必須項目・仕様確定結果を追記
   - Draft/非Draft を `doc/draft` と `doc/design` に分離
   - 非Draft の詳細設計を `doc/design/detail` に機能粒度で分割

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,8 @@
 
 - Status: In Progress
 - Notes:
+  - T-081 を完了し、README に XPath-like path access / diff entry の最小利用例を追加し、public API 設計書を実装後 API 名・契約・表示例と同期した
+  - T-081 では docs review の P2 指摘 2 件を修正し、最終再レビューで指摘なしを確認した。Markdown 検査はユーザー指示により未実施
   - T-080 を完了し、child node を持たない empty list / dictionary の container presence mismatch を `Kind == ContainerPresence` entry として列挙できるようにした
   - T-080 では `Node == null`、container member path、`Values` / `ToString()` による Missing と null の区別、`GetNodeByPath(Path)` 非保証を検証し、レビュー指摘なしを確認した
   - T-079 を完了し、`GetDiffEntries<T>()` で `Kind == Node` の通常 node 差分を structured entry として列挙できるようにした

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -8,29 +8,28 @@
 
 ## Backlog
 
+- なし
+
+## Done
+
 - T-082: T-076 系 API の統合検証と PR 仕上げ
-  - Status: 未着手
+  - Status: 完了（full validation と最終レビューをサブエージェントで実施し、PR body / tracking を最終同期）
   - Phase: Phase 4
   - Estimate: S
   - Depends on:
     - T-081 README 利用例と public API ドキュメントの同期
-  - Execution Policy:
-    - 検証実行はサブエージェントへ委譲する
-    - 最終レビューはサブエージェントへ委譲する
-    - 最終レビューサブエージェントは `gpt-5.5 high` を使う
-    - 1 task / 1 commit / 1 push で完結させる
-  - Scope:
-    - `dotnet test SSC.sln --configuration Release`
-    - PR body の validation / risk / report references 更新
-    - task / phase tracking の最終同期
-  - Exit Criteria:
-    - full test が成功している
-    - PR body が最新の変更、検証、残リスクを反映している
-    - T-076 系 task の完了状態が tracking に反映されている
-    - サブエージェント verification report とサブエージェント final review report がある
-    - final tracking commit/push 済み
-
-## Done
+  - Output:
+    - `reports/task-t-082-verification-20260623101834.md`
+    - `reports/task-t-082-final-review-20260623101834.md`
+    - `tasks/tasks-status.md`
+    - `tasks/phases-status.md`
+    - PR #32 body
+  - Verification:
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit tests 29 件、E2E tests 61 件）
+    - `git diff --check` 成功
+    - `gh pr view 32 --json body --jq .body` 成功
+    - 最終レビュー指摘なし
+    - Markdown 検査はユーザー指示により未実施
 
 - T-081: README 利用例と public API ドキュメントの同期
   - Status: 完了（README に XPath-like path access / diff entry 利用例を追加し、public API 設計書を実装 API と同期、レビュー P2 指摘 2 件を修正して最終レビュー指摘なし）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,35 +4,9 @@
 
 ## In Progress
 
-- （なし）
+- なし
 
 ## Backlog
-
-- T-079: 通常 node 差分の `GetDiffEntries()` 追加
-  - Status: 未着手
-  - Phase: Phase 3
-  - Estimate: M
-  - Depends on:
-    - T-078 XPath-like path による node/value/state 解決 API の追加
-  - Execution Policy:
-    - TDD で進め、先に diff entry 列挙の test target を確定する
-    - コード実装はサブエージェントへ委譲する
-    - 実装サブエージェントは `gpt-5.5 medium` を使う
-    - コードレビューはサブエージェントへ委譲する
-    - レビューサブエージェントは `gpt-5.5 high` を使う
-    - 1 task / 1 commit / 1 push で完結させる
-  - Scope:
-    - `Kind == Node` の `ParallelDiffEntry` 列挙
-    - leaf/value node 差分
-    - object/container node 自身の presence mismatch
-    - keyed path / ordinal path の生成
-  - Exit Criteria:
-    - `GetDiffEntries()` が構造化データを返す E2E がある
-    - 生成 path を `GetNodeByPath()` に渡して同じ node を解決できることを検証している
-    - `ToString()` の代表表示を検証している
-    - empty container の `ContainerPresence` には踏み込まない
-    - サブエージェント実装 report とサブエージェント review report がある
-    - focused test が成功し、commit/push 済み
 
 - T-080: empty container 差分の `ContainerPresence` entry 追加
   - Status: 未着手
@@ -105,6 +79,23 @@
     - final tracking commit/push 済み
 
 ## Done
+
+- T-079: 通常 node 差分の `GetDiffEntries()` 追加
+  - Status: 完了（通常 node 差分の structured entry 列挙を TDD で追加し、generated path の round-trip と代表 `ToString()` を検証、レビュー指摘なし）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-078 XPath-like path による node/value/state 解決 API の追加
+  - Output:
+    - `src/SSC/ParallelPathAccessExtensions.cs`
+    - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+    - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+    - `reports/task-t-079-implementation-20260623094407.md`
+    - `reports/task-t-079-review-20260623094407.md`
+  - Verification:
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"` 成功（4 件）
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests"` 成功（1 件）
+    - `git diff --check` 成功
 
 - T-078: XPath-like path による node/value/state 解決 API の追加
   - Status: 完了（path 解決 API を TDD で追加し、root prefix / keyed path / ordinal path / unresolved / out-of-range を検証、レビュー指摘なし）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -1,10 +1,20 @@
 # Tasks Status
 
-- Updated: 2026-04-21
+- Updated: 2026-06-23
 
 ## In Progress
 
-- （なし）
+- T-076: XPath-like path access と差分表示 helper の設計
+  - Status: 設計中（XPath-like path 文法、path 取得 API、差分構造化データ、`ToString()` 表示契約を設計書へ反映する）
+  - Phase: Phase 2
+  - Estimate: M
+  - Execution Policy:
+    - コード実装とコードレビューはサブエージェントへ委譲する
+    - 親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する
+  - Exit Criteria:
+    - XPath-like path grammar が `doc/design/detail/02-PublicApi.md` に詳細化されている
+    - `CompareIssue.Path` と差分 helper の path 表現の違いが設計上区別されている
+    - 差分 helper は構造化データを返し、返却型が `ToString()` を実装する契約になっている
 
 ## Backlog
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,48 +4,9 @@
 
 ## In Progress
 
-- T-076: XPath-like path access と差分表示 helper の設計
-  - Status: 設計更新済み（実装単位を T-077 から T-082 へ分解中）
-  - Phase: Phase 2
-  - Estimate: M
-  - Execution Policy:
-    - コード実装とコードレビューはサブエージェントへ委譲する
-    - コード実装は TDD で進め、先に test target と failing test または newly required test を確定する
-    - 実装サブエージェントは `gpt-5.5 medium` を使う
-    - レビューサブエージェントは `gpt-5.5 high` を使う
-    - 親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する
-  - Exit Criteria:
-    - XPath-like path grammar が `doc/design/detail/02-PublicApi.md` に詳細化されている
-    - `CompareIssue.Path` と差分 helper の path 表現の違いが設計上区別されている
-    - 差分 helper は構造化データを返し、返却型が `ToString()` を実装する契約になっている
-    - 1 task / 1 push の実装タスクへ分解されている
+- （なし）
 
 ## Backlog
-
-- T-077: XPath-like path parser と public result 型の追加
-  - Status: 未着手
-  - Phase: Phase 3
-  - Estimate: S
-  - Depends on:
-    - T-076 XPath-like path access と差分表示 helper の設計
-  - Execution Policy:
-    - TDD で進め、先に parser / `ToString()` の test target を確定する
-    - コード実装はサブエージェントへ委譲する
-    - 実装サブエージェントは `gpt-5.5 medium` を使う
-    - コードレビューはサブエージェントへ委譲する
-    - レビューサブエージェントは `gpt-5.5 high` を使う
-    - 1 task / 1 commit / 1 push で完結させる
-  - Scope:
-    - `ParallelDiffEntry`
-    - `ParallelDiffEntryKind`
-    - `ParallelDiffValue`
-    - XPath-like path parser の internal 実装
-  - Exit Criteria:
-    - grammar、root prefix、selector、escape の unit test がある
-    - public result 型に `ToString()` 契約が実装されている
-    - node 解決や差分列挙には踏み込まない
-    - サブエージェント実装 report とサブエージェント review report がある
-    - focused test が成功し、commit/push 済み
 
 - T-078: XPath-like path による node/value/state 解決 API の追加
   - Status: 未着手
@@ -170,6 +131,37 @@
     - final tracking commit/push 済み
 
 ## Done
+
+- T-077: XPath-like path parser と public result 型の追加
+  - Status: 完了（parser / public diff result 型 / `ToString()` を TDD で追加し、review P2 指摘を修正、再レビューで指摘なし）
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-076 XPath-like path access と差分表示 helper の設計
+  - Output:
+    - `src/SSC/ParallelDiffContracts.cs`
+    - `src/SSC/Internal/XPathLikePathParser.cs`
+    - `src/SSC/Properties/AssemblyInfo.cs`
+    - `tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`
+    - `tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs`
+    - `reports/task-t-077-implementation-20260623091447.md`
+    - `reports/task-t-077-review-20260623091556.md`
+    - `reports/task-t-077-review-fix-20260623092446.md`
+  - Verification:
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathParserUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"` 成功（20 件）
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release` 成功（23 件）
+    - `git diff --check` 成功
+
+- T-076: XPath-like path access と差分表示 helper の設計
+  - Status: 完了（XPath-like grammar、差分構造化データ、`ToString()` 表示契約、`CompareIssue.Path` との差分、1 task / 1 push の実装分解を設計・tracking に反映）
+  - Phase: Phase 2
+  - Estimate: M
+  - Output:
+    - `doc/design/detail/02-PublicApi.md`
+    - `doc/design/detail/05-ResultAndErrors.md`
+    - `tasks/tasks-status.md`
+    - `tasks/phases-status.md`
+    - `tasks/feedback-points.md`
 
 - T-075: dynamic `GetState` の実行時専用メンバー判定フロー明文化
   - Status: 完了（保存済み state 参照経路と呼び出し時の反射による代替解決経路の分岐、single-model `Missing`、`MissingMemberException` 条件、container 特例を設計書へ反映）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -5,7 +5,7 @@
 ## In Progress
 
 - T-076: XPath-like path access と差分表示 helper の設計
-  - Status: 設計中（XPath-like path 文法、path 取得 API、差分構造化データ、`ToString()` 表示契約を設計書へ反映する）
+  - Status: 設計更新済み（実装単位を T-077 から T-082 へ分解中）
   - Phase: Phase 2
   - Estimate: M
   - Execution Policy:
@@ -15,10 +15,141 @@
     - XPath-like path grammar が `doc/design/detail/02-PublicApi.md` に詳細化されている
     - `CompareIssue.Path` と差分 helper の path 表現の違いが設計上区別されている
     - 差分 helper は構造化データを返し、返却型が `ToString()` を実装する契約になっている
+    - 1 task / 1 push の実装タスクへ分解されている
 
 ## Backlog
 
-- （なし）
+- T-077: XPath-like path parser と public result 型の追加
+  - Status: 未着手
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-076 XPath-like path access と差分表示 helper の設計
+  - Execution Policy:
+    - コード実装はサブエージェントへ委譲する
+    - コードレビューはサブエージェントへ委譲する
+    - 1 task / 1 commit / 1 push で完結させる
+  - Scope:
+    - `ParallelDiffEntry`
+    - `ParallelDiffEntryKind`
+    - `ParallelDiffValue`
+    - XPath-like path parser の internal 実装
+  - Exit Criteria:
+    - grammar、root prefix、selector、escape の unit test がある
+    - public result 型に `ToString()` 契約が実装されている
+    - node 解決や差分列挙には踏み込まない
+    - サブエージェント実装 report とサブエージェント review report がある
+    - focused test が成功し、commit/push 済み
+
+- T-078: XPath-like path による node/value/state 解決 API の追加
+  - Status: 未着手
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-077 XPath-like path parser と public result 型の追加
+  - Execution Policy:
+    - コード実装はサブエージェントへ委譲する
+    - コードレビューはサブエージェントへ委譲する
+    - 1 task / 1 commit / 1 push で完結させる
+  - Scope:
+    - `GetNodeByPath<T>()`
+    - `GetValueByPath<T>()`
+    - `GetStateByPath<T>()`
+    - scalar/object member と keyed / ordinal container child の解決
+  - Exit Criteria:
+    - root prefix あり/なしの path 解決 E2E がある
+    - keyed container と `#ordinal` container の解決 E2E がある
+    - 未解決 path と範囲外 model index の挙動が設計どおり検証されている
+    - 差分列挙には踏み込まない
+    - サブエージェント実装 report とサブエージェント review report がある
+    - focused test が成功し、commit/push 済み
+
+- T-079: 通常 node 差分の `GetDiffEntries()` 追加
+  - Status: 未着手
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-078 XPath-like path による node/value/state 解決 API の追加
+  - Execution Policy:
+    - コード実装はサブエージェントへ委譲する
+    - コードレビューはサブエージェントへ委譲する
+    - 1 task / 1 commit / 1 push で完結させる
+  - Scope:
+    - `Kind == Node` の `ParallelDiffEntry` 列挙
+    - leaf/value node 差分
+    - object/container node 自身の presence mismatch
+    - keyed path / ordinal path の生成
+  - Exit Criteria:
+    - `GetDiffEntries()` が構造化データを返す E2E がある
+    - 生成 path を `GetNodeByPath()` に渡して同じ node を解決できることを検証している
+    - `ToString()` の代表表示を検証している
+    - empty container の `ContainerPresence` には踏み込まない
+    - サブエージェント実装 report とサブエージェント review report がある
+    - focused test が成功し、commit/push 済み
+
+- T-080: empty container 差分の `ContainerPresence` entry 追加
+  - Status: 未着手
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-079 通常 node 差分の `GetDiffEntries()` 追加
+  - Execution Policy:
+    - コード実装はサブエージェントへ委譲する
+    - コードレビューはサブエージェントへ委譲する
+    - 1 task / 1 commit / 1 push で完結させる
+  - Scope:
+    - child node を持たない container presence mismatch の diff entry
+    - `Kind == ContainerPresence`
+    - `Node == null`
+    - container member path の表示
+  - Exit Criteria:
+    - empty list / empty dictionary の片側欠損を diff entry として落とさない E2E がある
+    - `ContainerPresence` の `Values` と `ToString()` が Missing / null を混同しない
+    - `GetNodeByPath(Path)` で node 解決を保証しないことがテストまたは設計コメントで明確化されている
+    - サブエージェント実装 report とサブエージェント review report がある
+    - focused test が成功し、commit/push 済み
+
+- T-081: README 利用例と public API ドキュメントの同期
+  - Status: 未着手
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-080 empty container 差分の `ContainerPresence` entry 追加
+  - Execution Policy:
+    - ドキュメント更新はサブエージェントへ委譲する
+    - レビューはサブエージェントへ委譲する
+    - 1 task / 1 commit / 1 push で完結させる
+  - Scope:
+    - README の利用例
+    - public API 設計書と実装後 API 名の同期
+    - 必要に応じた package readme 同期
+  - Exit Criteria:
+    - XPath-like path access と diff entry の最小利用例が README にある
+    - 設計書と実装 API の命名・例外・表示例が一致している
+    - Markdown 検査はユーザー指示がない限り実施しない
+    - サブエージェント実装 report とサブエージェント review report がある
+    - docs-only commit/push 済み
+
+- T-082: T-076 系 API の統合検証と PR 仕上げ
+  - Status: 未着手
+  - Phase: Phase 4
+  - Estimate: S
+  - Depends on:
+    - T-081 README 利用例と public API ドキュメントの同期
+  - Execution Policy:
+    - 検証実行はサブエージェントへ委譲する
+    - 最終レビューはサブエージェントへ委譲する
+    - 1 task / 1 commit / 1 push で完結させる
+  - Scope:
+    - `dotnet test SSC.sln --configuration Release`
+    - PR body の validation / risk / report references 更新
+    - task / phase tracking の最終同期
+  - Exit Criteria:
+    - full test が成功している
+    - PR body が最新の変更、検証、残リスクを反映している
+    - T-076 系 task の完了状態が tracking に反映されている
+    - サブエージェント verification report とサブエージェント final review report がある
+    - final tracking commit/push 済み
 
 ## Done
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -10,6 +10,9 @@
   - Estimate: M
   - Execution Policy:
     - コード実装とコードレビューはサブエージェントへ委譲する
+    - コード実装は TDD で進め、先に test target と failing test または newly required test を確定する
+    - 実装サブエージェントは `gpt-5.5 medium` を使う
+    - レビューサブエージェントは `gpt-5.5 high` を使う
     - 親 agent は設計判断、scope 管理、report 確認、Git 操作を担当する
   - Exit Criteria:
     - XPath-like path grammar が `doc/design/detail/02-PublicApi.md` に詳細化されている
@@ -26,8 +29,11 @@
   - Depends on:
     - T-076 XPath-like path access と差分表示 helper の設計
   - Execution Policy:
+    - TDD で進め、先に parser / `ToString()` の test target を確定する
     - コード実装はサブエージェントへ委譲する
+    - 実装サブエージェントは `gpt-5.5 medium` を使う
     - コードレビューはサブエージェントへ委譲する
+    - レビューサブエージェントは `gpt-5.5 high` を使う
     - 1 task / 1 commit / 1 push で完結させる
   - Scope:
     - `ParallelDiffEntry`
@@ -48,8 +54,11 @@
   - Depends on:
     - T-077 XPath-like path parser と public result 型の追加
   - Execution Policy:
+    - TDD で進め、先に path 解決 API の test target を確定する
     - コード実装はサブエージェントへ委譲する
+    - 実装サブエージェントは `gpt-5.5 medium` を使う
     - コードレビューはサブエージェントへ委譲する
+    - レビューサブエージェントは `gpt-5.5 high` を使う
     - 1 task / 1 commit / 1 push で完結させる
   - Scope:
     - `GetNodeByPath<T>()`
@@ -71,8 +80,11 @@
   - Depends on:
     - T-078 XPath-like path による node/value/state 解決 API の追加
   - Execution Policy:
+    - TDD で進め、先に diff entry 列挙の test target を確定する
     - コード実装はサブエージェントへ委譲する
+    - 実装サブエージェントは `gpt-5.5 medium` を使う
     - コードレビューはサブエージェントへ委譲する
+    - レビューサブエージェントは `gpt-5.5 high` を使う
     - 1 task / 1 commit / 1 push で完結させる
   - Scope:
     - `Kind == Node` の `ParallelDiffEntry` 列挙
@@ -94,8 +106,11 @@
   - Depends on:
     - T-079 通常 node 差分の `GetDiffEntries()` 追加
   - Execution Policy:
+    - TDD で進め、先に `ContainerPresence` の test target を確定する
     - コード実装はサブエージェントへ委譲する
+    - 実装サブエージェントは `gpt-5.5 medium` を使う
     - コードレビューはサブエージェントへ委譲する
+    - レビューサブエージェントは `gpt-5.5 high` を使う
     - 1 task / 1 commit / 1 push で完結させる
   - Scope:
     - child node を持たない container presence mismatch の diff entry
@@ -117,7 +132,9 @@
     - T-080 empty container 差分の `ContainerPresence` entry 追加
   - Execution Policy:
     - ドキュメント更新はサブエージェントへ委譲する
+    - ドキュメント更新サブエージェントは `gpt-5.5 medium` を使う
     - レビューはサブエージェントへ委譲する
+    - レビューサブエージェントは `gpt-5.5 high` を使う
     - 1 task / 1 commit / 1 push で完結させる
   - Scope:
     - README の利用例
@@ -139,6 +156,7 @@
   - Execution Policy:
     - 検証実行はサブエージェントへ委譲する
     - 最終レビューはサブエージェントへ委譲する
+    - 最終レビューサブエージェントは `gpt-5.5 high` を使う
     - 1 task / 1 commit / 1 push で完結させる
   - Scope:
     - `dotnet test SSC.sln --configuration Release`

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -8,32 +8,6 @@
 
 ## Backlog
 
-- T-078: XPath-like path による node/value/state 解決 API の追加
-  - Status: 未着手
-  - Phase: Phase 3
-  - Estimate: M
-  - Depends on:
-    - T-077 XPath-like path parser と public result 型の追加
-  - Execution Policy:
-    - TDD で進め、先に path 解決 API の test target を確定する
-    - コード実装はサブエージェントへ委譲する
-    - 実装サブエージェントは `gpt-5.5 medium` を使う
-    - コードレビューはサブエージェントへ委譲する
-    - レビューサブエージェントは `gpt-5.5 high` を使う
-    - 1 task / 1 commit / 1 push で完結させる
-  - Scope:
-    - `GetNodeByPath<T>()`
-    - `GetValueByPath<T>()`
-    - `GetStateByPath<T>()`
-    - scalar/object member と keyed / ordinal container child の解決
-  - Exit Criteria:
-    - root prefix あり/なしの path 解決 E2E がある
-    - keyed container と `#ordinal` container の解決 E2E がある
-    - 未解決 path と範囲外 model index の挙動が設計どおり検証されている
-    - 差分列挙には踏み込まない
-    - サブエージェント実装 report とサブエージェント review report がある
-    - focused test が成功し、commit/push 済み
-
 - T-079: 通常 node 差分の `GetDiffEntries()` 追加
   - Status: 未着手
   - Phase: Phase 3
@@ -131,6 +105,22 @@
     - final tracking commit/push 済み
 
 ## Done
+
+- T-078: XPath-like path による node/value/state 解決 API の追加
+  - Status: 完了（path 解決 API を TDD で追加し、root prefix / keyed path / ordinal path / unresolved / out-of-range を検証、レビュー指摘なし）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-077 XPath-like path parser と public result 型の追加
+  - Output:
+    - `src/SSC/ParallelPathAccessExtensions.cs`
+    - `tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs`
+    - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+    - `reports/task-t-078-implementation-20260623093152.md`
+    - `reports/task-t-078-review-20260623093200.md`
+  - Verification:
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessE2ETests"` 成功（4 件）
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikePathAccessUnitTests"` 成功（1 件）
 
 - T-077: XPath-like path parser と public result 型の追加
   - Status: 完了（parser / public diff result 型 / `ToString()` を TDD で追加し、review P2 指摘を修正、再レビューで指摘なし）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -8,29 +8,6 @@
 
 ## Backlog
 
-- T-081: README 利用例と public API ドキュメントの同期
-  - Status: 未着手
-  - Phase: Phase 3
-  - Estimate: S
-  - Depends on:
-    - T-080 empty container 差分の `ContainerPresence` entry 追加
-  - Execution Policy:
-    - ドキュメント更新はサブエージェントへ委譲する
-    - ドキュメント更新サブエージェントは `gpt-5.5 medium` を使う
-    - レビューはサブエージェントへ委譲する
-    - レビューサブエージェントは `gpt-5.5 high` を使う
-    - 1 task / 1 commit / 1 push で完結させる
-  - Scope:
-    - README の利用例
-    - public API 設計書と実装後 API 名の同期
-    - 必要に応じた package readme 同期
-  - Exit Criteria:
-    - XPath-like path access と diff entry の最小利用例が README にある
-    - 設計書と実装 API の命名・例外・表示例が一致している
-    - Markdown 検査はユーザー指示がない限り実施しない
-    - サブエージェント実装 report とサブエージェント review report がある
-    - docs-only commit/push 済み
-
 - T-082: T-076 系 API の統合検証と PR 仕上げ
   - Status: 未着手
   - Phase: Phase 4
@@ -54,6 +31,22 @@
     - final tracking commit/push 済み
 
 ## Done
+
+- T-081: README 利用例と public API ドキュメントの同期
+  - Status: 完了（README に XPath-like path access / diff entry 利用例を追加し、public API 設計書を実装 API と同期、レビュー P2 指摘 2 件を修正して最終レビュー指摘なし）
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-080 empty container 差分の `ContainerPresence` entry 追加
+  - Output:
+    - `README.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `reports/task-t-081-implementation-20260623100427.md`
+    - `reports/task-t-081-review-20260623100427.md`
+  - Verification:
+    - `rg -n "PackageReadmeFile|README.md" src/SSC/SSC.csproj src/SSC.Generators/SSC.Generators.csproj` 成功
+    - `git diff --check` 成功
+    - Markdown 検査はユーザー指示により未実施
 
 - T-080: empty container 差分の `ContainerPresence` entry 追加
   - Status: 完了（empty list / dictionary の child node を持たない container presence mismatch を `ContainerPresence` entry として TDD で追加し、レビュー指摘なし）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -8,31 +8,6 @@
 
 ## Backlog
 
-- T-080: empty container 差分の `ContainerPresence` entry 追加
-  - Status: 未着手
-  - Phase: Phase 3
-  - Estimate: M
-  - Depends on:
-    - T-079 通常 node 差分の `GetDiffEntries()` 追加
-  - Execution Policy:
-    - TDD で進め、先に `ContainerPresence` の test target を確定する
-    - コード実装はサブエージェントへ委譲する
-    - 実装サブエージェントは `gpt-5.5 medium` を使う
-    - コードレビューはサブエージェントへ委譲する
-    - レビューサブエージェントは `gpt-5.5 high` を使う
-    - 1 task / 1 commit / 1 push で完結させる
-  - Scope:
-    - child node を持たない container presence mismatch の diff entry
-    - `Kind == ContainerPresence`
-    - `Node == null`
-    - container member path の表示
-  - Exit Criteria:
-    - empty list / empty dictionary の片側欠損を diff entry として落とさない E2E がある
-    - `ContainerPresence` の `Values` と `ToString()` が Missing / null を混同しない
-    - `GetNodeByPath(Path)` で node 解決を保証しないことがテストまたは設計コメントで明確化されている
-    - サブエージェント実装 report とサブエージェント review report がある
-    - focused test が成功し、commit/push 済み
-
 - T-081: README 利用例と public API ドキュメントの同期
   - Status: 未着手
   - Phase: Phase 3
@@ -79,6 +54,26 @@
     - final tracking commit/push 済み
 
 ## Done
+
+- T-080: empty container 差分の `ContainerPresence` entry 追加
+  - Status: 完了（empty list / dictionary の child node を持たない container presence mismatch を `ContainerPresence` entry として TDD で追加し、レビュー指摘なし）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-079 通常 node 差分の `GetDiffEntries()` 追加
+  - Output:
+    - `src/SSC/Contracts.cs`
+    - `src/SSC/ParallelNode.cs`
+    - `src/SSC/ParallelPathAccessExtensions.cs`
+    - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+    - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+    - `tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs`
+    - `reports/task-t-080-implementation-20260623095422.md`
+    - `reports/task-t-080-review-20260623095422.md`
+  - Verification:
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"` 成功（5 件）
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~XPathLikePathAccessUnitTests"` 成功（3 件）
+    - `git diff --check` 成功
 
 - T-079: 通常 node 差分の `GetDiffEntries()` 追加
   - Status: 完了（通常 node 差分の structured entry 列挙を TDD で追加し、generated path の round-trip と代表 `ToString()` を検証、レビュー指摘なし）

--- a/tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs
@@ -79,31 +79,65 @@ public sealed class XPathLikeDiffEntriesE2ETests
     }
 
     [Fact]
-    public void GetDiffEntries_DoesNotReturnContainerPresenceForEmptyContainerMismatch()
+    public void GetDiffEntries_ReturnsContainerPresenceForEmptyListMissingOnOneSide()
     {
-        // Intent: child node を持たない empty container presence mismatch は T-080 対象なので T-079 では列挙しない。
+        // Intent: child node を持たない empty list presence mismatch を ContainerPresence entry として返す。
         var result = ParallelCompareApi.Compare(
         [
-            new Dataset
+            new OptionalContainerDataset
             {
-                Groups =
-                [
-                    new Group { GroupId = 1, Items = [] },
-                ],
+                Items = [],
             },
-            new Dataset
+            new OptionalContainerDataset
             {
-                Groups =
-                [
-                    new Group { GroupId = 1, Items = [new Item { ItemId = 100, MetricA = 10.0 }] },
-                ],
+                Items = null,
             },
         ]);
 
         var entries = result.GetDiffEntries();
+        var entry = Assert.Single(entries, candidate => candidate.Path == "Items");
 
-        Assert.DoesNotContain(entries, entry => entry.Kind == ParallelDiffEntryKind.ContainerPresence);
-        Assert.DoesNotContain(entries, entry => entry.Path == "Groups[1].Items");
+        Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Null(entry.Node);
+        Assert.Null(result.GetNodeByPath(entry.Path));
+        Assert.Equal(2, entry.Values.Count);
+        Assert.Equal(0, entry.Values[0].ModelIndex);
+        Assert.Null(entry.Values[0].Value);
+        Assert.Equal(ValueState.Mismatched, entry.Values[0].State);
+        Assert.Equal(1, entry.Values[1].ModelIndex);
+        Assert.Null(entry.Values[1].Value);
+        Assert.Equal(ValueState.Mismatched, entry.Values[1].State);
+        Assert.Equal("Items: [0]=null(Mismatched), [1]=null(Mismatched)", entry.ToString());
+    }
+
+    [Fact]
+    public void GetDiffEntries_ReturnsContainerPresenceForEmptyDictionaryMissingOnOneSide()
+    {
+        // Intent: child node を持たない empty dictionary presence mismatch を ContainerPresence entry として返す。
+        var result = ParallelCompareApi.Compare(
+        [
+            new OptionalDictionaryDataset
+            {
+                Scores = [],
+            },
+            new OptionalDictionaryDataset
+            {
+                Scores = null,
+            },
+        ]);
+
+        var entries = result.GetDiffEntries();
+        var entry = Assert.Single(entries, candidate => candidate.Path == "Scores");
+
+        Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Null(entry.Node);
+        Assert.Null(result.GetNodeByPath(entry.Path));
+        Assert.Equal(2, entry.Values.Count);
+        Assert.Null(entry.Values[0].Value);
+        Assert.Equal(ValueState.Mismatched, entry.Values[0].State);
+        Assert.Null(entry.Values[1].Value);
+        Assert.Equal(ValueState.Mismatched, entry.Values[1].State);
+        Assert.Equal("Scores: [0]=null(Mismatched), [1]=null(Mismatched)", entry.ToString());
     }
 
     private static void AssertResolvablePath<T>(
@@ -184,5 +218,28 @@ public sealed class XPathLikeDiffEntriesE2ETests
         public string ItemId { get; init; } = string.Empty;
 
         public string Label { get; init; } = string.Empty;
+    }
+
+    public sealed class ScoreDataset
+    {
+        public List<ScoreGroup> Groups { get; init; } = [];
+    }
+
+    public sealed class ScoreGroup
+    {
+        [CompareKey]
+        public int GroupId { get; init; }
+
+        public Dictionary<string, int> Scores { get; init; } = [];
+    }
+
+    public sealed class OptionalContainerDataset
+    {
+        public List<Item>? Items { get; init; }
+    }
+
+    public sealed class OptionalDictionaryDataset
+    {
+        public Dictionary<string, int>? Scores { get; init; }
     }
 }

--- a/tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs
@@ -1,0 +1,188 @@
+using SSC;
+
+namespace SSC.E2E.Tests;
+
+public sealed class XPathLikeDiffEntriesE2ETests
+{
+    [Fact]
+    public void GetDiffEntries_ReturnsStructuredNodeEntriesWithResolvablePaths()
+    {
+        // Intent: 通常 node 差分を構造化 entry として返し、生成 path が同じ node に解決できる。
+        var result = ParallelCompareApi.Compare(CreateModels());
+
+        var entries = result.GetDiffEntries();
+        var metric = Assert.Single(entries, entry => entry.Path == "Groups[1].Items[100].MetricA");
+
+        Assert.Equal(ParallelDiffEntryKind.Node, metric.Kind);
+        Assert.NotNull(metric.Node);
+        Assert.Same(metric.Node, result.GetNodeByPath(metric.Path));
+        Assert.Equal(2, metric.Values.Count);
+        Assert.Equal(0, metric.Values[0].ModelIndex);
+        Assert.Equal(1.0, metric.Values[0].Value);
+        Assert.Equal(ValueState.Mismatched, metric.Values[0].State);
+        Assert.Equal(1, metric.Values[1].ModelIndex);
+        Assert.Equal(10.0, metric.Values[1].Value);
+        Assert.Equal(ValueState.Mismatched, metric.Values[1].State);
+        Assert.Equal("Groups[1].Items[100].MetricA: [0]=1(Mismatched), [1]=10(Mismatched)", metric.ToString());
+    }
+
+    [Fact]
+    public void GetDiffEntries_ReturnsObjectPresenceMismatchWithoutDuplicatingChildren()
+    {
+        // Intent: container child object 自身の presence mismatch は child leaf を重複列挙しない。
+        var result = ParallelCompareApi.Compare(CreateModels());
+
+        var entries = result.GetDiffEntries();
+        var missingItem = Assert.Single(entries, entry => entry.Path == "Groups[1].Items[200]");
+
+        Assert.Equal(ParallelDiffEntryKind.Node, missingItem.Kind);
+        Assert.NotNull(missingItem.Node);
+        Assert.Same(missingItem.Node, result.GetNodeByPath(missingItem.Path));
+        Assert.Equal(200, ((Item?)missingItem.Values[0].Value)?.ItemId);
+        Assert.Equal(ValueState.Mismatched, missingItem.Values[0].State);
+        Assert.Null(missingItem.Values[1].Value);
+        Assert.Equal(ValueState.Missing, missingItem.Values[1].State);
+        Assert.DoesNotContain(entries, entry => entry.Path.StartsWith("Groups[1].Items[200].", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GetDiffEntries_EscapesKeyTextAndGeneratedPathResolves()
+    {
+        // Intent: path 生成時に key text の ], \\, 先頭 #digits を escape し、生成 path で解決できる。
+        var result = ParallelCompareApi.Compare(
+        [
+            new EscapedKeyDataset
+            {
+                Items =
+                [
+                    new EscapedKeyItem { ItemId = "A]B", Label = "left-bracket" },
+                    new EscapedKeyItem { ItemId = "A\\B", Label = "left-slash" },
+                    new EscapedKeyItem { ItemId = "#0", Label = "left-hash" },
+                ],
+            },
+            new EscapedKeyDataset
+            {
+                Items =
+                [
+                    new EscapedKeyItem { ItemId = "A]B", Label = "right-bracket" },
+                    new EscapedKeyItem { ItemId = "A\\B", Label = "right-slash" },
+                    new EscapedKeyItem { ItemId = "#0", Label = "right-hash" },
+                ],
+            },
+        ]);
+
+        var entries = result.GetDiffEntries();
+
+        AssertResolvablePath(entries, result, "Items[A\\]B].Label");
+        AssertResolvablePath(entries, result, "Items[A\\\\B].Label");
+        AssertResolvablePath(entries, result, "Items[\\#0].Label");
+    }
+
+    [Fact]
+    public void GetDiffEntries_DoesNotReturnContainerPresenceForEmptyContainerMismatch()
+    {
+        // Intent: child node を持たない empty container presence mismatch は T-080 対象なので T-079 では列挙しない。
+        var result = ParallelCompareApi.Compare(
+        [
+            new Dataset
+            {
+                Groups =
+                [
+                    new Group { GroupId = 1, Items = [] },
+                ],
+            },
+            new Dataset
+            {
+                Groups =
+                [
+                    new Group { GroupId = 1, Items = [new Item { ItemId = 100, MetricA = 10.0 }] },
+                ],
+            },
+        ]);
+
+        var entries = result.GetDiffEntries();
+
+        Assert.DoesNotContain(entries, entry => entry.Kind == ParallelDiffEntryKind.ContainerPresence);
+        Assert.DoesNotContain(entries, entry => entry.Path == "Groups[1].Items");
+    }
+
+    private static void AssertResolvablePath<T>(
+        IReadOnlyList<ParallelDiffEntry> entries,
+        CompareResult<T> result,
+        string path)
+    {
+        var entry = Assert.Single(entries, candidate => candidate.Path == path);
+        Assert.Same(entry.Node, result.GetNodeByPath(path));
+    }
+
+    private static IReadOnlyList<Dataset> CreateModels()
+    {
+        return
+        [
+            new Dataset
+            {
+                Groups =
+                [
+                    new Group
+                    {
+                        GroupId = 1,
+                        Items =
+                        [
+                            new Item { ItemId = 100, MetricA = 1.0 },
+                            new Item { ItemId = 200, MetricA = 2.0 },
+                        ],
+                    },
+                ],
+            },
+            new Dataset
+            {
+                Groups =
+                [
+                    new Group
+                    {
+                        GroupId = 1,
+                        Items =
+                        [
+                            new Item { ItemId = 100, MetricA = 10.0 },
+                            new Item { ItemId = 300, MetricA = 30.0 },
+                        ],
+                    },
+                ],
+            },
+        ];
+    }
+
+    public sealed class Dataset
+    {
+        public List<Group> Groups { get; init; } = [];
+    }
+
+    public sealed class Group
+    {
+        [CompareKey]
+        public int GroupId { get; init; }
+
+        public List<Item> Items { get; init; } = [];
+    }
+
+    public sealed class Item
+    {
+        [CompareKey]
+        public int ItemId { get; init; }
+
+        public double MetricA { get; init; }
+    }
+
+    public sealed class EscapedKeyDataset
+    {
+        public List<EscapedKeyItem> Items { get; init; } = [];
+    }
+
+    public sealed class EscapedKeyItem
+    {
+        [CompareKey]
+        public string ItemId { get; init; } = string.Empty;
+
+        public string Label { get; init; } = string.Empty;
+    }
+}

--- a/tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XPathLikePathAccessE2ETests.cs
@@ -1,0 +1,121 @@
+using SSC;
+
+namespace SSC.E2E.Tests;
+
+public sealed class XPathLikePathAccessE2ETests
+{
+    [Fact]
+    public void GetNodeByPath_WithKeyedPathAndRootPrefix_ResolvesNodeValueAndState()
+    {
+        // Intent: root type prefix 付き path で keyed container child と scalar member を解決する。
+        var result = ParallelCompareApi.Compare(CreateModels());
+
+        var node = result.GetNodeByPath("Dataset.Groups[1].Items[100].MetricA");
+
+        Assert.NotNull(node);
+        Assert.Equal(1.0, result.GetValueByPath("Dataset.Groups[1].Items[100].MetricA", 0));
+        Assert.Equal(10.0, result.GetValueByPath("Dataset.Groups[1].Items[100].MetricA", 1));
+        Assert.Equal(ValueState.Mismatched, result.GetStateByPath("Dataset.Groups[1].Items[100].MetricA", 0));
+        Assert.Equal(ValueState.Mismatched, result.GetStateByPath("Dataset.Groups[1].Items[100].MetricA", 1));
+    }
+
+    [Fact]
+    public void GetNodeByPath_WithKeyedPathWithoutRootPrefix_ResolvesSameNode()
+    {
+        // Intent: root type prefix なしの root-relative path でも同じ node を解決する。
+        var result = ParallelCompareApi.Compare(CreateModels());
+
+        var prefixed = result.GetNodeByPath("Dataset.Groups[1].Items[100].MetricA");
+        var relative = result.GetNodeByPath("Groups[1].Items[100].MetricA");
+
+        Assert.NotNull(relative);
+        Assert.Same(prefixed, relative);
+        Assert.Equal(1.0, result.GetValueByPath("Groups[1].Items[100].MetricA", 0));
+        Assert.Equal(10.0, result.GetValueByPath("Groups[1].Items[100].MetricA", 1));
+    }
+
+    [Fact]
+    public void GetPathAccess_WithUnresolvedPath_ReturnsNullAndMissing()
+    {
+        // Intent: 未解決 path は node/value を null、state を Missing として返す。
+        var result = ParallelCompareApi.Compare(CreateModels());
+
+        Assert.Null(result.GetNodeByPath("Groups[9].Items[100].MetricA"));
+        Assert.Null(result.GetValueByPath("Groups[9].Items[100].MetricA", 0));
+        Assert.Equal(ValueState.Missing, result.GetStateByPath("Groups[9].Items[100].MetricA", 0));
+        Assert.Null(result.GetNodeByPath("WrongRoot.Groups[1].Items[100].MetricA"));
+    }
+
+    [Fact]
+    public void GetPathAccess_WithOutOfRangeModelIndex_ThrowsExecutionException()
+    {
+        // Intent: node 解決後の model index 範囲外は既存 node と同じ契約例外で失敗する。
+        var result = ParallelCompareApi.Compare(CreateModels());
+
+        var valueException = Assert.Throws<CompareExecutionException>(
+            () => result.GetValueByPath("Groups[1].Items[100].MetricA", 2));
+        var stateException = Assert.Throws<CompareExecutionException>(
+            () => result.GetStateByPath("Groups[1].Items[100].MetricA", -1));
+
+        Assert.Equal(CompareIssueCode.ModelIndexOutOfRange, valueException.Code);
+        Assert.Equal(CompareIssueCode.ModelIndexOutOfRange, stateException.Code);
+    }
+
+    private static IReadOnlyList<Dataset> CreateModels()
+    {
+        return
+        [
+            new Dataset
+            {
+                Groups =
+                [
+                    new Group
+                    {
+                        GroupId = 1,
+                        Items =
+                        [
+                            new Item { ItemId = 100, MetricA = 1.0 },
+                            new Item { ItemId = 200, MetricA = 2.0 },
+                        ],
+                    },
+                ],
+            },
+            new Dataset
+            {
+                Groups =
+                [
+                    new Group
+                    {
+                        GroupId = 1,
+                        Items =
+                        [
+                            new Item { ItemId = 100, MetricA = 10.0 },
+                            new Item { ItemId = 300, MetricA = 30.0 },
+                        ],
+                    },
+                ],
+            },
+        ];
+    }
+
+    public sealed class Dataset
+    {
+        public List<Group> Groups { get; init; } = [];
+    }
+
+    public sealed class Group
+    {
+        [CompareKey]
+        public int GroupId { get; init; }
+
+        public List<Item> Items { get; init; } = [];
+    }
+
+    public sealed class Item
+    {
+        [CompareKey]
+        public int ItemId { get; init; }
+
+        public double MetricA { get; init; }
+    }
+}

--- a/tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs
+++ b/tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using SSC;
+
+namespace SSC.Unit.Tests;
+
+public sealed class ParallelDiffResultUnitTests
+{
+    [Fact]
+    public void ParallelDiffValue_ToString_FormatsValueByContract()
+    {
+        // Intent: Missing/null/string/数値を人間確認用の固定形式で表示する。
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        try
+        {
+            Assert.Equal("[0]=<missing>(Missing)", new ParallelDiffValue { ModelIndex = 0, State = ValueState.Missing, Value = "ignored" }.ToString());
+            Assert.Equal("[1]=null(Matched)", new ParallelDiffValue { ModelIndex = 1, State = ValueState.Matched, Value = null }.ToString());
+            Assert.Equal("[2]=\"left\"(Mismatched)", new ParallelDiffValue { ModelIndex = 2, State = ValueState.Mismatched, Value = "left" }.ToString());
+            Assert.Equal("[3]=1.5(Mismatched)", new ParallelDiffValue { ModelIndex = 3, State = ValueState.Mismatched, Value = 1.5m }.ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void ParallelDiffEntry_ToString_JoinsPathAndValues()
+    {
+        // Intent: path と model slot 別 value/state を 1 行にまとめる。
+        var entry = new ParallelDiffEntry
+        {
+            Path = "Groups[1].Items[200].Name",
+            Kind = ParallelDiffEntryKind.Node,
+            Values =
+            [
+                new ParallelDiffValue { ModelIndex = 0, Value = "left", State = ValueState.Mismatched },
+                new ParallelDiffValue { ModelIndex = 1, Value = null, State = ValueState.Missing },
+            ],
+        };
+
+        Assert.Equal(
+            "Groups[1].Items[200].Name: [0]=\"left\"(Mismatched), [1]=<missing>(Missing)",
+            entry.ToString());
+    }
+}

--- a/tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs
+++ b/tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs
@@ -1,0 +1,121 @@
+using SSC;
+
+namespace SSC.Unit.Tests;
+
+public sealed class XPathLikeDiffEntriesUnitTests
+{
+    [Fact]
+    public void GetDiffEntries_WithKeylessContainerChild_GeneratesOrdinalPath()
+    {
+        // Intent: KeyText が null の container child は #ordinal path を生成し、生成 path で解決できる。
+        var nameNode = new FakeNode(value: "left", state: ValueState.Mismatched);
+        var itemNode = new FakeNode(value: new object(), state: ValueState.Mismatched);
+        itemNode.SetMember("Name", nameNode);
+        var root = new FakeRootNode();
+        root.SetChildren("Items", [itemNode]);
+        var result = new CompareResult<FakeRoot> { Root = root };
+
+        var entry = Assert.Single(result.GetDiffEntries());
+
+        Assert.Equal("Items[#0].Name", entry.Path);
+        Assert.Same(nameNode, entry.Node);
+        Assert.Same(entry.Node, result.GetNodeByPath(entry.Path));
+    }
+
+    private sealed class FakeRoot;
+
+    private class FakeNode : IParallelNode, IParallelNodeInternal
+    {
+        private readonly object? _value;
+        private readonly ValueState _state;
+        private readonly Dictionary<string, IParallelNode> _members = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<IParallelNode>> _children = new(StringComparer.Ordinal);
+
+        public FakeNode(object? value, ValueState state, string? keyText = null)
+        {
+            _value = value;
+            _state = state;
+            KeyText = keyText;
+        }
+
+        public int Count => 1;
+
+        public bool AllPresent => _state != ValueState.Missing;
+
+        public bool AnyPresent => _state != ValueState.Missing;
+
+        public string? KeyText { get; }
+
+        public Type ModelType => typeof(object);
+
+        public object? GetValue(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state == ValueState.Missing ? null : _value;
+        }
+
+        public ValueState GetState(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state;
+        }
+
+        public bool HasDifferences() => _state == ValueState.Mismatched;
+
+        public IReadOnlyList<ParallelChildSet> GetDirectChildren()
+        {
+            var sets = new List<ParallelChildSet>();
+            sets.AddRange(_members.Select(pair => new ParallelChildSet(pair.Key, [pair.Value], pair.Value.HasDifferences())));
+            sets.AddRange(_children.Select(pair => new ParallelChildSet(pair.Key, pair.Value, pair.Value.Any(node => node.HasDifferences()))));
+            return sets;
+        }
+
+        public bool TryGetChildren(string memberName, out IReadOnlyList<IParallelNode> nodes)
+        {
+            return _children.TryGetValue(memberName, out nodes!);
+        }
+
+        public bool TryGetMemberNode(string memberName, out IParallelNode node)
+        {
+            return _members.TryGetValue(memberName, out node!);
+        }
+
+        public NodePresenceState GetPresenceState(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state == ValueState.Missing ? NodePresenceState.Missing : NodePresenceState.PresentValue;
+        }
+
+        public void SetMember(string name, IParallelNode node)
+        {
+            _members[name] = node;
+        }
+
+        public void SetChildren(string name, IReadOnlyList<IParallelNode> nodes)
+        {
+            _children[name] = nodes;
+        }
+
+        private static void ValidateIndex(int modelIndex)
+        {
+            if (modelIndex == 0)
+            {
+                return;
+            }
+
+            throw new CompareExecutionException(
+                CompareIssueCode.ModelIndexOutOfRange,
+                $"modelIndex '{modelIndex}' is out of range for count '1'.");
+        }
+    }
+
+    private sealed class FakeRootNode : FakeNode, Parallel<FakeRoot>
+    {
+        public FakeRootNode()
+            : base(new FakeRoot(), ValueState.Matched)
+        {
+        }
+
+        public FakeRoot? this[int modelIndex] => (FakeRoot?)GetValue(modelIndex);
+    }
+}

--- a/tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs
+++ b/tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs
@@ -22,6 +22,27 @@ public sealed class XPathLikeDiffEntriesUnitTests
         Assert.Same(entry.Node, result.GetNodeByPath(entry.Path));
     }
 
+    [Fact]
+    public void GetDiffEntries_WithContainerPresenceMissingState_DistinguishesMissingFromNullValue()
+    {
+        // Intent: ContainerPresence では Value は null 固定でも、State で Missing と present 側を区別する。
+        var root = new FakeRootNode();
+        root.SetChildren("Items", [], [NodePresenceState.PresentValue, NodePresenceState.Missing]);
+        var result = new CompareResult<FakeRoot> { Root = root };
+
+        var entry = Assert.Single(result.GetDiffEntries());
+
+        Assert.Equal("Items", entry.Path);
+        Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Null(entry.Node);
+        Assert.Null(result.GetNodeByPath(entry.Path));
+        Assert.Equal(ValueState.Mismatched, entry.Values[0].State);
+        Assert.Null(entry.Values[0].Value);
+        Assert.Equal(ValueState.Missing, entry.Values[1].State);
+        Assert.Null(entry.Values[1].Value);
+        Assert.Equal("Items: [0]=null(Mismatched), [1]=<missing>(Missing)", entry.ToString());
+    }
+
     private sealed class FakeRoot;
 
     private class FakeNode : IParallelNode, IParallelNodeInternal
@@ -30,6 +51,7 @@ public sealed class XPathLikeDiffEntriesUnitTests
         private readonly ValueState _state;
         private readonly Dictionary<string, IParallelNode> _members = new(StringComparer.Ordinal);
         private readonly Dictionary<string, IReadOnlyList<IParallelNode>> _children = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<NodePresenceState>> _containerPresenceStates = new(StringComparer.Ordinal);
 
         public FakeNode(object? value, ValueState state, string? keyText = null)
         {
@@ -66,7 +88,10 @@ public sealed class XPathLikeDiffEntriesUnitTests
         {
             var sets = new List<ParallelChildSet>();
             sets.AddRange(_members.Select(pair => new ParallelChildSet(pair.Key, [pair.Value], pair.Value.HasDifferences())));
-            sets.AddRange(_children.Select(pair => new ParallelChildSet(pair.Key, pair.Value, pair.Value.Any(node => node.HasDifferences()))));
+            sets.AddRange(_children.Select(pair => new ParallelChildSet(
+                pair.Key,
+                pair.Value,
+                HasPresenceMismatch(_containerPresenceStates[pair.Key]) || pair.Value.Any(node => node.HasDifferences()))));
             return sets;
         }
 
@@ -78,6 +103,18 @@ public sealed class XPathLikeDiffEntriesUnitTests
         public bool TryGetMemberNode(string memberName, out IParallelNode node)
         {
             return _members.TryGetValue(memberName, out node!);
+        }
+
+        public bool TryGetContainerPresenceStates(string memberName, out IReadOnlyList<NodePresenceState> states)
+        {
+            if (_containerPresenceStates.TryGetValue(memberName, out var containerStates))
+            {
+                states = containerStates;
+                return true;
+            }
+
+            states = Array.Empty<NodePresenceState>();
+            return false;
         }
 
         public NodePresenceState GetPresenceState(int modelIndex)
@@ -93,7 +130,32 @@ public sealed class XPathLikeDiffEntriesUnitTests
 
         public void SetChildren(string name, IReadOnlyList<IParallelNode> nodes)
         {
+            SetChildren(name, nodes, [NodePresenceState.PresentValue]);
+        }
+
+        public void SetChildren(string name, IReadOnlyList<IParallelNode> nodes, IReadOnlyList<NodePresenceState> states)
+        {
             _children[name] = nodes;
+            _containerPresenceStates[name] = states;
+        }
+
+        private static bool HasPresenceMismatch(IReadOnlyList<NodePresenceState> states)
+        {
+            if (states.Count <= 1)
+            {
+                return false;
+            }
+
+            var first = states[0];
+            for (var index = 1; index < states.Count; index++)
+            {
+                if (states[index] != first)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void ValidateIndex(int modelIndex)

--- a/tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs
+++ b/tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs
@@ -1,0 +1,121 @@
+using SSC;
+
+namespace SSC.Unit.Tests;
+
+public sealed class XPathLikePathAccessUnitTests
+{
+    [Fact]
+    public void GetNodeByPath_WithOrdinalSelector_ResolvesKeylessContainerChild()
+    {
+        // Intent: KeyText を持たない container child は #ordinal で同一 child set 内の順序から解決する。
+        var nameNode = new FakeNode(value: "first", state: ValueState.Matched);
+        var itemNode = new FakeNode(value: new object(), state: ValueState.Matched);
+        itemNode.SetMember("Name", nameNode);
+        var root = new FakeRootNode();
+        root.SetChildren("Items", [itemNode]);
+        var result = new CompareResult<FakeRoot> { Root = root };
+
+        var node = result.GetNodeByPath("Items[#0].Name");
+
+        Assert.Same(nameNode, node);
+        Assert.Equal("first", result.GetValueByPath("Items[#0].Name", 0));
+        Assert.Equal(ValueState.Matched, result.GetStateByPath("Items[#0].Name", 0));
+    }
+
+    private sealed class FakeRoot;
+
+    private class FakeNode : IParallelNode, IParallelNodeInternal
+    {
+        private readonly object? _value;
+        private readonly ValueState _state;
+        private readonly Dictionary<string, IParallelNode> _members = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<IParallelNode>> _children = new(StringComparer.Ordinal);
+
+        public FakeNode(object? value, ValueState state, string? keyText = null)
+        {
+            _value = value;
+            _state = state;
+            KeyText = keyText;
+        }
+
+        public int Count => 1;
+
+        public bool AllPresent => _state != ValueState.Missing;
+
+        public bool AnyPresent => _state != ValueState.Missing;
+
+        public string? KeyText { get; }
+
+        public Type ModelType => typeof(object);
+
+        public object? GetValue(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state == ValueState.Missing ? null : _value;
+        }
+
+        public ValueState GetState(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state;
+        }
+
+        public bool HasDifferences() => _state == ValueState.Mismatched;
+
+        public IReadOnlyList<ParallelChildSet> GetDirectChildren()
+        {
+            var sets = new List<ParallelChildSet>();
+            sets.AddRange(_members.Select(pair => new ParallelChildSet(pair.Key, [pair.Value], pair.Value.HasDifferences())));
+            sets.AddRange(_children.Select(pair => new ParallelChildSet(pair.Key, pair.Value, pair.Value.Any(node => node.HasDifferences()))));
+            return sets;
+        }
+
+        public bool TryGetChildren(string memberName, out IReadOnlyList<IParallelNode> nodes)
+        {
+            return _children.TryGetValue(memberName, out nodes!);
+        }
+
+        public bool TryGetMemberNode(string memberName, out IParallelNode node)
+        {
+            return _members.TryGetValue(memberName, out node!);
+        }
+
+        public NodePresenceState GetPresenceState(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state == ValueState.Missing ? NodePresenceState.Missing : NodePresenceState.PresentValue;
+        }
+
+        public void SetMember(string name, IParallelNode node)
+        {
+            _members[name] = node;
+        }
+
+        public void SetChildren(string name, IReadOnlyList<IParallelNode> nodes)
+        {
+            _children[name] = nodes;
+        }
+
+        private static void ValidateIndex(int modelIndex)
+        {
+            if (modelIndex == 0)
+            {
+                return;
+            }
+
+            throw new CompareExecutionException(
+                CompareIssueCode.ModelIndexOutOfRange,
+                $"modelIndex '{modelIndex}' is out of range for count '1'.");
+        }
+    }
+
+    private sealed class FakeRootNode : FakeNode, Parallel<FakeRoot>
+    {
+        public FakeRootNode()
+            : base(new FakeRoot(), ValueState.Matched)
+        {
+        }
+
+        public FakeRoot? this[int modelIndex] => (FakeRoot?)GetValue(modelIndex);
+    }
+}

--- a/tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs
+++ b/tests/SSC.Unit.Tests/XPathLikePathAccessUnitTests.cs
@@ -80,6 +80,18 @@ public sealed class XPathLikePathAccessUnitTests
             return _members.TryGetValue(memberName, out node!);
         }
 
+        public bool TryGetContainerPresenceStates(string memberName, out IReadOnlyList<NodePresenceState> states)
+        {
+            if (_children.ContainsKey(memberName))
+            {
+                states = [NodePresenceState.PresentValue];
+                return true;
+            }
+
+            states = Array.Empty<NodePresenceState>();
+            return false;
+        }
+
         public NodePresenceState GetPresenceState(int modelIndex)
         {
             ValidateIndex(modelIndex);

--- a/tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs
+++ b/tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs
@@ -1,0 +1,91 @@
+using SSC.Internal;
+
+namespace SSC.Unit.Tests;
+
+public sealed class XPathLikePathParserUnitTests
+{
+    [Fact]
+    public void TryParse_WithRootPrefixAndKeySelector_ParsesSegments()
+    {
+        // Intent: root type 名 prefix と key selector を grammar 通りに分解する。
+        var parsed = AssertParsed("Dataset.Groups[1].Items[100].MetricA", rootName: "Dataset");
+
+        Assert.Equal("Dataset", parsed.RootName);
+        Assert.Equal(3, parsed.Segments.Count);
+        Assert.Equal("Groups", parsed.Segments[0].MemberName);
+        Assert.Equal(XPathLikePathSelectorKind.Key, parsed.Segments[0].Selector?.Kind);
+        Assert.Equal("1", parsed.Segments[0].Selector?.KeyText);
+        Assert.Equal("Items", parsed.Segments[1].MemberName);
+        Assert.Equal("100", parsed.Segments[1].Selector?.KeyText);
+        Assert.Equal("MetricA", parsed.Segments[2].MemberName);
+        Assert.Null(parsed.Segments[2].Selector);
+    }
+
+    [Fact]
+    public void TryParse_WithOrdinalSelector_ParsesOrdinal()
+    {
+        // Intent: # + digits は key ではなく ordinal discriminator として扱う。
+        var parsed = AssertParsed("Items[#0].Name");
+
+        Assert.Null(parsed.RootName);
+        Assert.Equal(XPathLikePathSelectorKind.Ordinal, parsed.Segments[0].Selector?.Kind);
+        Assert.Equal(0, parsed.Segments[0].Selector?.Ordinal);
+        Assert.Null(parsed.Segments[0].Selector?.KeyText);
+    }
+
+    [Fact]
+    public void TryParse_WithoutExpectedRootName_KeepsDottedPathAsSegments()
+    {
+        // Intent: root type 名を知らない parser 呼び出しでは、先頭 segment を root prefix と決め打ちしない。
+        var parsed = AssertParsed("Customer.Name");
+
+        Assert.Null(parsed.RootName);
+        Assert.Equal("Customer", parsed.Segments[0].MemberName);
+        Assert.Equal("Name", parsed.Segments[1].MemberName);
+    }
+
+    [Theory]
+    [InlineData("Items[A.B]", "A.B")]
+    [InlineData("Items[A\\]B]", "A]B")]
+    [InlineData("Items[A\\\\B]", "A\\B")]
+    [InlineData("Items[\\#0]", "#0")]
+    public void TryParse_WithEscapedKeySelector_UnescapesKeyText(string path, string expectedKey)
+    {
+        // Intent: bracket 内の dot と escape 対象文字を key text として保持する。
+        var parsed = AssertParsed(path);
+
+        Assert.Equal(XPathLikePathSelectorKind.Key, parsed.Segments[0].Selector?.Kind);
+        Assert.Equal(expectedKey, parsed.Segments[0].Selector?.KeyText);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(".Items")]
+    [InlineData("Items.")]
+    [InlineData("Items[]")]
+    [InlineData("Items[#]")]
+    [InlineData("Items[#A]")]
+    [InlineData("Items[A")]
+    [InlineData("Items[A\\x]")]
+    [InlineData("Items[A][B]")]
+    [InlineData("Items[#0][B]")]
+    [InlineData("Items[A]B]")]
+    public void TryParse_WithInvalidGrammar_ReturnsFalse(string path)
+    {
+        // Intent: 解釈できない path は例外ではなく parse 失敗として扱う。
+        Assert.False(XPathLikePathParser.TryParse(path, out var parsed));
+        Assert.Null(parsed);
+    }
+
+    private static XPathLikePath AssertParsed(string path)
+    {
+        Assert.True(XPathLikePathParser.TryParse(path, out var parsed));
+        return Assert.IsType<XPathLikePath>(parsed);
+    }
+
+    private static XPathLikePath AssertParsed(string path, string rootName)
+    {
+        Assert.True(XPathLikePathParser.TryParse(path, rootName, out var parsed));
+        return Assert.IsType<XPathLikePath>(parsed);
+    }
+}


### PR DESCRIPTION
## Scope

Related local task chain: T-076 through T-082

This PR adds SSC-specific XPath-like path access and structured diff entries for compare results.

## Completed tasks

- T-076: design for XPath-like path access and diff display helper. Done.
- T-077: XPath-like path parser and public result types. Done in `7d242bf`.
- T-078: `GetNodeByPath`, `GetValueByPath`, and `GetStateByPath`. Done in `cc26f5e`.
- T-079: normal `Kind == Node` diff entries. Done in `b8a04b4`.
- T-080: empty-container `ContainerPresence` diff entries. Done in `fa845a3`.
- T-081: README and public API documentation sync. Done in `8e82888`.
- T-082: full integration validation and PR finish. Done in `9d0560c`.

## What changed

- Added XPath-like path parsing for compare-result tree paths.
- Added `CompareResult<T>` path helpers:
  - `GetNodeByPath(path)`
  - `GetValueByPath(path, modelIndex)`
  - `GetStateByPath(path, modelIndex)`
- Added structured diff entries:
  - `ParallelDiffEntry`
  - `ParallelDiffValue`
  - `ParallelDiffEntryKind.Node`
  - `ParallelDiffEntryKind.ContainerPresence`
- Added `GetDiffEntries()` for normal node diffs and empty-container presence diffs.
- Added `ToString()` display for diff entries and values.
- Documented XPath-like path access and diff entries in README and `doc/design/detail/02-PublicApi.md`.

## Contract notes

- XPath-like paths are a separate contract from `CompareIssue.Path`.
- Generated `Kind == Node` entry paths round-trip through `GetNodeByPath(entry.Path)`.
- `Kind == ContainerPresence` uses the container member path for display, sets `Node == null`, and does not guarantee `GetNodeByPath(entry.Path)` resolution.
- Missing slots and actual `null` values are distinguished by `ValueState`.
- This PR intentionally does not implement full XML XPath.

## Reports

- T-077 implementation: `reports/task-t-077-implementation-20260623091447.md`
- T-077 review: `reports/task-t-077-review-20260623091556.md`
- T-077 review fix: `reports/task-t-077-review-fix-20260623092446.md`
- T-078 implementation: `reports/task-t-078-implementation-20260623093152.md`
- T-078 review: `reports/task-t-078-review-20260623093200.md`
- T-079 implementation: `reports/task-t-079-implementation-20260623094407.md`
- T-079 review: `reports/task-t-079-review-20260623094407.md`
- T-080 implementation: `reports/task-t-080-implementation-20260623095422.md`
- T-080 review: `reports/task-t-080-review-20260623095422.md`
- T-081 implementation: `reports/task-t-081-implementation-20260623100427.md`
- T-081 review: `reports/task-t-081-review-20260623100427.md`
- T-082 verification: `reports/task-t-082-verification-20260623101834.md`
- T-082 final review: `reports/task-t-082-final-review-20260623101834.md`

## Validation

- T-077 implementation worker: focused unit tests passed, 20 tests.
- T-077 implementation worker: full unit test project passed, 23 tests.
- T-077 review worker: focused unit tests passed, 20 tests.
- T-078 implementation worker: focused E2E tests passed, 4 tests.
- T-078 implementation worker: focused unit tests passed, 1 test.
- T-078 review worker: focused E2E/unit tests passed, no findings.
- T-079 implementation worker: focused E2E tests passed, 4 tests.
- T-079 implementation worker: focused unit tests passed, 1 test.
- T-079 review worker: focused E2E tests passed, 4 tests.
- T-079 review worker: focused unit tests passed, 1 test.
- T-079 review worker: `git diff --check` passed, no findings.
- T-080 implementation worker: focused E2E tests passed, 5 tests.
- T-080 implementation worker: focused unit tests passed, 3 tests.
- T-080 review worker: focused E2E tests passed, 5 tests.
- T-080 review worker: focused unit tests passed, 3 tests.
- T-080 review worker: `git diff --check` passed, no findings.
- T-081 implementation worker: package README inclusion check passed.
- T-081 implementation worker: `git diff --check` passed.
- T-081 review worker: final rereview no findings.
- T-082 verification worker: `dotnet test SSC.sln --configuration Release` passed. Unit tests 29, E2E tests 61.
- T-082 verification worker: `git diff --check` passed.
- T-082 final review worker: PR body and branch diff reviewed, no findings.
- Markdown checks were not run, per user direction.

## Risk

- No unresolved implementation, docs, or review blocker is currently known.
- Markdown checks were intentionally skipped by user direction.
