### PR TITLE
Fix generated object member views

### DIFF
--- a/Design/BreakingChanges.md
+++ b/Design/BreakingChanges.md
@@ -1,5 +1,23 @@
 # Breaking Changes
 
+## 2026-06-25
+
+### T-084 Source Generator object member の生成型変更
+
+- 対象:
+  - class / struct 型の direct object member に対する generated projection
+  - 例: `Document.Root`
+- 変更種別:
+  - generated API の source shape 変更
+- 影響:
+  - 従来は `Document.Root` 相当の member が `ParallelGeneratedValue<TModel, TMember>` として生成されていた
+  - T-084 以降は nested generated view として生成され、`root.Root.Name` / `root.Root.Attribute` / `root.Root.Range` のように配下 member を直接辿れる
+  - 旧 generated 型へ明示代入していた利用コードは source 互換でない可能性がある
+- 背景:
+  - gist `YXml.cs` の `Document.Root` 配下 generated member が不完全になり、Source Generator の型付き導線で class model 配下を辿れなかったため
+- 備考:
+  - 保守性と性能を優先し、object member は既存比較ツリーの member-node dictionary から直接 nested view 化する
+
 ## 2026-04-21
 
 ### T-070 `IParallelNode` への探索 API 追加

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -733,7 +733,8 @@ var root = ParallelCompareApi.Compare(models).AsGeneratedView();
 
 var leftMetricAt100 = root.Groups[0].Items[0].MetricA[0]; // 1.0
 var rightStateAt200 = root.Groups[0].Items[1].MetricA.GetState(1); // Missing
-var leftLabel = root.Groups[0].Items[0].Detail.Select(x => x.Label)[0]; // nested value path
+var leftLabel = root.Groups[0].Items[0].Detail.Label[0]; // direct nested object view
+var leftLabelViaSelector = root.Groups[0].Items[0].Detail.Select(x => x.Label)[0]; // compatible nested value path
 var nodeCount = root.Groups[0].Items[0].NodeMeta.Count;
 
 // model 単位で list を選択（Missing slot を除外）
@@ -747,6 +748,8 @@ var leftGroupIdAt0 = leftGroups[0].GroupId[0];
 - 投影切替の入口は `CompareResult` 拡張に統一する
 - generated API の node メタ情報は `NodeMeta` 配下に分離し、モデル同名メンバーと衝突させない
 - Dictionary も List と同様に key union 順の index でアクセスする（例: `root.Scores[0][1]`）
+- class / struct 型の object member は nested generated view として直接辿れる（例: `root.Root.Name[0]`）
+- object member view は互換導線として `Select(...)` も提供し、既存の nested value path 利用を維持する
 - `SelectModel(modelIndex)` は指定 model で `Missing` でない要素のみを返し、順序は key union 順を維持する
 - getter を再実行しない `GetState` 保証は dynamic value path に限定し、generated nested value path の parity はこの設計範囲に含めない
 
@@ -759,7 +762,10 @@ var leftGroupIdAt0 = leftGroups[0].GroupId[0];
 - value path:
   - `Property[modelIndex]`
   - `Property.GetState(modelIndex)`
-  - nested object path は `Select(...)` で連鎖
+- object path:
+  - class / struct 型の direct member は nested generated view として生成
+  - nested object path は直接 member access で連鎖
+  - `Select(...)` による nested value path は互換導線として維持
 - out of scope（初期版）:
   - 任意メソッド呼び出しの投影
   - indexer プロパティ投影

