### PR TITLE
Recognize public fields (including IEnumerable<T>) in metadata and generated views (fix #34)

### DIFF
--- a/src/SSC.Generators/ParallelViewGenerator.cs
+++ b/src/SSC.Generators/ParallelViewGenerator.cs
@@ -187,7 +187,7 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
             }
 
             var members = new List<MemberShape>();
-            foreach (var property in GetComparableProperties(type))
+            foreach (var property in GetComparableMembers(type))
             {
                 if (TryGetDictionaryValueType(property.Type, out var dictionaryElementType)
                     && dictionaryElementType is INamedTypeSymbol dictionaryElementNamedType)
@@ -214,34 +214,58 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         return shapes;
     }
 
-    private static IEnumerable<IPropertySymbol> GetComparableProperties(INamedTypeSymbol type)
+    private static IEnumerable<IFieldOrPropertySymbol> GetComparableMembers(INamedTypeSymbol type)
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
         for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
         {
-            foreach (var property in current.GetMembers().OfType<IPropertySymbol>())
+            foreach (var member in current.GetMembers())
             {
-                if (!seen.Add(property.Name))
+                if (member is IPropertySymbol property)
                 {
+                    if (!seen.Add(property.Name))
+                    {
+                        continue;
+                    }
+
+                    if (property.IsStatic || property.GetMethod is null || property.Parameters.Length > 0)
+                    {
+                        continue;
+                    }
+
+                    if (property.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        continue;
+                    }
+
+                    if (HasAttribute(property, CompareIgnoreAttributeMetadataName))
+                    {
+                        continue;
+                    }
+
+                    yield return new FieldOrPropertySymbol(property.Name, property.Type);
                     continue;
                 }
 
-                if (property.IsStatic || property.GetMethod is null || property.Parameters.Length > 0)
+                if (member is IFieldSymbol field)
                 {
-                    continue;
-                }
+                    if (!seen.Add(field.Name))
+                    {
+                        continue;
+                    }
 
-                if (property.DeclaredAccessibility != Accessibility.Public)
-                {
-                    continue;
-                }
+                    if (field.IsStatic || field.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        continue;
+                    }
 
-                if (HasAttribute(property, CompareIgnoreAttributeMetadataName))
-                {
-                    continue;
-                }
+                    if (HasAttribute(field, CompareIgnoreAttributeMetadataName))
+                    {
+                        continue;
+                    }
 
-                yield return property;
+                    yield return new FieldOrPropertySymbol(field.Name, field.Type);
+                }
             }
         }
     }
@@ -392,6 +416,20 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         }
 
         return sanitized;
+    }
+
+    private interface IFieldOrPropertySymbol
+    {
+        string Name { get; }
+
+        ITypeSymbol Type { get; }
+    }
+
+    private sealed class FieldOrPropertySymbol(string name, ITypeSymbol type) : IFieldOrPropertySymbol
+    {
+        public string Name { get; } = name;
+
+        public ITypeSymbol Type { get; } = type;
     }
 
     private enum MemberKind

