### PR TITLE
Sample: Sprache XML-like compare csx

### DIFF
--- a/reports/task-t-083-implementation-20260623132920.md
+++ b/reports/task-t-083-implementation-20260623132920.md
@@ -1,0 +1,74 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-083 Sprache `.csx` XML-like compare sample の追加
+- タスク種別: TDD 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザー指示の sample 実装であり、コード実装は sub-agent に委譲する。親 agent は scope 管理、report 確認、Git 操作を担当する。
+
+## 対象範囲
+
+- 対象: Sprache `2.3.1` を使う `.csx` sample、数字始まり element / attribute name を許可する parser、SSC 比較 sample、実行または代替検証
+
+## 対象外
+
+- 対象外: SSC runtime 本体の public API 変更、標準 XML 仕様準拠 parser 化、Markdown 検査、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `test -f samples/xml-compare-sprache/compare-xml.csx`: 失敗（実装前）。sample file が未作成であることを確認。
+  - `dotnet build src/SSC/SSC.csproj --configuration Release`: 成功。sample から参照する `SSC.dll` を生成。
+  - `dotnet tool install --tool-path /tmp/dotnet-tools dotnet-script`: 成功。repo 外一時 tool path に `dotnet-script` 2.0.1 をインストール。
+  - `/tmp/dotnet-tools/dotnet-script samples/xml-compare-sprache/compare-xml.csx`: 失敗。`/home/ibis/.cache/dotnet-script` が read-only のため cache 書き込み不可。
+  - `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages /tmp/dotnet-tools/dotnet-script samples/xml-compare-sprache/compare-xml.csx`: 失敗。script の `equals` identifier と list 型変換を修正対象として検出。
+  - `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages /tmp/dotnet-tools/dotnet-script samples/xml-compare-sprache/compare-xml.csx`: 成功。数字始まり element / attribute name を parse し、SSC diff entries を出力。
+  - `dotnet script --version`: 成功。ユーザーが global install した `dotnet-script` 2.0.1 を確認。
+  - `dotnet script samples/xml-compare-sprache/compare-xml.csx`: 失敗。global tool は利用可能だが、default cache path `/home/ibis/.cache/dotnet-script` が read-only のため cache 書き込み不可。
+  - `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages dotnet script samples/xml-compare-sprache/compare-xml.csx`: 成功。global `dotnet script` でも数字始まり element / attribute name を parse し、SSC diff entries を出力。
+  - `rg -n "XDocument|System.Xml|#r \"nuget: Sprache, 2\\.3\\.1\"|Parse\\.Char\\(IsNameChar|<1root 2id" samples/xml-compare-sprache/compare-xml.csx`: 成功。Sprache 2.3.1 参照、数字始まり input、name parser を確認し、`XDocument` / `System.Xml` 使用なしを確認。
+  - `git diff --check`: 成功。
+  - `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages dotnet script samples/xml-compare-sprache/compare-xml.csx`: 成功。follow-up 後、runner が NuGet `devo6.SSC, 0.3.1-pre` と `#load "xml-like-parser.csx"` を使う構成で実行できることを確認。
+  - `rg -n "XDocument|System\\.Xml|XmlReader|#r \"nuget: devo6\\.SSC, 0\\.3\\.1-pre\"|#load \"xml-like-parser\\.csx\"|Parse\\.Char\\(IsNameChar|<1root 2id" samples/xml-compare-sprache`: 成功。NuGet SSC 参照、parser 分離、数字始まり input/name grammar を確認し、標準 XML parser 使用なしを確認。
+  - `git diff --check`: 成功。follow-up 後の差分に whitespace error なし。
+  - Markdown 検査: ユーザー指示により未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `samples/xml-compare-sprache/compare-xml.csx`
+  - `samples/xml-compare-sprache/xml-like-parser.csx`
+  - `src/SSC/ParallelPathAccessExtensions.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `README.md`
+  - `reports/task-t-083-implementation-20260623132920.md`
+  - `tasks/tasks-status.md`
+  - `AGENTS.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `samples/xml-compare-sprache/compare-xml.csx` を追加した。
+  - `.csx` は `#r "nuget: Sprache, 2.3.1"` を使い、標準 XML parser ではなく Sprache parser combinator で XML-like input を parse する。
+  - name grammar は最初の文字を含めて `A-Z` / `a-z` / digit / `_` / `:` / `-` を許可し、sample input の `<1root 2id="left">...</1root>` を受け付ける。
+  - start tag / end tag name の一致を parser 内で検証する。
+  - attributes は名前順に deterministic な model へ変換し、list item には `[CompareKey]` を設定した。
+  - parser 結果を `XmlDocumentModel` / `XmlElementModel` / `XmlAttributeModel` に変換し、`ParallelCompareApi.Compare()` と `GetDiffEntries()` で差分 path / values / state を表示する。
+  - 実行結果として、`Root.Attributes[2id].Value`、`Root.Children[1root/2item#0].Text`、`Root.Children[1root/2item#0].Attributes[3code].Value` など、数字始まり element / attribute name を含む diff entries が出力された。
+  - follow-up で parser 実装を `samples/xml-compare-sprache/xml-like-parser.csx` に分離し、`compare-xml.csx` は実行 runner として NuGet `devo6.SSC, 0.3.1-pre` を参照する形に変更した。
+  - follow-up 後も数字始まり element / attribute name の parse check と SSC diff entry 出力 check は維持されている。
+  - SSC runtime 本体の public API 変更、`.sln` への sample project 追加、Markdown 検査、PR 操作、commit/push には踏み込んでいない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。`dotnet-script` は repo 外の `/tmp/dotnet-tools` に一時インストールして検証した。
+  - follow-up 後も未解決リスクなし。SSC 参照はローカル DLL ではなく NuGet package を使用している。