--- a/reports/task-t-084-implementation-20260625080132.md
+++ b/reports/task-t-084-implementation-20260625080132.md
@@ -1,0 +1,60 @@
+# T-084 Implementation Report
+
+## 対象
+
+- T-084: Source Generator の object member 展開不足修正
+- 参照 gist: https://gist.github.com/ssaattww/fbd4fa683d03cd03dd73df0fa37bf1a0
+- PR: #37
+
+## 再現
+
+更新後 gist の `global_Document.ParallelGenerated.g.cs` では、`Document.Root` が `ParallelGeneratedValue<Document, Node>` として生成され、`Root.Name` / `Root.Attribute` / `Root.Range` へ型付き generated view で進めない。
+
+追加した regression test:
+
+- `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers`
+
+初回実行結果:
+
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
+- 失敗
+- 主なエラー: `ParallelGeneratedValue<GeneratedDocument, GeneratedXmlNode>` に `Name` / `Attribute` / `Range` が存在しない
+
+## 実装
+
+- `src/SSC.Generators/ParallelViewGenerator.cs`
+  - scalar / container 以外の class / struct / interface member を `Object` member として分類
+  - object member の型も type graph に追加し、nested generated view を生成
+  - object member accessor は `ParallelGeneratedRuntime.RequireMemberNode<TParent, TMember>()` で既存比較ツリーの member node を取得して view 化
+  - generated view 自体に `GetState(modelIndex)` と `Select(...)` を追加
+- `src/SSC/GeneratedProjectionRuntime.cs`
+  - generated object member 用 helper `RequireMemberNode<TParent, TMember>()` を追加
+  - 性能優先で `GetDirectChildren()` 経由ではなく内部 member-node dictionary を直接参照
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - gist の `Document.Root` に相当する最小モデルを追加
+  - `root.Root.Name` / `root.Root.Attribute` / `root.Root.Range` を型付き generated view で辿ることを検証
+- `doc/design/detail/02-PublicApi.md`
+  - Source Generator が class / struct object member を direct nested view として生成する契約を追記
+
+## 検証
+
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
+  - 成功: 1 件
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests"`
+  - 成功: 9 件
+- `dotnet test SSC.sln --configuration Release`
+  - 成功: Unit 29 件 / E2E 64 件
+- `dotnet format SSC.sln --verify-no-changes`
+  - 成功
+- `git diff --check`
+  - 成功
+- `npm run lint:md`
+  - 失敗: `Missing script: "lint:md"`
+  - repo 側に Markdown lint script / 設定がないため unsupported と判定
+- gpt-5.5 high sub-agent review
+  - 通常パスを壊す実装バグなし
+  - generated API source shape 変更は breaking change として `Design/BreakingChanges.md` へ記録
+
+## 残リスク
+
+- Markdown lint はリポジトリ側に実行 script / 設定がないため unsupported。