--- a/src/SSC/Internal/TypeMetadataResolver.cs
+++ b/src/SSC/Internal/TypeMetadataResolver.cs
@@ -5,23 +5,64 @@ namespace SSC.Internal;
 
 internal static class TypeMetadataResolver
 {
-    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
-    private static readonly ConcurrentDictionary<Type, PropertyInfo?> CompareKeyCache = new();
+    private static readonly ConcurrentDictionary<Type, ComparableMember[]> MemberCache = new();
+    private static readonly ConcurrentDictionary<Type, ComparableMember?> CompareKeyCache = new();
 
-    public static PropertyInfo[] GetComparableProperties(Type type)
+    public static ComparableMember[] GetComparableMembers(Type type)
     {
-        return PropertyCache.GetOrAdd(type, static t =>
+        return MemberCache.GetOrAdd(type, static t =>
             t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(property => property.GetMethod is not null)
                 .Where(property => property.GetIndexParameters().Length == 0)
                 .Where(property => property.GetCustomAttribute<CompareIgnoreAttribute>() is null)
+                .Select(property => new ComparableMember(property))
+                .Concat(t.GetFields(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(field => field.GetCustomAttribute<CompareIgnoreAttribute>() is null)
+                    .Select(field => new ComparableMember(field)))
                 .ToArray());
     }
 
-    public static PropertyInfo? GetCompareKeyProperty(Type type)
+    public static ComparableMember? GetCompareKeyMember(Type type)
     {
         return CompareKeyCache.GetOrAdd(type, static t =>
-            t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .FirstOrDefault(property => property.GetCustomAttribute<CompareKeyAttribute>() is not null));
+        {
+            var property = t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(property => property.GetCustomAttribute<CompareKeyAttribute>() is not null);
+            if (property is not null)
+            {
+                return new ComparableMember(property);
+            }
+
+            var field = t.GetFields(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(field => field.GetCustomAttribute<CompareKeyAttribute>() is not null);
+            return field is null ? null : new ComparableMember(field);
+        });
     }
+}
+
+internal sealed class ComparableMember
+{
+    private readonly PropertyInfo? _property;
+    private readonly FieldInfo? _field;
+
+    public ComparableMember(PropertyInfo property)
+    {
+        _property = property;
+        Name = property.Name;
+        MemberType = property.PropertyType;
+    }
+
+    public ComparableMember(FieldInfo field)
+    {
+        _field = field;
+        Name = field.Name;
+        MemberType = field.FieldType;
+    }
+
+    public string Name { get; }
+
+    public Type MemberType { get; }
+
+    public object? GetValue(object instance) =>
+        _property is not null ? _property.GetValue(instance) : _field!.GetValue(instance);
 }

--- a/src/SSC/ParallelCompareApi.cs
+++ b/src/SSC/ParallelCompareApi.cs
@@ -119,7 +119,7 @@ public static class ParallelCompareApi
             context.Trace("node", path, ("nodeType", typeof(TNode)), ("nodeKind", "Object"), ("keyText", keyText));
         }
 
-        foreach (var property in TypeMetadataResolver.GetComparableProperties(typeof(TNode)))
+        foreach (var property in TypeMetadataResolver.GetComparableMembers(typeof(TNode)))
         {
             var propertyPath = $"{path}.{property.Name}";
             if (context.IsTraceEnabled)
@@ -127,13 +127,13 @@ public static class ParallelCompareApi
                 context.Trace(
                     "metadata",
                     propertyPath,
-                    ("declaredType", property.PropertyType),
-                    ("container", GetContainerCategory(property.PropertyType)));
+                    ("declaredType", property.MemberType),
+                    ("container", GetContainerCategory(property.MemberType)));
             }
 
             var memberSlots = BuildMemberSlots(slots, property, propertyPath, context);
 
-            if (TryGetDictionaryTypes(property.PropertyType, out var keyType, out var elementType))
+            if (TryGetDictionaryTypes(property.MemberType, out var keyType, out var elementType))
             {
                 if (context.IsTraceEnabled)
                 {
@@ -144,18 +144,18 @@ public static class ParallelCompareApi
                 continue;
             }
 
-            if (TryGetSequenceElementType(property.PropertyType, out elementType))
+            if (TryGetSequenceElementType(property.MemberType, out elementType))
             {
                 if (context.IsTraceEnabled)
                 {
                     context.Trace("metadata", propertyPath, ("elementType", elementType));
                 }
-                var children = BuildSequenceChildren(memberSlots, property.PropertyType, elementType, propertyPath, context);
+                var children = BuildSequenceChildren(memberSlots, property.MemberType, elementType, propertyPath, context);
                 node.SetChildren(property.Name, children, memberSlots.Select(slot => slot.State).ToArray());
                 continue;
             }
 
-            var memberNode = BuildNode(property.PropertyType, memberSlots, propertyPath, context, keyText: null);
+            var memberNode = BuildNode(property.MemberType, memberSlots, propertyPath, context, keyText: null);
             node.SetMemberNode(property.Name, memberNode);
         }
 