--- a/reports/task-t-083-review-20260623132920.md
+++ b/reports/task-t-083-review-20260623132920.md
@@ -1,0 +1,71 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-083 Sprache `.csx` XML-like compare sample のコードレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer とユーザー指示により、コードレビューは sub-agent に委譲する。実装者とは別 agent による独立レビューを行う。
+
+## 対象範囲
+
+- 対象: T-083 の task-scoped diff、Sprache parser、数字始まり element / attribute name、SSC 比較 sample、検証 evidence
+
+## 対象外
+
+- 対象外: Markdown 検査、SSC runtime 本体の public API 変更、PR 操作、commit/push
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet build src/SSC/SSC.csproj --configuration Release`: 成功。
+  - `rg -n "XDocument|System\\.Xml|XmlDocument|XmlReader|nuget: Sprache, 2\\.3\\.1|Parse\\.Char\\(IsNameChar|<1root 2id|<2item 3code|<4leaf 5attr|CompareKey|GetDiffEntries|ParallelCompareApi\\.Compare" samples/xml-compare-sprache/compare-xml.csx`: 成功。Sprache 2.3.1、数字始まり input、name parser、CompareKey、SSC 比較導線を確認し、標準 XML parser 使用なしを確認。
+  - `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages dotnet script samples/xml-compare-sprache/compare-xml.csx`: 成功。数字始まり element / attribute name を含む diff entries を出力。
+  - `git diff --check`: 成功。
+  - Markdown 検査: ユーザー指示により未実行。
+  - follow-up review: `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages dotnet script samples/xml-compare-sprache/compare-xml.csx`: 成功。NuGet `devo6.SSC, 0.3.1-pre` と `#load "xml-like-parser.csx"` の構成で数字始まり element / attribute name を含む diff entries を出力。
+  - follow-up review: `rg -n "XDocument|System\\.Xml|XmlDocument|XmlReader|#r \"../../src/SSC|#r \"nuget: devo6\\.SSC, 0\\.3\\.1-pre\"|#load \"xml-like-parser\\.csx\"|#r \"nuget: Sprache, 2\\.3\\.1\"|Parse\\.Char\\(IsNameChar|<1root 2id|<2item 3code|<4leaf 5attr" samples/xml-compare-sprache`: 成功。parser 分離、NuGet SSC 参照、Sprache 2.3.1、数字始まり input/name grammar を確認し、標準 XML parser とローカル DLL 参照がないことを確認。
+  - follow-up review: `git diff --check`: 成功。
+  - follow-up review: Markdown 検査はユーザー指示により未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `samples/xml-compare-sprache/compare-xml.csx`
+  - `reports/task-t-083-implementation-20260623132920.md`
+  - `reports/task-t-083-review-20260623132920.md`
+  - `tasks/tasks-status.md`
+  - `AGENTS.md`
+  - follow-up review: `samples/xml-compare-sprache/xml-like-parser.csx`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+  - follow-up review:
+    - P3: `tasks/tasks-status.md:21` の T-083 Output に、follow-up で追加された `samples/xml-compare-sprache/xml-like-parser.csx` が含まれていない。sample 実行自体は成功するため normal-path blocker ではないが、parser 実装と runner を分離した追加要件の成果物 tracking として不完全。
+    - disposition: 親 agent が `tasks/tasks-status.md` の T-083 Output に `samples/xml-compare-sprache/xml-like-parser.csx` を追加して解消した。
+
+## 結果
+
+- 結果:
+  - Sprache `2.3.1` を使う `.csx` sample として T-083 scope に収まっていることを確認した。
+  - `Name` parser は `Parse.Char(IsNameChar, "name character").AtLeastOnce().Text()` で、先頭文字も数字を許可している。
+  - `XDocument` / `System.Xml` / `XmlReader` などの標準 XML parser 依存は見つからなかった。
+  - parser は element / attribute / text / nested element を parse し、`EndTag(name)` で start tag / end tag name の一致を検証している。
+  - model 変換では attribute を名前順に整列し、`XmlElementModel.Path` と `XmlAttributeModel.Name` に `[CompareKey]` を付与しており、比較 path は deterministic に生成される。
+  - sample 実行で `Root.Attributes[2id].Value`、`Root.Children[1root/2item#0].Text`、`Root.Children[1root/2item#0].Attributes[3code].Value` など、数字始まり element / attribute name を含む差分出力を確認した。
+  - `.csx` の `#r "../../src/SSC/bin/Release/net8.0/SSC.dll"` は repo root から `dotnet script samples/xml-compare-sprache/compare-xml.csx` を実行する想定で動作することを確認した。
+  - follow-up review: `xml-like-parser.csx` に Sprache parser 実装が分離され、`compare-xml.csx` は runner として `#load "xml-like-parser.csx"` していることを確認した。
+  - follow-up review: `compare-xml.csx` は `#r "nuget: devo6.SSC, 0.3.1-pre"` で SSC を参照しており、ローカル DLL 参照は残っていないことを確認した。
+  - follow-up review: Sprache `2.3.1` 使用、数字始まり element / attribute name 許可、start/end tag name 一致検証、標準 XML parser 不使用は維持されている。
+  - follow-up review: sample 実行 evidence は現行ファイル構成と一致している。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未解決リスクなし。
+  - Markdown 検査はユーザー指示により未実行。
+  - follow-up review: 実装 normal path の未解決リスクはなし。tracking 上の `xml-like-parser.csx` Output 記載漏れは親 agent 側で修正済み。