--- a/reports/task-t-084-review-20260625080208.md
+++ b/reports/task-t-084-review-20260625080208.md
@@ -1,0 +1,136 @@
+# Sub-agent実行レポート
+
+## タスク
+
+T-084 Source Generator の object member 展開不足修正のコードレビュー。
+
+## sub-agentを使う理由
+
+review-enforcer / sub-agent-task-manager に従い、実装者とは独立した gpt-5.5 high のレビューで normal path の欠陥、設計逸脱、検証不足を確認するため。
+
+## 対象範囲
+
+- `src/SSC.Generators/ParallelViewGenerator.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- `doc/design/detail/02-PublicApi.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
+- `reports/task-t-084-implementation-20260625080132.md`
+
+## 対象外
+
+- unrelated な既存 warning の修正
+- T-084 と無関係な API 再設計
+- nested Codex / agent-spawning の実行
+- report 形式の変更
+
+## 実行コマンド
+
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - 成功。レビュー手順、report materialize、Markdown gate 要件を確認した。
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - 成功。sub-agent レポート形式と「agent-spawning 禁止」制約を確認した。
+- `sed -n '1,240p' reports/task-t-084-review-20260625080208.md`
+  - 成功。既存レポートの見出し順・空欄箇所を確認した。
+- `git status --short`
+  - 成功。レビュー対象ファイルと implementation / review report が変更・追加状態であることを確認した。
+- `git diff --stat`
+  - 成功。T-084 の変更範囲を確認した。
+- `git diff -- src/SSC.Generators/ParallelViewGenerator.cs`
+  - 成功。Source Generator の object member 分類と generated accessor 変更を確認した。
+- `git diff -- src/SSC/GeneratedProjectionRuntime.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - 成功。runtime helper と regression test 追加を確認した。
+- `git diff -- doc/design/detail/02-PublicApi.md tasks/tasks-status.md tasks/phases-status.md`
+  - 成功。設計書・進捗記録の変更を確認した。
+- `sed -n '1,260p' reports/task-t-084-implementation-20260625080132.md`
+  - 成功。実装報告の再現・実装・検証・残リスクを確認した。
+- `nl -ba src/SSC.Generators/ParallelViewGenerator.cs | sed -n '1,660p'`
+  - 成功。変更箇所の行番号付き確認を行った。
+- `nl -ba src/SSC/GeneratedProjectionRuntime.cs | sed -n '1,340p'`
+  - 成功。`RequireMemberNode<TParent,TMember>()` と既存 runtime 型の関係を確認した。
+- `rg -n "interface IParallelNodeInternal|TryGetMemberNode|GetDirectChildren|class ParallelNode|record.*ParallelNode|ParallelGeneratedRuntime" src tests`
+  - 成功。member-node 取得経路の既存利用箇所を確認した。
+- `nl -ba src/SSC/ParallelNode.cs | sed -n '1,320p'`
+  - 成功。`_memberNodes` / `TryGetMemberNode` / `GetDirectChildren` の実装を確認した。
+- `nl -ba src/SSC/Contracts.cs | sed -n '1,140p'`
+  - 成功。`IParallelNodeInternal` の契約を確認した。
+- `nl -ba src/SSC/ParallelCompareApi.cs | sed -n '1,220p'`
+  - 成功。object member が runtime で member node として materialize されることを確認した。
+- `nl -ba src/SSC/Internal/TypeMetadataResolver.cs | sed -n '1,220p'`
+  - 成功。runtime 側 comparable member 解決を確認した。
+- `nl -ba tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs | sed -n '1,520p'`
+  - 成功。追加 test と既存 generated projection test の関係を確認した。
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests"`
+  - 成功。9 件 passed。
+- `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/markdown-word-checker/SKILL.md`
+  - 成功。Markdown review gate の unsupported 記録要件を確認した。
+- `rg --files -g 'package.json' -g '.markdownlint*' -g 'tools/lint/**' -g '*.yml' -g '*.yaml'`
+  - 成功。`package.json` のみ検出し、Markdown lint 設定は検出できなかった。
+- `sed -n '1,200p' package.json`
+  - 成功。`package.json` は `{}` で lint script がないことを確認した。
+- `find tools -maxdepth 3 -type f -print | sort`
+  - 成功。`tools/` 配下に lint 設定ファイルがないことを確認した。
+- `npm run lint:md`
+  - 失敗。`Missing script: "lint:md"`。Markdown lint は repo 側未配線のため unsupported と判定する。
+- `dotnet test SSC.sln --configuration Release`
+  - 成功。Unit 29 件 / E2E 64 件 passed。
+- `rg -n "private static bool IsScalarType|DateOnly|TimeOnly|Guid|DateTimeOffset" src/SSC/ParallelCompareApi.cs src tests doc`
+  - 成功。runtime / generator の scalar 判定範囲を確認した。
+- `dotnet format SSC.sln --verify-no-changes`
+  - 成功。format 差分なし。
+- `git diff --check`
+  - 成功。whitespace error なし。
+
+## 対象ファイル
+
+- 確認した主要ファイル:
+  - `src/SSC.Generators/ParallelViewGenerator.cs`
+  - `src/SSC/GeneratedProjectionRuntime.cs`
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - `doc/design/detail/02-PublicApi.md`
+  - `tasks/tasks-status.md`
+  - `tasks/phases-status.md`
+  - `reports/task-t-084-implementation-20260625080132.md`
+  - `reports/task-t-084-review-20260625080208.md`
+- 周辺確認:
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/Contracts.cs`
+  - `src/SSC/ParallelCompareApi.cs`
+  - `src/SSC/Internal/TypeMetadataResolver.cs`
+  - `Design/BreakingChanges.md`
+  - `AGENTS.md`
+  - `package.json`
+  - `tools/`
+- 変更したファイル:
+  - `reports/task-t-084-review-20260625080208.md`
+- reviewer:
+  - gpt-5.5 high sub-agent `Tesla` による built-in review behavior。sub-agent 自身には nested Codex / agent-spawning を禁止した。
+
+## 指摘事項
+
+- blocking normal-path bugs:
+  - なし。`Document.Root` 相当の class member が nested generated view になり、`root.Root.Name` / `root.Root.Attribute` / `root.Root.Range` を辿る通常パスは追加 test と full solution test で通っている。
+- user-confirmation-required capability gaps:
+  - 解決済み: object member accessor の生成型が `ParallelGeneratedValue<TModel,TMember>` から nested generated view に変わるため、明示的に旧 generated 型へ代入していた利用コードは source 互換でない可能性がある。ユーザーは互換性より保守性・性能を優先する方針を明示済み。AGENTS.md の breaking change 記録要件に従い、`Design/BreakingChanges.md` へ T-084 を記録した。
+- non-blocking concerns held:
+  - Markdown lint は review gate 上 unsupported。`package.json` に `lint:md` script がなく、`tools/` 配下にも repo-local Markdown lint 設定がないため、Markdown 文面の機械チェックは実行できない。通常パスのコード挙動は `dotnet test SSC.sln --configuration Release` で確認済み。
+
+## 結果
+
+- 通常パスを壊す実装バグは見つからなかった。
+- `ParallelViewGenerator` は scalar / dictionary / sequence 以外の class / struct / interface member を object member として分類し、member node を `ParallelGeneratedRuntime.RequireMemberNode<TParent,TMember>()` 経由で nested view 化している。
+- runtime 側では `ParallelCompareApi.BuildNodeGeneric` が object/scalar member を `SetMemberNode` で保持し、`ParallelNode<T>` が `IParallelNodeInternal.TryGetMemberNode` を提供しているため、今回の helper は既存 materialized tree と整合している。
+- `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers` は gist の `Document.Root` 問題を最小再現し、`Name` / `Attribute` / `Range` へ型付きに辿れることを検証している。
+- 検証結果:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests"`: 9 件 passed。
+  - `dotnet test SSC.sln --configuration Release`: Unit 29 件 / E2E 64 件 passed。
+  - `dotnet format SSC.sln --verify-no-changes`: pass。
+  - `git diff --check`: pass。
+- レポートはこのファイルに直接更新した。
+
+## リスク
+
+- generated projection の型形状変更は `Design/BreakingChanges.md` に記録済み。
+- Markdown lint は repository 側に実行 script / 設定がないため unsupported。今回の Markdown 変更は目視レビューのみ。
+- review-enforcer 標準の sub-agent review は、ユーザー指示に従って gpt-5.5 high で実施済み。