@@ -164,7 +164,7 @@ public static class ParallelCompareApi
 
     private static NodeSlot[] BuildMemberSlots(
         NodeSlot[] parentSlots,
-        PropertyInfo property,
+        ComparableMember property,
         string path,
         CompareContext context)
     {
@@ -186,7 +186,7 @@ public static class ParallelCompareApi
             object? value;
             try
             {
-                value = property.GetValue(parentSlots[modelIndex].Value);
+                value = property.GetValue(parentSlots[modelIndex].Value!);
             }
             catch (Exception ex)
             {
@@ -195,7 +195,7 @@ public static class ParallelCompareApi
                     path,
                     modelIndex,
                     null,
-                    $"failed to get property '{property.Name}': {ex.Message}");
+                    $"failed to get member '{property.Name}': {ex.Message}");
                 slots[modelIndex] = NodeSlot.Missing;
                 continue;
             }
@@ -320,8 +320,8 @@ public static class ParallelCompareApi
         string path,
         CompareContext context)
     {
-        var compareKeyProperty = TypeMetadataResolver.GetCompareKeyProperty(elementType);
-        if (compareKeyProperty is null)
+        var compareKeyMember = TypeMetadataResolver.GetCompareKeyMember(elementType);
+        if (compareKeyMember is null)
         {
             context.RecordExecutionError(
                 CompareIssueCode.CompareKeyNotFoundOnSequenceElement,
@@ -340,10 +340,10 @@ public static class ParallelCompareApi
                 path,
                 ("container", containerCategory),
                 ("elementType", elementType),
-                ("compareKey", compareKeyProperty.Name));
+                ("compareKey", compareKeyMember.Name));
         }
 
-        var keyType = compareKeyProperty.PropertyType;
+        var keyType = compareKeyMember.MemberType;
         var comparer = new KeyComparer(keyType, context.Configuration.StringKeyComparison);
         var maps = new Dictionary<object, object?>[containerSlots.Length];
         var union = new HashSet<object>(comparer);
@@ -412,7 +412,7 @@ public static class ParallelCompareApi
                 object? key;
                 try
                 {
-                    key = compareKeyProperty.GetValue(element);
+                    key = compareKeyMember.GetValue(element);
                 }
                 catch (Exception ex)
                 {
@@ -421,7 +421,7 @@ public static class ParallelCompareApi
                         path,
                         modelIndex,
                         null,
-                        $"failed to read compare key '{compareKeyProperty.Name}': {ex.Message}");
+                        $"failed to read compare key '{compareKeyMember.Name}': {ex.Message}");
                     continue;
                 }
 
@@ -432,7 +432,7 @@ public static class ParallelCompareApi
                         path,
                         modelIndex,
                         NullKeyText,
-                        $"compare key '{compareKeyProperty.Name}' is null.");
+                        $"compare key '{compareKeyMember.Name}' is null.");
                     continue;
                 }
 

--- a/src/SSC/ParallelDynamicAccessExtensions.cs
+++ b/src/SSC/ParallelDynamicAccessExtensions.cs
@@ -65,7 +65,10 @@ internal sealed class DynamicParallelNodeView : DynamicObject
         var property = _internalNode.ModelType.GetProperty(
             binder.Name,
             BindingFlags.Instance | BindingFlags.Public);
-        if (_internalNode.TryGetMemberNode(binder.Name, out var memberNode) || property is not null)
+        var field = property is null
+            ? _internalNode.ModelType.GetField(binder.Name, BindingFlags.Instance | BindingFlags.Public)
+            : null;
+        if (_internalNode.TryGetMemberNode(binder.Name, out var memberNode) || property is not null || field is not null)
         {
             result = DynamicParallelValuePathView.FromMember(_node, binder.Name, memberNode, _configuration);
             return true;
@@ -350,18 +353,20 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
                 continue;
             }
 