--- a/samples/xml-compare-sprache/compare-xml.csx
+++ b/samples/xml-compare-sprache/compare-xml.csx
@@ -1,0 +1,130 @@
+#r "nuget: Sprache, 2.3.1"
+#r "nuget: devo6.SSC, 0.3.1-pre"
+#load "xml-like-parser.csx"
+
+#nullable enable
+
+using SSC;
+
+const string leftXml = """
+<1root 2id="left" stable="same">
+  <2item 3code="A">left text</2item>
+  <group>
+    <4leaf 5attr="left">10</4leaf>
+  </group>
+</1root>
+""";
+
+const string rightXml = """
+<1root 2id="right" stable="same">
+  <2item 3code="B">right text</2item>
+  <group>
+    <4leaf 5attr="right">20</4leaf>
+  </group>
+</1root>
+""";
+
+XmlElement leftParsed = XmlLikeParser.ParseDocument(leftXml);
+XmlElement rightParsed = XmlLikeParser.ParseDocument(rightXml);
+
+Require(leftParsed.Name == "1root", "element names may start with a digit");
+Require(leftParsed.Attributes.Any(attribute => attribute.Name == "2id"), "attribute names may start with a digit");
+
+XmlDocumentModel[] models =
+[
+    new XmlDocumentModel { Root = XmlModelBuilder.ToModel(leftParsed) },
+    new XmlDocumentModel { Root = XmlModelBuilder.ToModel(rightParsed) },
+];
+
+CompareResult<XmlDocumentModel> result = ParallelCompareApi.Compare(models);
+IReadOnlyList<ParallelDiffEntry> diffs = result.GetDiffEntries();
+
+Require(diffs.Any(entry => entry.Path == "Root.Attributes[2id].Value"), "numeric attribute diff is present");
+Require(diffs.Any(entry => entry.Path == "Root.Children[1root/2item#0].Text"), "numeric element text diff is present");
+
+foreach (ParallelDiffEntry diff in diffs)
+{
+    Console.WriteLine(diff);
+}
+
+public static class XmlModelBuilder
+{
+    public static XmlElementModel ToModel(XmlElement element)
+    {
+        return ToModel(element, element.Name, ordinal: 0);
+    }
+
+    private static XmlElementModel ToModel(XmlElement element, string parentPath, int ordinal)
+    {
+        string path = ordinal == 0 && string.Equals(parentPath, element.Name, StringComparison.Ordinal)
+            ? element.Name
+            : $"{parentPath}/{element.Name}#{ordinal}";
+
+        var text = string.Concat(element.Children
+            .Where(child => child.Text is not null)
+            .Select(child => child.Text!.Trim())
+            .Where(textPart => textPart.Length > 0));
+
+        var elementOrdinalByName = new Dictionary<string, int>(StringComparer.Ordinal);
+        var children = new List<XmlElementModel>();
+        foreach (XmlElement childElement in element.Children
+            .Where(child => child.Element is not null)
+            .Select(child => child.Element!))
+        {
+            elementOrdinalByName.TryGetValue(childElement.Name, out var childOrdinal);
+            elementOrdinalByName[childElement.Name] = childOrdinal + 1;
+            children.Add(ToModel(childElement, path, childOrdinal));
+        }
+
+        return new XmlElementModel
+        {
+            Path = path,
+            Name = element.Name,
+            Text = text,
+            Attributes = element.Attributes
+                .OrderBy(attribute => attribute.Name, StringComparer.Ordinal)
+                .Select(attribute => new XmlAttributeModel
+                {
+                    Name = attribute.Name,
+                    Value = attribute.Value,
+                })
+                .ToList(),
+            Children = children,
+        };
+    }
+}
+
+public sealed class XmlDocumentModel
+{
+    public XmlElementModel Root { get; init; } = new();
+}
+
+public sealed class XmlElementModel
+{
+    [CompareKey]
+    public string Path { get; init; } = string.Empty;
+
+    public string Name { get; init; } = string.Empty;
+
+    public string Text { get; init; } = string.Empty;
+
+    public List<XmlAttributeModel> Attributes { get; init; } = [];
+
+    public List<XmlElementModel> Children { get; init; } = [];
+}
+
+public sealed class XmlAttributeModel
+{
+    [CompareKey]
+    public string Name { get; init; } = string.Empty;
+
+    public string Value { get; init; } = string.Empty;
+}
+
+static void Require(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}