--- a/src/SSC.Generators/ParallelViewGenerator.cs
+++ b/src/SSC.Generators/ParallelViewGenerator.cs
@@ -143,6 +143,22 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         source.AppendLine();
         source.AppendLine("    public global::SSC.ParallelGeneratedMeta NodeMeta => new(_node);");
         source.AppendLine();
+        if (!typeShape.Members.Any(static member => string.Equals(member.MemberName, "GetState", StringComparison.Ordinal)))
+        {
+            source.AppendLine("    public global::SSC.ValueState GetState(int modelIndex) => _node.GetState(modelIndex);");
+            source.AppendLine();
+        }
+
+        if (!typeShape.Members.Any(static member => string.Equals(member.MemberName, "Select", StringComparison.Ordinal)))
+        {
+            source.AppendLine("    public global::SSC.ParallelGeneratedValue<");
+            source.AppendLine($"        {modelTypeName},");
+            source.AppendLine("        TNext> Select<TNext>(global::System.Func<");
+            source.AppendLine($"        {modelTypeName},");
+            source.AppendLine("        TNext> selector) =>");
+            source.AppendLine("        new(_node, selector);");
+            source.AppendLine();
+        }
 
         foreach (var member in typeShape.Members)
         {
@@ -157,6 +173,20 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
                 var elementTypeName = member.ElementType.ToDisplayString(TypeDisplayFormat);
                 source.AppendLine($"    public global::SSC.ParallelGeneratedList<{elementTypeName}, {childViewName}> {memberName} =>");
                 source.AppendLine($"        new(_node.GetChildren<{elementTypeName}>(nameof({modelTypeName}.{memberName})), _node.Count, static child => new {childViewName}(child));");
+                source.AppendLine();
+                continue;
+            }
+
+            if (member.Kind == MemberKind.Object)
+            {
+                if (member.ObjectType is null || !viewNames.TryGetValue(member.ObjectType, out var childViewName))
+                {
+                    continue;
+                }
+
+                var objectTypeName = member.ObjectType.ToDisplayString(TypeDisplayFormat);
+                source.AppendLine($"    public {childViewName} {memberName} =>");
+                source.AppendLine($"        new(global::SSC.ParallelGeneratedRuntime.RequireMemberNode<{modelTypeName}, {objectTypeName}>(_node, nameof({modelTypeName}.{memberName}), nameof({modelTypeName}.{memberName})));");
                 source.AppendLine();
                 continue;
             }