-            var property = currentValue.GetType().GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public);
-            if (property is null)
+            var currentType = currentValue.GetType();
+            var property = currentType.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public);
+            var field = property is null ? currentType.GetField(memberName, BindingFlags.Instance | BindingFlags.Public) : null;
+            if (property is null && field is null)
             {
                 result = null;
                 return false;
             }
 
-            var memberValue = property.GetValue(currentValue);
+            var memberValue = property is not null ? property.GetValue(currentValue) : field!.GetValue(currentValue);
             values[modelIndex] = memberValue;
             states[modelIndex] = memberValue is null ? NodePresenceState.PresentNull : NodePresenceState.PresentValue;
 
-            var candidateType = memberValue?.GetType() ?? property.PropertyType;
+            var candidateType = memberValue?.GetType() ?? property?.PropertyType ?? field!.FieldType;
             if (ParallelCompareApi.IsContainerType(candidateType))
             {
                 containerType ??= candidateType;
@@ -402,15 +407,17 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
 
         foreach (var memberName in _memberPath)
         {
-            var property = current.GetType().GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public);
-            if (property is null)
+            var currentType = current.GetType();
+            var property = currentType.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public);
+            var field = property is null ? currentType.GetField(memberName, BindingFlags.Instance | BindingFlags.Public) : null;
+            if (property is null && field is null)
             {
                 throw new MissingMemberException(
                     current.GetType().FullName,
                     memberName);
             }
 