--- a/samples/xml-compare-sprache/xml-like-parser.csx
+++ b/samples/xml-compare-sprache/xml-like-parser.csx
@@ -1,0 +1,84 @@
+#nullable enable
+
+using Sprache;
+
+public static class XmlLikeParser
+{
+    private static readonly Parser<string> Name =
+        Parse.Char(IsNameChar, "name character").AtLeastOnce().Text();
+
+    private static readonly Parser<string> QuotedValue =
+        from open in Parse.Char('"')
+        from value in Parse.CharExcept('"').Many().Text()
+        from close in Parse.Char('"')
+        select value;
+
+    private static readonly Parser<XmlAttributeNode> Attribute =
+        from leading in Parse.WhiteSpace.AtLeastOnce()
+        from name in Name
+        from beforeEquals in Parse.WhiteSpace.Many()
+        from eq in Parse.Char('=')
+        from afterEquals in Parse.WhiteSpace.Many()
+        from value in QuotedValue
+        select new XmlAttributeNode(name, value);
+
+    private static readonly Parser<XmlContent> Text =
+        Parse.CharExcept('<').AtLeastOnce().Text().Select(XmlContent.FromText);
+
+    private static readonly Parser<XmlContent> Content =
+        Parse.Ref(() => Element.Select(XmlContent.FromElement).Or(Text));
+
+    private static readonly Parser<XmlElement> Element =
+        from open in Parse.Char('<')
+        from name in Name
+        from attributes in Attribute.Many()
+        from beforeClose in Parse.WhiteSpace.Many()
+        from close in Parse.Char('>')
+        from children in Content.Many()
+        from end in EndTag(name)
+        select new XmlElement(name, attributes.ToArray(), children.ToArray());
+
+    public static XmlElement ParseDocument(string text)
+    {
+        return Element.End().Parse(text.Trim());
+    }
+
+    private static Parser<string> EndTag(string expectedName)
+    {
+        return
+            from open in Parse.String("</")
+            from actualName in Name
+            from beforeClose in Parse.WhiteSpace.Many()
+            from close in Parse.Char('>')
+            where string.Equals(actualName, expectedName, StringComparison.Ordinal)
+            select actualName;
+    }
+
+    private static bool IsNameChar(char value)
+    {
+        return char.IsLetterOrDigit(value)
+            || value == '_'
+            || value == ':'
+            || value == '-';
+    }
+}
+
+public sealed record XmlElement(
+    string Name,
+    IReadOnlyList<XmlAttributeNode> Attributes,
+    IReadOnlyList<XmlContent> Children);
+
+public sealed record XmlAttributeNode(string Name, string Value);
+
+public sealed record XmlContent(XmlElement? Element, string? Text)
+{
+    public static XmlContent FromElement(XmlElement element)
+    {
+        return new XmlContent(element, null);
+    }
+
+    public static XmlContent FromText(string text)
+    {
+        return new XmlContent(null, text);
+    }
+}

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,7 @@
 
 - Status: Done
 - Notes:
+  - T-083 を完了し、Sprache `2.3.1` を使う `.csx` sample として、数字始まり element / attribute name を許可する XML-like parser と SSC 比較出力を追加した
   - T-076 系の XPath-like path access / diff entry helper 実装は T-077 から T-081 まで完了した
   - T-081 を完了し、README に XPath-like path access / diff entry の最小利用例を追加し、public API 設計書を実装後 API 名・契約・表示例と同期した
   - T-081 では docs review の P2 指摘 2 件を修正し、最終再レビューで指摘なしを確認した。Markdown 検査はユーザー指示により未実施

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -12,6 +12,24 @@
 
 ## Done
 
+- T-083: Sprache `.csx` XML-like compare sample の追加
+  - Status: 完了（Sprache `2.3.1` の `.csx` sample を追加し、数字始まり element / attribute name を許可する parser と SSC 比較出力を検証、レビュー指摘なし）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-082 T-076 系 API の統合検証と PR 仕上げ
+  - Output:
+    - `samples/xml-compare-sprache/compare-xml.csx`
+    - `samples/xml-compare-sprache/xml-like-parser.csx`
+    - `reports/task-t-083-implementation-20260623132920.md`
+    - `reports/task-t-083-review-20260623132920.md`
+    - PR #33
+  - Verification:
+    - `dotnet build src/SSC/SSC.csproj --configuration Release` 成功
+    - `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages dotnet script samples/xml-compare-sprache/compare-xml.csx` 成功
+    - `git diff --check` 成功
+    - Markdown 検査はユーザー指示により未実施
+
 - T-082: T-076 系 API の統合検証と PR 仕上げ
   - Status: 完了（full validation と最終レビューをサブエージェントで実施し、PR body / tracking を最終同期）
   - Phase: Phase 4


### PR DESCRIPTION
## Scope

No linked GitHub issue. This PR implements the user-requested sample from chat: a C# script using Sprache to parse XML-like input and compare it with SSC.

## What changed

- Added `samples/xml-compare-sprache/compare-xml.csx` as the executable runner.
- Added `samples/xml-compare-sprache/xml-like-parser.csx` as the parser implementation loaded by the runner.
- Uses `#r "nuget: Sprache, 2.3.1"`.
- Uses `#r "nuget: devo6.SSC, 0.3.1-pre"` instead of a local SSC DLL reference.
- Allows element and attribute names that start with digits, such as `<1root 2id="left">`.
- Avoids `XDocument`, `System.Xml`, and other standard XML parsers because standard XML names do not allow this shape.
- Converts parsed elements and attributes into `[CompareKey]`-based SSC models.
- Runs `ParallelCompareApi.Compare()` and prints `GetDiffEntries()` output.

## Validation

- `XDG_CACHE_HOME=/tmp/dotnet-script-cache DOTNET_CLI_HOME=/tmp/dotnet-cli-home NUGET_PACKAGES=/tmp/nuget-packages dotnet script samples/xml-compare-sprache/compare-xml.csx`: passed.
- `git diff --check`: passed.
- Review sub-agent: follow-up P3 tracking finding fixed, no implementation blocker.
- Markdown checks were not run, per user direction.

## Reports

- Implementation: `reports/task-t-083-implementation-20260623132920.md`
- Review: `reports/task-t-083-review-20260623132920.md`

## Risk

- No unresolved implementation or review risk is known.
- The parser is intentionally XML-like sample code, not a full XML specification implementation.