@@ -202,6 +232,13 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
                 {
                     members.Add(MemberShape.Container(property.Name, sequenceElementNamedType));
                     queue.Enqueue(sequenceElementNamedType);
+                    continue;
+                }
+
+                if (TryGetObjectMemberType(property.Type, out var objectMemberType))
+                {
+                    members.Add(MemberShape.Object(property.Name, objectMemberType));
+                    queue.Enqueue(objectMemberType);
                     continue;
                 }
 
@@ -299,6 +336,26 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         return false;
     }
 
+    private static bool TryGetObjectMemberType(ITypeSymbol type, out INamedTypeSymbol objectType)
+    {
+        if (IsScalarType(type))
+        {
+            objectType = null!;
+            return false;
+        }
+
+        if (type is INamedTypeSymbol named
+            && (named.TypeKind == TypeKind.Class || named.TypeKind == TypeKind.Struct || named.TypeKind == TypeKind.Interface)
+            && named.SpecialType != SpecialType.System_Object)
+        {
+            objectType = named;
+            return true;
+        }
+
+        objectType = null!;
+        return false;
+    }
+
     private static bool TryGetSequenceElementType(ITypeSymbol type, out ITypeSymbol elementType)
     {
         if (type.SpecialType == SpecialType.System_String)
@@ -380,6 +437,48 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         return $"model.{escapedMemberName}";
     }
 
+    private static bool IsScalarType(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol named
+            && named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+            && named.TypeArguments.Length == 1)
+        {
+            return IsScalarType(named.TypeArguments[0]);
+        }
+
+        if (type.TypeKind == TypeKind.Enum)
+        {
+            return true;
+        }
+
+        return type.SpecialType is
+                SpecialType.System_Boolean or
+                SpecialType.System_Char or
+                SpecialType.System_SByte or
+                SpecialType.System_Byte or
+                SpecialType.System_Int16 or
+                SpecialType.System_UInt16 or
+                SpecialType.System_Int32 or
+                SpecialType.System_UInt32 or
+                SpecialType.System_Int64 or
+                SpecialType.System_UInt64 or
+                SpecialType.System_Decimal or
+                SpecialType.System_Single or
+                SpecialType.System_Double or
+                SpecialType.System_String
+            || IsWellKnownScalar(type);
+    }
+
+    private static bool IsWellKnownScalar(ITypeSymbol type)
+    {
+        var fullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return fullName is
+            "global::System.DateTime" or
+            "global::System.DateTimeOffset" or
+            "global::System.Guid" or
+            "global::System.TimeSpan";
+    }
+
     private static bool IsNullableValueType(ITypeSymbol type)
     {
         return type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
@@ -435,6 +534,7 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
     private enum MemberKind
     {
         Container,
+        Object,
         Value,
     }
 
@@ -453,11 +553,17 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
 
     private sealed class MemberShape
     {
-        private MemberShape(string memberName, MemberKind kind, INamedTypeSymbol? elementType, ITypeSymbol? valueType)
+        private MemberShape(
+            string memberName,
+            MemberKind kind,
+            INamedTypeSymbol? elementType,
+            INamedTypeSymbol? objectType,
+            ITypeSymbol? valueType)
         {
             MemberName = memberName;
             Kind = kind;
             ElementType = elementType;
+            ObjectType = objectType;
             ValueType = valueType;
         }
 
@@ -467,12 +573,17 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
 
         public INamedTypeSymbol? ElementType { get; }
 
+        public INamedTypeSymbol? ObjectType { get; }
+
         public ITypeSymbol? ValueType { get; }
 
         public static MemberShape Container(string memberName, INamedTypeSymbol elementType) =>
-            new(memberName, MemberKind.Container, elementType, null);
+            new(memberName, MemberKind.Container, elementType, null, null);
+
+        public static MemberShape Object(string memberName, INamedTypeSymbol objectType) =>
+            new(memberName, MemberKind.Object, null, objectType, null);
 
         public static MemberShape Value(string memberName, ITypeSymbol valueType) =>
-            new(memberName, MemberKind.Value, null, valueType);
+            new(memberName, MemberKind.Value, null, null, valueType);
     }
 }