-            current = property.GetValue(current);
+            current = property is not null ? property.GetValue(current) : field!.GetValue(current);
             if (current is null)
             {
                 state = NodePresenceState.PresentNull;

--- a/tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs
@@ -4,6 +4,42 @@ namespace SSC.E2E.Tests;
 
 public sealed class ContainerAndSelectManyE2ETests
 {
+
+    [Fact]
+    public void Compare_PublicIEnumerableField_NormalizesChildrenByCompareKey()
+    {
+        // Intent: public IEnumerable<T> field is a comparable container member, matching Issue #34.
+        var models = new[]
+        {
+            new FieldEnumerableDataset
+            {
+                Children = new[]
+                {
+                    new FieldEnumerableItem { ItemId = 1, Label = "left-1" },
+                    new FieldEnumerableItem { ItemId = 2, Label = "left-2" },
+                },
+            },
+            new FieldEnumerableDataset
+            {
+                Children = new[]
+                {
+                    new FieldEnumerableItem { ItemId = 1, Label = "right-1" },
+                    new FieldEnumerableItem { ItemId = 3, Label = "right-3" },
+                },
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+        var root = Assert.IsType<ParallelNode<FieldEnumerableDataset>>(result.Root);
+        var children = root.Children(model => model.Children);
+
+        Assert.Equal(new[] { "1", "2", "3" }, children.Select(child => child.KeyText).ToArray());
+        Assert.Equal("left-1", children[0][0]?.Label);
+        Assert.Equal("right-1", children[0][1]?.Label);
+        Assert.Equal(ValueState.Missing, children[1].GetState(1));
+        Assert.Equal(ValueState.Missing, children[2].GetState(0));
+    }
+
     [Fact]
     public void Compare_NormalizesDictionaryByUnionedKeys()
     {
@@ -863,6 +899,19 @@ public sealed class ContainerAndSelectManyE2ETests
     public sealed class NullableDataset
     {
         public List<NullableItem> Items { get; init; } = [];
+    }
+
+    public sealed class FieldEnumerableDataset
+    {
+        public IEnumerable<FieldEnumerableItem>? Children;
+    }
+
+    public sealed class FieldEnumerableItem
+    {
+        [CompareKey]
+        public int ItemId { get; init; }
+
+        public string? Label { get; init; }
     }
 
     public sealed class NullableItem

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -5,6 +5,40 @@ namespace SSC.E2E.Tests;
 
 public sealed class GeneratedProjectionE2ETests
 {
+
+    [Fact]
+    public void Compare_GeneratedProjection_PublicIEnumerableField_GeneratesContainerAccessor()
+    {
+        // Intent: Source Generator also recognizes public IEnumerable<T> fields as comparable containers, matching Issue #34.
+        var models = new[]
+        {
+            new GeneratedDataset
+            {
+                FieldChildren = new[]
+                {
+                    new GeneratedFieldChild { ChildId = 1, Label = "left-1" },
+                    new GeneratedFieldChild { ChildId = 2, Label = "left-2" },
+                },
+            },
+            new GeneratedDataset
+            {
+                FieldChildren = new[]
+                {
+                    new GeneratedFieldChild { ChildId = 1, Label = "right-1" },
+                    new GeneratedFieldChild { ChildId = 3, Label = "right-3" },
+                },
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        Assert.Equal(new[] { "1", "2", "3" }, root.FieldChildren.Select(child => child.NodeMeta.KeyText).ToArray());
+        Assert.Equal("left-1", root.FieldChildren[0].Label[0]);
+        Assert.Equal("right-1", root.FieldChildren[0].Label[1]);
+        Assert.Equal(ValueState.Missing, root.FieldChildren[1].Label.GetState(1));
+        Assert.Equal(ValueState.Missing, root.FieldChildren[2].Label.GetState(0));
+    }
+
     [Fact]
     public void Compare_GeneratedProjection_AllowsContainerScalarAndDictionaryAccess()
     {
@@ -366,6 +400,16 @@ public sealed class GeneratedDataset
     public List<GeneratedGroup> Groups { get; init; } = [];
 
     public Dictionary<string, int> Scores { get; init; } = new(StringComparer.Ordinal);
+
+    public IEnumerable<GeneratedFieldChild>? FieldChildren;
+}
+
+public sealed class GeneratedFieldChild
+{
+    [CompareKey]
+    public int ChildId { get; init; }
+
+    public string? Label { get; init; }
 }
 
 public sealed class GeneratedGroup


### PR DESCRIPTION
### Motivation
- Public field members such as `public IEnumerable<Item>? Children;` were not being discovered as comparable containers or compare-key members, causing runtime/dynamic and generated projections to miss these members (Issue #34). 
- The intent is to treat public fields equivalently to public properties for comparison, dynamic access, and source-generator view generation. 
- Tests and generator output should be updated so both runtime and generated views expose and normalize `IEnumerable<T>` fields by compare-key.

### Description
- Replace property-only metadata with a `ComparableMember` abstraction in `src/SSC/Internal/TypeMetadataResolver.cs` to include public fields and expose `Name`, `MemberType` and `GetValue` access. 
- Update the runtime pipeline in `src/SSC/ParallelCompareApi.cs` to iterate `GetComparableMembers(...)`, use `ComparableMember.MemberType` for container detection, and call `ComparableMember.GetValue(...)` when building member slots and reading compare keys. 
- Extend dynamic access in `src/SSC/ParallelDynamicAccessExtensions.cs` to resolve public fields as well as properties when creating runtime-derived container views and resolving member paths. 
- Extend the source generator in `src/SSC.Generators/ParallelViewGenerator.cs` to enumerate public fields in addition to properties (`GetComparableMembers` / `FieldOrPropertySymbol`) and emit generated view accessors for `IEnumerable<T>` fields. 
- Add E2E tests exercising runtime/dynamic and generated projection access to public `IEnumerable<T>` fields in `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs` and `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`.

### Testing
- Ran the focused test filter with `dotnet test SSC.sln --configuration Release --filter "FullyQualifiedName~PublicIEnumerableField"`, which passed the added checks for public field handling. 
- Ran the full test suite with `dotnet test SSC.sln --configuration Release`, which completed successfully with unit tests passing and E2E tests passing (Unit: 29 passed; E2E: 63 passed). 
- Compilation warnings were addressed where necessary (nullable access fixes) and no test failures remain after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b7c04bda88323a14139fe682825fe)