--- a/src/SSC/GeneratedProjectionRuntime.cs
+++ b/src/SSC/GeneratedProjectionRuntime.cs
@@ -273,4 +273,31 @@ public static class ParallelGeneratedRuntime
             $"{apiName} can be used only with compare result nodes.",
             nameof(node));
     }
+
+    public static ParallelNode<TMember> RequireMemberNode<TParent, TMember>(
+        ParallelNode<TParent> node,
+        string memberName,
+        string apiName)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        ArgumentException.ThrowIfNullOrEmpty(memberName);
+        ArgumentException.ThrowIfNullOrEmpty(apiName);
+
+        var internalNode = (IParallelNodeInternal)node;
+        if (!internalNode.TryGetMemberNode(memberName, out var rawMemberNode))
+        {
+            throw new ArgumentException(
+                $"{apiName} cannot find generated member node '{memberName}'.",
+                nameof(memberName));
+        }
+
+        if (rawMemberNode is ParallelNode<TMember> memberNode)
+        {
+            return memberNode;
+        }
+
+        throw new ArgumentException(
+            $"{apiName} can be used only with generated member node '{memberName}'.",
+            nameof(memberName));
+    }
 }

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -1,6 +1,6 @@
 # Phases Status
 
-- Updated: 2026-06-23
+- Updated: 2026-06-25
 
 ## Phase 1: 要件・外部仕様確定
 
@@ -33,6 +33,9 @@
 
 - Status: Done
 - Notes:
+  - T-084 を完了し、gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` の Source Generator 出力を根拠に、`Document.Root` 配下の generated member 展開不足を regression test で再現して修正した
+  - T-084 では class / struct 型の direct object member を nested generated view として生成し、`root.Root.Name` / `root.Root.Attribute` / `root.Root.Range` 相当の型付きアクセスを可能にした
+  - T-084 の generated API source shape 変更は `Design/BreakingChanges.md` に記録した
   - T-083 を完了し、Sprache `2.3.1` を使う `.csx` sample として、数字始まり element / attribute name を許可する XML-like parser と SSC 比較出力を追加した
   - T-076 系の XPath-like path access / diff entry helper 実装は T-077 から T-081 まで完了した
   - T-081 を完了し、README に XPath-like path access / diff entry の最小利用例を追加し、public API 設計書を実装後 API 名・契約・表示例と同期した

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -1,6 +1,6 @@
 # Tasks Status
 
-- Updated: 2026-06-23
+- Updated: 2026-06-25
 
 ## In Progress
 
@@ -11,6 +11,35 @@
 - なし
 
 ## Done
+
+- T-084: Source Generator の object member 展開不足修正
+  - Status: 完了（gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` を根拠に、`Document.Root` が nested generated view にならず `Root` 配下の generated member が不完全になる問題を修正した）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-083 Sprache `.csx` XML-like compare sample の追加
+  - Exit Criteria:
+    - gist の `Document.Root` 構造を最小再現する Source Generator regression test が追加されている
+    - class / struct 型の object member が nested generated view として生成され、`Root.Name` / `Root.Attribute` / `Root.Range` 相当の対象メンバーを辿れる
+    - 既存の比較 API 契約を破壊しない
+    - 検証・レビュー・PR 更新が完了している
+  - Output:
+    - PR #37
+    - `src/SSC.Generators/ParallelViewGenerator.cs`
+    - `src/SSC/GeneratedProjectionRuntime.cs`
+    - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+    - `doc/design/detail/02-PublicApi.md`
+    - `Design/BreakingChanges.md`
+    - `reports/task-t-084-implementation-20260625080132.md`
+    - `reports/task-t-084-review-20260625080208.md`
+  - Verification:
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"` 成功（1 件）
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests"` 成功（9 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 29 件 / E2E 64 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - gpt-5.5 high sub-agent review 実施、通常パスを壊す指摘なし
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
 
 - T-083: Sprache `.csx` XML-like compare sample の追加
   - Status: 完了（Sprache `2.3.1` の `.csx` sample を追加し、数字始まり element / attribute name を許可する parser と SSC 比較出力を検証、レビュー指摘なし）

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -5,6 +5,47 @@ namespace SSC.E2E.Tests;
 
 public sealed class GeneratedProjectionE2ETests
 {
+    [Fact]
+    public void Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers()
+    {
+        // Intent: Source Generator expands class-typed members such as Document.Root into nested generated views.
+        var models = new[]
+        {
+            new GeneratedDocument
+            {
+                Root = new GeneratedXmlNode
+                {
+                    Name = "root",
+                    Attribute = new Dictionary<string, GeneratedXmlAttribute>
+                    {
+                        ["id"] = new() { Name = "id", Value = "left" },
+                    },
+                    Range = new GeneratedTextRange { StartLine = 1, EndLine = 3 },
+                },
+            },
+            new GeneratedDocument
+            {
+                Root = new GeneratedXmlNode
+                {
+                    Name = "root",
+                    Attribute = new Dictionary<string, GeneratedXmlAttribute>
+                    {
+                        ["id"] = new() { Name = "id", Value = "right" },
+                    },
+                    Range = new GeneratedTextRange { StartLine = 1, EndLine = 4 },
+                },
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        Assert.Equal("root", root.Root.Name[0]);
+        Assert.Equal("right", root.Root.Attribute[0].Value[1]);
+        Assert.Equal(ValueState.Mismatched, root.Root.Attribute[0].Value.GetState(0));
+        Assert.Equal(1, root.Root.Range.StartLine[0]);
+        Assert.Equal(4, root.Root.Range.EndLine[1]);
+    }
+
 
     [Fact]
     public void Compare_GeneratedProjection_PublicIEnumerableField_GeneratesContainerAccessor()
@@ -392,6 +433,35 @@ public sealed class GeneratedProjectionE2ETests
 
         public ValueState GetState(int modelIndex) => ValueState.Missing;
     }
+}
+
+[GenerateParallelView]
+public sealed class GeneratedDocument
+{
+    public GeneratedXmlNode Root { get; init; } = new();
+}
+
+public sealed class GeneratedXmlNode
+{
+    public string Name { get; init; } = string.Empty;
+
+    public Dictionary<string, GeneratedXmlAttribute>? Attribute;
+
+    public GeneratedTextRange Range;
+}
+
+public sealed class GeneratedXmlAttribute
+{
+    public required string Name;
+
+    public required string Value;
+}
+
+public struct GeneratedTextRange
+{
+    public int StartLine;
+
+    public int EndLine;
 }
 
 [GenerateParallelView]


### PR DESCRIPTION
## Summary
- Generate nested Source Generator views for class / struct object members such as `Document.Root`.
- Add a runtime helper that resolves generated object members through the existing member-node lookup instead of traversing public child sets.
- Add a regression test based on the updated gist output so `root.Root.Name`, `root.Root.Attribute`, and `root.Root.Range` are available.
- Update public API design notes, breaking-change log, task tracking, and reports.

## Reference
- Gist: https://gist.github.com/ssaattww/fbd4fa683d03cd03dd73df0fa37bf1a0
- No GitHub issue exists for this user-requested gist fix; this PR tracks the work.

## Validation
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests"`
- `dotnet test SSC.sln --configuration Release`
- `dotnet format SSC.sln --verify-no-changes`
- `git diff --check`
- gpt-5.5 high sub-agent review: no normal-path implementation findings
- `npm run lint:md` unsupported: package has no `lint:md` script

## Reports
- `reports/task-t-084-implementation-20260625080132.md`
- `reports/task-t-084-review-20260625080208.md`

## Breaking Change
- Generated API source shape changes for object members: direct class / struct members now produce nested generated views instead of `ParallelGeneratedValue<TModel, TMember>`. Logged in `Design/BreakingChanges.md`.