### PR TITLE
Fix keyless XmlCustom comparison

### DIFF
--- a/Design/BreakingChanges.md
+++ b/Design/BreakingChanges.md
@@ -2,6 +2,22 @@
 
 ## 2026-06-25
 
+### T-085 MissingCompareKeyListPolicy の既定値変更
+
+- 対象:
+  - `CompareConfiguration.MissingCompareKeyListPolicy`
+  - `[CompareKey]` が無い sequence member の既定比較
+- 変更種別:
+  - public runtime behavior の変更
+- 影響:
+  - 従来は `CompareKey` が無い sequence member で `CompareKeyNotFoundOnSequenceElement` を Error 記録し、配下 node をスキップしていた
+  - T-085 以降の既定値は `AlignByIndex` となり、同条件では ordinal index で要素を揃えて比較する
+  - 旧挙動が必要な利用コードは `MissingCompareKeyListPolicy.SkipAndRecordError` を明示する必要がある
+- 背景:
+  - gist `XmlCustom.cs` の `Node.Children` / `Node.ChildrenOfNode` は `[CompareKey]` なしの `IEnumerable<T>` であり、既定 `Compare(...)` で parsed `Document` 比較を成功させる必要があったため
+- 備考:
+  - `CompareKey` が存在する sequence では従来どおり key union で比較する
+
 ### T-084 Source Generator object member の生成型変更
 
 - 対象:

--- a/doc/design/basic/BasicDesign.md
+++ b/doc/design/basic/BasicDesign.md
@@ -105,10 +105,11 @@ public interface Parallel<T> : IEnumerable<Parallel<T>>
 
 ## 6. List マッピング方針（属性ベース）
 
-### 6.1 順序比較の禁止
+### 6.1 順序比較の位置づけ
 
-List を index で揃える比較は**設計上禁止**する。
-順序は表示上の情報であり、比較意味を持たない。
+List は、要素型に `CompareKey` がある場合は key union で揃える。
+`CompareKey` が無い場合は ordinal index で揃える。
+旧来の skip + error が必要な利用者は `MissingCompareKeyListPolicy.SkipAndRecordError` を明示する。
 
 ---
 
@@ -138,11 +139,8 @@ public sealed class ItemDetail
 ### 6.3 List マッピング公式ルール
 
 1. CompareKey がある List<T> は必ずキーで揃える
-2. CompareKey が無い List<T> に順序比較を行ってはならない
-3. CompareKey 無し List は
-   - スキップ
-   - 全要素を null として並列化
-   のいずれかをポリシーで選択
+2. CompareKey が無い List<T> は ordinal index で揃える
+3. 旧来の skip + error が必要な場合は `MissingCompareKeyListPolicy.SkipAndRecordError` を明示する
 
 ---
 

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -623,7 +623,8 @@ foreach (dynamic child in root.Items[0].Detail.Children)
 ```
 
 - これは `a.b.c.d` の `d` が実行時専用 `List` でも `foreach` / index access できる、という意味である
-- ただし container 正規化の前提（例: sequence element に `[CompareKey]` が必要）を満たさない場合は、silent に欠落させず access 時に `CompareExecutionException` を返す
+- sequence element に `[CompareKey]` が無い場合は ordinal index で揃えるため、runtime-only container でも list view として access できる
+- `MissingCompareKeyListPolicy.SkipAndRecordError` を明示した場合は、旧来どおり `CompareKeyNotFoundOnSequenceElement` を記録して配下をスキップする
 
 ### 4.2.4 実行時専用メンバーで `GetState` が判定される仕組み
 
@@ -807,7 +808,7 @@ public sealed class CompareConfiguration
     public StringComparison StringKeyComparison { get; init; } = StringComparison.Ordinal;
     public NullKeyPolicy NullKeyPolicy { get; init; } = NullKeyPolicy.Error;
     public MissingCompareKeyListPolicy MissingCompareKeyListPolicy { get; init; } =
-        MissingCompareKeyListPolicy.SkipAndRecordError;
+        MissingCompareKeyListPolicy.AlignByIndex;
     public DuplicateKeyPolicy DuplicateKeyPolicy { get; init; } =
         DuplicateKeyPolicy.RecordError;
     public Action<string>? TraceLog { get; init; }
@@ -815,6 +816,9 @@ public sealed class CompareConfiguration
 ```
 
 `TraceLog` を指定した場合、`Compare(...)` 実行中に内部 trace 行を同期的に受け取れる。
+
+`MissingCompareKeyListPolicy.AlignByIndex` は、sequence 要素型に `CompareKey` が無い場合に ordinal index で要素を揃える。
+旧来どおり `CompareKeyNotFoundOnSequenceElement` を Error として記録して配下をスキップする場合は、`SkipAndRecordError` を明示する。
 
 - 用途:
   - container 判定の確認

--- a/doc/design/detail/03-ContainerRules.md
+++ b/doc/design/detail/03-ContainerRules.md
@@ -25,8 +25,8 @@ E0=[80,90], E1=[70,null], E2=[null,60]
 
 ## 3. List/Array Rules
 
-- 要素型に `CompareKey` が必須
-- `CompareKey` 無し: `Skip + CompareKeyNotFoundOnSequenceElement`
+- 要素型に `CompareKey` がある場合は key union で揃える
+- `CompareKey` 無し: ordinal index で揃える
 - 重複キー: `DuplicateCompareKeyDetected`
 - strict モードでは上記を例外化
 - trace 有効時は declared type に対して `List` / `Array` のどちらで扱ったかを記録する
@@ -46,6 +46,7 @@ E2=[null,(3,30)]
 ## 4. IEnumerable Rules
 
 - Compare 開始時に `List<T>` へ 1 回マテリアライズ
+- 要素型に `CompareKey` がある場合は key union で揃え、無い場合は ordinal index で揃える
 - 再列挙しない
 - 実行時型が未対応コンテナの場合 `UnsupportedContainerType`
 - trace 有効時は declared type と runtime type、materialize 件数、再判定結果を記録する

--- a/doc/design/detail/05-ResultAndErrors.md
+++ b/doc/design/detail/05-ResultAndErrors.md
@@ -32,7 +32,7 @@ public enum CompareIssueLevel { Error, Warning }
 - `InputModelListEmpty`: models が空
 - `InputModelNullElement`: models 内に null
 - `UnsupportedContainerType`: 未対応コンテナ
-- `CompareKeyNotFoundOnSequenceElement`: List 要素に CompareKey 無し
+- `CompareKeyNotFoundOnSequenceElement`: `MissingCompareKeyListPolicy.SkipAndRecordError` 指定時に List 要素に CompareKey 無し
 - `CompareKeyValueIsNull`: CompareKey 値 / dictionary key / sequence element が null
 - `DuplicateCompareKeyDetected`: 重複キー
 - `ModelIndexOutOfRange`: indexer 範囲外

--- a/doc/design/detail/08-ImplementationChecklist.md
+++ b/doc/design/detail/08-ImplementationChecklist.md
@@ -9,8 +9,8 @@
 ## 2. Container Rules
 
 4. Dictionary 正規化で `TKey` を比較キーとして使っているか
-5. List/Array で CompareKey 必須を検証しているか
-6. CompareKey 無し List を `Skip + Error` 化しているか
+5. List/Array で CompareKey ありの場合は key union で揃えているか
+6. CompareKey 無し List を ordinal index で揃えているか
 7. 重複キーを Error 化しているか
 8. IEnumerable の 1 回マテリアライズを保証しているか
 
@@ -38,7 +38,7 @@
 
 20. 2 model / N model の正常系
 21. 欠損混在（片側・両側）
-22. CompareKey 無し / 重複キー異常系
+22. CompareKey 無し ordinal 比較 / 明示 skip policy / 重複キー異常系
 23. Dictionary/List/IEnumerable 各コンテナ系
 24. SelectMany の順序保証
 

--- a/reports/task-t-085-implementation-20260625082652.md
+++ b/reports/task-t-085-implementation-20260625082652.md
@@ -1,0 +1,85 @@
+# Sub-agent実行レポート
+
+## タスク
+
+T-085 gist `XmlCustom` 同等 E2E 比較の修正。
+
+## sub-agentを使う理由
+
+ユーザー指示により実装を sub-agent に委譲するため。TDD で gist `XmlCustom.cs` と同等の E2E を追加し、失敗確認後に最小修正で比較成功まで進める。
+
+## 対象範囲
+
+- gist: https://gist.github.com/ssaattww/fbd4fa683d03cd03dd73df0fa37bf1a0
+- `tests/SSC.E2E.Tests/`
+- `tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj`
+- `src/SSC/`
+- `src/SSC.Generators/`
+- 必要な場合のみ `doc/design/detail/02-PublicApi.md`
+- 必要な場合のみ `Design/BreakingChanges.md`
+
+## 対象外
+
+- `tasks/tasks-status.md` と `tasks/phases-status.md` の編集
+- T-085 と無関係な既存 warning の修正
+- 既存 sample の書き換え
+- nested Codex / agent-spawning の実行
+- report 形式の変更
+
+## 実行コマンド
+
+- `curl -L https://gist.githubusercontent.com/ssaattww/fbd4fa683d03cd03dd73df0fa37bf1a0/raw/ -o /tmp/t085-gist.txt`
+- 失敗確認: `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests"`
+  - production 修正前に失敗。
+  - 失敗内容: `CompareKeyNotFoundOnSequenceElement path=Document.Root.ChildrenOfNode` と `CompareKeyNotFoundOnSequenceElement path=Document.Root.Children` により `HasError == true`。
+- 修正後 focused: `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests"`
+  - Passed: 1
+- 修正後 focused: `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~CompareApiE2ETests.Compare_WhenSequenceElementHasNoCompareKey_AlignsByOrdinalIndex|FullyQualifiedName~CompareApiE2ETests.Compare_WhenMissingCompareKeyPolicySkips_RecordsErrorAndSkips|FullyQualifiedName~ContainerAndSelectManyE2ETests.Compare_DynamicProjection_RuntimeDerivedContainerMember_WithoutCompareKeyAlignsByOrdinalIndex|FullyQualifiedName~GeneratedProjection"`
+  - Passed: 15
+- generated projection focused: `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjection"`
+  - Passed: 11
+- 全体: `dotnet test SSC.sln --configuration Release`
+  - Passed: E2E 66, Unit 29
+- `dotnet format SSC.sln --verify-no-changes`
+  - Passed
+- `git diff --check`
+  - Passed
+- `cat package.json`
+  - Markdown lint script なしを確認
+
+## 対象ファイル
+
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj`
+- `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+- `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+- `src/SSC/CompareConfiguration.cs`
+- `src/SSC/ParallelCompareApi.cs`
+- `doc/design/detail/02-PublicApi.md`
+- `doc/design/detail/03-ContainerRules.md`
+- `doc/design/detail/05-ResultAndErrors.md`
+- `Design/BreakingChanges.md`
+
+## 指摘事項
+
+- ユーザー割り込みで要件が明確化された。`List` / sequence 要素型に `[CompareKey]` が無い場合は `CompareKeyNotFoundOnSequenceElement` を記録して skip するのではなく、ordinal index で比較する。
+- 既存 keyed sequence の key union 動作は維持する必要がある。
+- `tasks/tasks-status.md` と `tasks/phases-status.md` は親管理のため編集対象外。作業開始時点から未コミット変更があったが、本作業では触っていない。
+
+## 結果
+
+- gist `XmlCustom.cs` 同等の E2E を追加し、`Sprache` で 2 つの XML-like 文字列を `Document` に parse して `ParallelCompareApi.Compare` するテストを追加した。
+- production 修正前は `Node.Children` / `Node.ChildrenOfNode` の `[CompareKey]` 欠如により focused E2E が失敗することを確認した。
+- `MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、`[CompareKey]` が無い sequence は ordinal index を `KeyText` として children を構築するようにした。
+- keyless sequence の value mismatch と片側 trailing extra element の Missing を回帰テストで確認した。
+- dynamic runtime-derived container の keyless element も ordinal index で辿れることを回帰テストで確認した。
+- `MissingCompareKeyListPolicy.SkipAndRecordError` を明示した場合の旧 skip+error 経路も回帰テストで確認した。
+- public behavior 変更として design docs と breaking changes を更新した。
+- 親側で review-readiness 調整として、T-085 で追加・変更した `[Fact]` 4 件に XML summary を追加した。
+- 親側で focused / full validation を再実行し、worker 報告と同じ成功結果を確認した。
+
+## リスク
+
+- `MissingCompareKeyListPolicy` の既定値変更は public runtime behavior の変更。旧来の skip+error 前提の利用者には影響があるため `Design/BreakingChanges.md` に記録済み。
+- Markdown lint script は `package.json` に存在しなかったため未実行。
+- focused test 実行時に既存 `ContainerAndSelectManyE2ETests.cs(34,47)` の nullable warning `CS8603` が出ることがあるが、T-085 とは無関係な既存 warning として未対応。

--- a/reports/task-t-085-review-20260625084004.md
+++ b/reports/task-t-085-review-20260625084004.md
@@ -1,0 +1,173 @@
+# Sub-agent実行レポート
+
+## タスク
+
+T-085 gist `XmlCustom` 同等 E2E 比較修正のコードレビュー。
+
+## sub-agentを使う理由
+
+review-enforcer / sub-agent-task-manager に従い、実装者とは独立した gpt-5.5 high のレビューで normal path の欠陥、設計逸脱、検証不足を確認するため。
+
+## 対象範囲
+
+- `src/SSC/CompareConfiguration.cs`
+- `src/SSC/ParallelCompareApi.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+- `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+- `tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj`
+- `doc/design/detail/02-PublicApi.md`
+- `doc/design/detail/03-ContainerRules.md`
+- `doc/design/detail/05-ResultAndErrors.md`
+- `Design/BreakingChanges.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
+- `reports/task-t-085-implementation-20260625082652.md`
+
+## 対象外
+
+- unrelated な既存 warning の修正
+- T-085 と無関係な API 再設計
+- nested Codex / agent-spawning の実行
+- report 形式の変更
+
+## 実行コマンド
+
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - review-enforcer 指示を確認
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - sub-agent-task-manager 指示を確認
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/session-review-shape-policy.md`
+  - source shape review policy を確認
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-layout-policy.md`
+  - source layout policy を確認
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-documentation-policy.md`
+  - source documentation policy を確認
+- `sed -n '1,260p' reports/task-t-085-review-20260625084004.md`
+  - pre-created report を確認
+- `git status --short --branch`
+  - branch: `fix/t-085-xmlcustom-generated-compare`
+- `git diff --stat`
+  - T-085 差分概要を確認
+- `git diff -- src/SSC/CompareConfiguration.cs src/SSC/ParallelCompareApi.cs tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs tests/SSC.E2E.Tests/CompareApiE2ETests.cs tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj doc/design/detail/02-PublicApi.md doc/design/detail/03-ContainerRules.md doc/design/detail/05-ResultAndErrors.md Design/BreakingChanges.md tasks/tasks-status.md tasks/phases-status.md reports/task-t-085-implementation-20260625082652.md`
+  - task-scoped diff を確認
+- `sed -n '1,260p' reports/task-t-085-implementation-20260625082652.md`
+  - implementation report を確認
+- `curl -L https://gist.githubusercontent.com/ssaattww/fbd4fa683d03cd03dd73df0fa37bf1a0/raw/`
+  - gist `XmlCustom.cs` の model/parser 構造を確認
+- `sed -n '1,320p' tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+  - gist-equivalent E2E と generated view assertion を確認
+- `sed -n '1,260p' src/SSC/ParallelCompareApi.cs`
+  - compare entry と member/container dispatch を確認
+- `sed -n '260,620p' src/SSC/ParallelCompareApi.cs`
+  - keyed sequence と keyless ordinal sequence の構築処理を確認
+- `sed -n '620,980p' src/SSC/ParallelCompareApi.cs`
+  - dynamic container access と trace/error 補助処理を確認
+- `sed -n '1,140p' src/SSC/CompareConfiguration.cs`
+  - `MissingCompareKeyListPolicy` default と enum を確認
+- `sed -n '1,180p' tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+  - keyless/default と explicit skip policy tests を確認
+- `sed -n '180,420p' tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+  - keyed sequence/null key/duplicate key regressions を確認
+- `sed -n '440,580p' tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+  - dynamic runtime-derived container regressions を確認
+- `rg -n "CompareKey|MissingCompareKey|AlignByIndex|SkipAndRecordError|ChildrenOfNode|GenerateParallelView|NodeKeyText|KeyText" src tests doc Design tasks reports/task-t-085-implementation-20260625082652.md`
+  - 仕様語句と旧仕様残存箇所を横断確認
+- `nl -ba doc/design/basic/BasicDesign.md | sed -n '132,150p'`
+  - review scope 外の旧仕様記述を確認
+- `nl -ba doc/design/detail/08-ImplementationChecklist.md | sed -n '1,24p'`
+  - review scope 外の旧仕様 checklist を確認
+- `nl -ba doc/draft/DetailDesignDraft.md | sed -n '430,446p'`
+  - review scope 外 draft の旧仕様記述を確認
+- `nl -ba doc/draft/DetailDesignDraft.md | sed -n '535,568p'`
+  - review scope 外 draft の旧 default 記述を確認
+- `nl -ba doc/draft/DetailDesignDraft.md | sed -n '648,676p'`
+  - review scope 外 draft の旧 checklist 記述を確認
+- `nl -ba doc/design/detail/02-PublicApi.md | sed -n '612,630p'`
+  - review scope 内 public API design の dynamic container 記述を確認
+- `sed -n '1,120p' src/SSC/Contracts.cs`
+  - 既存 public API documentation shape を確認
+- `sed -n '1,80p' src/SSC/CompareAttributes.cs`
+  - 既存 public attribute documentation shape を確認
+- `rg -n "<summary>|public sealed class CompareConfiguration|public enum MissingCompareKeyListPolicy|AlignByIndex|SkipAndRecordError" src/SSC tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs tests/SSC.E2E.Tests/CompareApiE2ETests.cs tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+  - changed tests の XML summary と changed public API 周辺を確認
+- `nl -ba src/SSC/CompareConfiguration.cs`
+  - changed public API の行番号を確認
+- `nl -ba tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs | sed -n '1,150p'`
+  - new E2E helper/source shape を確認
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~CompareApiE2ETests.Compare_WhenSequenceElementHasNoCompareKey_AlignsByOrdinalIndex|FullyQualifiedName~CompareApiE2ETests.Compare_WhenMissingCompareKeyPolicySkips_RecordsErrorAndSkips|FullyQualifiedName~ContainerAndSelectManyE2ETests.Compare_DynamicProjection_RuntimeDerivedContainerMember_WithoutCompareKeyAlignsByOrdinalIndex|FullyQualifiedName~GeneratedProjection"`
+  - Passed: 15, Failed: 0, Skipped: 0
+  - 既存 warning: `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs(34,47): warning CS8603`
+- `dotnet format SSC.sln --verify-no-changes`
+  - Passed
+- `git diff --check`
+  - Passed
+- `cat package.json`
+  - `{}`
+- `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/markdown-word-checker/SKILL.md`
+  - Markdown lint gate の分類手順を確認
+- `find tools -maxdepth 3 -type f | sort`
+  - repo-local `tools/lint` 設定なし
+- `npm run lint:md`
+  - Failed: `Missing script: "lint:md"`
+  - Markdown lint state: unsupported
+
+## 対象ファイル
+
+- Checked:
+  - `src/SSC/CompareConfiguration.cs`
+  - `src/SSC/ParallelCompareApi.cs`
+  - `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+  - `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+  - `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+  - `tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj`
+  - `doc/design/detail/02-PublicApi.md`
+  - `doc/design/detail/03-ContainerRules.md`
+  - `doc/design/detail/05-ResultAndErrors.md`
+  - `Design/BreakingChanges.md`
+  - `tasks/tasks-status.md`
+  - `tasks/phases-status.md`
+  - `reports/task-t-085-implementation-20260625082652.md`
+  - `reports/task-t-085-review-20260625084004.md`
+- Context checked:
+  - gist `XmlCustom.cs` raw content
+  - `src/SSC/Contracts.cs`
+  - `src/SSC/CompareAttributes.cs`
+  - `doc/design/basic/BasicDesign.md`
+  - `doc/design/detail/08-ImplementationChecklist.md`
+  - `doc/draft/DetailDesignDraft.md`
+  - `package.json`
+  - `tools/`
+- Changed by this review:
+  - `reports/task-t-085-review-20260625084004.md`
+
+## 指摘事項
+
+- Blocking:
+  - `doc/design/detail/02-PublicApi.md:626` still states that when a runtime-only dynamic container violates the normalization precondition, for example a sequence element lacking `[CompareKey]`, access returns `CompareExecutionException` instead of silently omitting it. T-085 changes the default behavior so keyless sequence elements align by ordinal index, and `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs:498` now verifies dynamic access succeeds for a runtime-derived keyless container. This leaves a scoped public API design document contradicting the implemented normal path and the updated container rules, so the design documentation gate is not closed.
+- Blocking normal-path source bugs:
+  - なし。`BuildIndexAlignedSequenceChildren` aligns keyless list/array/`IEnumerable<T>` members by ordinal index, preserves trailing missing slots, and leaves keyed sequence union behavior on the existing `[CompareKey]` path.
+- User-confirmation-required / hold:
+  - `doc/design/basic/BasicDesign.md:140-145`, `doc/design/detail/08-ImplementationChecklist.md:11-14`, and `doc/draft/DetailDesignDraft.md:437-438`, `doc/draft/DetailDesignDraft.md:541-565`, `doc/draft/DetailDesignDraft.md:650-653` also retain old CompareKey-less sequence wording. These files were outside the explicit review scope. If they are still authoritative for T-085, update them in a follow-up; if they are historical/draft-only, record that disposition.
+- Non-blocking concerns:
+  - Markdown lint is unsupported in this repository state: `package.json` is `{}`, `tools/lint` has no files, and `npm run lint:md` fails with `Missing script: "lint:md"`. This is recorded as unsupported rather than pass.
+  - Focused test emits existing nullable warning `CS8603` at `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs(34,47)`. It is outside the T-085 changed behavior and was not treated as blocking for this review.
+
+## 結果
+
+- Review outcome: findings found.
+- The implementation satisfies the T-085 runtime normal path in focused validation:
+  - gist-equivalent Sprache parser E2E compares two `Document` instances with `HasError == false`
+  - generated view root members are accessible
+  - default keyless sequence comparison aligns by ordinal index
+  - explicit `MissingCompareKeyListPolicy.SkipAndRecordError` preserves old skip/error behavior
+  - keyed sequence behavior remains covered by existing generated projection and keyed sequence regressions
+- Blocking follow-up is required before this review gate can close:
+  - update `doc/design/detail/02-PublicApi.md:626` to match T-085 dynamic keyless ordinal behavior, or otherwise document the intended exception boundary if the current implementation is wrong.
+- gpt-5.5 high sub-agent reviewer `Volta` が review-enforcer に従ってレビューを実施した。sub-agent 自身には nested Codex / agent-spawning を禁止した。
+
+## リスク
+
+- Until `doc/design/detail/02-PublicApi.md:626` is corrected, users reading the public API design can expect dynamic keyless runtime containers to throw even though the implemented and tested behavior is ordinal-index access.
+- Markdown lint remains unsupported because the repository has no `lint:md` script or repo-local `tools/lint` configuration. No Markdown wording pass/fail signal is available from local tooling.
+- Review scope was limited to T-085 files plus directly relevant context. Old wording in basic/draft/checklist documents may need separate disposition if those documents are part of the authoritative design set for this release.

--- a/reports/task-t-085-review-r2-20260625084601.md
+++ b/reports/task-t-085-review-r2-20260625084601.md
@@ -1,0 +1,113 @@
+# Sub-agent実行レポート
+
+## タスク
+
+T-085 review 指摘対応後の再レビュー。
+
+## sub-agentを使う理由
+
+初回 gpt-5.5 high review で `doc/design/detail/02-PublicApi.md` の旧仕様記述が blocking とされたため、同じ reviewer に修正後の差分を確認して review gate を閉じるため。
+
+## 対象範囲
+
+- `doc/design/detail/02-PublicApi.md`
+- `doc/design/basic/BasicDesign.md`
+- `doc/design/detail/08-ImplementationChecklist.md`
+- 初回 review report: `reports/task-t-085-review-20260625084004.md`
+- T-085 全体差分のうち、初回指摘に関係する設計文書整合
+
+## 対象外
+
+- unrelated な既存 warning の修正
+- T-085 と無関係な API 再設計
+- nested Codex / agent-spawning の実行
+- report 形式の変更
+
+## 実行コマンド
+
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - review-enforcer 指示を確認
+- `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/markdown-word-checker/SKILL.md`
+  - Markdown lint gate の分類手順を確認
+- `sed -n '1,260p' reports/task-t-085-review-r2-20260625084601.md`
+  - pre-created r2 report を確認
+- `sed -n '1,260p' reports/task-t-085-review-20260625084004.md`
+  - 初回 blocking finding と hold 項目を確認
+- `git status --short --branch`
+  - branch: `fix/t-085-xmlcustom-generated-compare`
+- `git diff -- doc/design/detail/02-PublicApi.md doc/design/basic/BasicDesign.md doc/design/detail/08-ImplementationChecklist.md`
+  - follow-up scope の設計文書差分を確認
+- `nl -ba doc/design/detail/02-PublicApi.md | sed -n '600,635p'`
+  - 初回 blocking 箇所の修正後行を確認
+- `nl -ba doc/design/basic/BasicDesign.md | sed -n '136,150p'`
+  - non-draft basic design の list mapping 公式ルールを確認
+- `nl -ba doc/design/detail/08-ImplementationChecklist.md | sed -n '9,18p'`
+  - non-draft checklist の container rules を確認
+- `rg -n "CompareKey|MissingCompareKey|AlignByIndex|SkipAndRecordError|CompareExecutionException" doc/design/detail/02-PublicApi.md doc/design/basic/BasicDesign.md doc/design/detail/08-ImplementationChecklist.md`
+  - 関連語句の現行記述を確認
+- `nl -ba doc/design/detail/02-PublicApi.md | sed -n '680,718p'`
+  - `CompareExecutionException` の残存記述が keyless sequence と矛盾しない文脈か確認
+- `nl -ba doc/design/basic/BasicDesign.md | sed -n '104,130p'`
+  - basic design の順序比較方針を確認
+- `nl -ba doc/design/detail/08-ImplementationChecklist.md | sed -n '36,45p'`
+  - minimum test set の keyless ordinal / explicit skip policy 記述を確認
+- `rg -n '順序比較を行ってはならない|CompareKey 無し List を .?Skip|CompareKey 無し List: .?Skip|CompareKey が無い List<T> に順序比較|CompareKey 無しは .?Skip|SkipAndRecordError;|MissingCompareKeyListPolicy\.SkipAndRecordError;|List/Array で CompareKey 必須|sequence element に .?\[CompareKey\].? が必要' doc/design/basic/BasicDesign.md doc/design/detail/02-PublicApi.md doc/design/detail/08-ImplementationChecklist.md`
+  - 対象 non-draft docs で旧仕様語句の残存なし（exit 1 / no matches）
+- `find tools -maxdepth 3 -type f | sort`
+  - repo-local `tools/lint` 設定なし
+- `cat package.json`
+  - `{}`
+- `npm run lint:md`
+  - Failed: `Missing script: "lint:md"`
+  - Markdown lint state: unsupported
+- `git diff --check`
+  - Passed
+
+## 対象ファイル
+
+- Checked:
+  - `doc/design/detail/02-PublicApi.md`
+  - `doc/design/basic/BasicDesign.md`
+  - `doc/design/detail/08-ImplementationChecklist.md`
+  - `reports/task-t-085-review-20260625084004.md`
+- T-085 context checked as needed:
+  - `doc/design/detail/03-ContainerRules.md`
+  - `doc/design/detail/05-ResultAndErrors.md`
+  - `Design/BreakingChanges.md`
+  - `src/SSC/CompareConfiguration.cs`
+  - `src/SSC/ParallelCompareApi.cs`
+  - `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+  - `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+  - `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- Changed by this review:
+  - `reports/task-t-085-review-r2-20260625084601.md`
+
+## 指摘事項
+
+- Blocking:
+  - なし。
+- Blocking normal-path source/design bugs:
+  - なし。
+- Prior blocking finding disposition:
+  - Resolved. `doc/design/detail/02-PublicApi.md:626-627` now states that sequence elements without `[CompareKey]` align by ordinal index for runtime-only containers, and that explicit `MissingCompareKeyListPolicy.SkipAndRecordError` preserves the old `CompareKeyNotFoundOnSequenceElement` skip behavior.
+- Non-draft design consistency:
+  - `doc/design/basic/BasicDesign.md:110-112` and `doc/design/basic/BasicDesign.md:141-143` now describe keyed list alignment by key union, keyless list alignment by ordinal index, and explicit opt-in for old skip + error behavior.
+  - `doc/design/detail/08-ImplementationChecklist.md:11-15` now checks keyed key-union behavior and keyless ordinal behavior, and `doc/design/detail/08-ImplementationChecklist.md:39-42` includes keyless ordinal comparison plus explicit skip policy coverage.
+  - Old non-draft wording such as "順序比較を行ってはならない", "List/Array で CompareKey 必須", and keyless `Skip + Error` checklist wording was not found in the follow-up scope.
+- User-confirmation-required / hold:
+  - なし。Draft docs were intentionally left as historical draft per parent context and were not treated as authoritative for this follow-up review.
+- Non-blocking concerns:
+  - Markdown lint remains unsupported: `package.json` is `{}`, `tools/lint` has no files, and `npm run lint:md` fails with `Missing script: "lint:md"`. This is unchanged from the initial review and remains recorded as unsupported rather than pass.
+
+## 結果
+
+- Review outcome: no findings remain in the follow-up scope.
+- The initial blocking design-doc contradiction is resolved.
+- Non-draft design docs in follow-up scope consistently describe T-085 keyless ordinal behavior and explicit `MissingCompareKeyListPolicy.SkipAndRecordError` opt-in for old skip/error behavior.
+- `git diff --check` passed.
+- gpt-5.5 high sub-agent reviewer `Volta` が初回 review と同じ基準で再レビューを実施した。sub-agent 自身には nested Codex / agent-spawning を禁止した。
+
+## リスク
+
+- Markdown lint remains unsupported because the repository has no `lint:md` script or repo-local `tools/lint` configuration. No Markdown wording pass/fail signal is available from local tooling.
+- Full test and `dotnet format` were not rerun by this follow-up reviewer; parent reported focused tests 15 passed and `dotnet format SSC.sln --verify-no-changes` passed after the design-doc fix. This follow-up review ran targeted document inspection and `git diff --check`.

--- a/src/SSC/CompareConfiguration.cs
+++ b/src/SSC/CompareConfiguration.cs
@@ -8,7 +8,7 @@ public sealed class CompareConfiguration
 
     public NullKeyPolicy NullKeyPolicy { get; init; } = NullKeyPolicy.Error;
 
-    public MissingCompareKeyListPolicy MissingCompareKeyListPolicy { get; init; } = MissingCompareKeyListPolicy.SkipAndRecordError;
+    public MissingCompareKeyListPolicy MissingCompareKeyListPolicy { get; init; } = MissingCompareKeyListPolicy.AlignByIndex;
 
     public DuplicateKeyPolicy DuplicateKeyPolicy { get; init; } = DuplicateKeyPolicy.RecordError;
 
@@ -22,6 +22,7 @@ public enum NullKeyPolicy
 
 public enum MissingCompareKeyListPolicy
 {
+    AlignByIndex,
     SkipAndRecordError,
 }
 

--- a/src/SSC/ParallelCompareApi.cs
+++ b/src/SSC/ParallelCompareApi.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Globalization;
 using System.Reflection;
 using SSC.Internal;
 
@@ -323,6 +324,11 @@ public static class ParallelCompareApi
         var compareKeyMember = TypeMetadataResolver.GetCompareKeyMember(elementType);
         if (compareKeyMember is null)
         {
+            if (context.Configuration.MissingCompareKeyListPolicy == MissingCompareKeyListPolicy.AlignByIndex)
+            {
+                return BuildIndexAlignedSequenceChildren(containerSlots, containerType, elementType, path, context);
+            }
+
             context.RecordExecutionError(
                 CompareIssueCode.CompareKeyNotFoundOnSequenceElement,
                 path,
@@ -482,6 +488,82 @@ public static class ParallelCompareApi
                 context,
                 keyText: keyTexts.TryGetValue(key, out var keyText) ? keyText : KeyToText(key));
             children.Add(childNode);
+        }
+
+        return children;
+    }
+
+    private static IReadOnlyList<IParallelNode> BuildIndexAlignedSequenceChildren(
+        NodeSlot[] containerSlots,
+        Type containerType,
+        Type elementType,
+        string path,
+        CompareContext context)
+    {
+        var containerCategory = GetContainerCategory(containerType);
+        if (context.IsTraceEnabled)
+        {
+            context.Trace(
+                "container",
+                path,
+                ("container", containerCategory),
+                ("elementType", elementType),
+                ("compareKey", "<index>"));
+        }
+
+        var lists = new List<object?>[containerSlots.Length];
+        var maxCount = 0;
+        for (var modelIndex = 0; modelIndex < containerSlots.Length; modelIndex++)
+        {
+            lists[modelIndex] = [];
+            if (containerSlots[modelIndex].State != NodePresenceState.PresentValue || containerSlots[modelIndex].Value is null)
+            {
+                continue;
+            }
+
+            var rawContainer = containerSlots[modelIndex].Value!;
+            if (rawContainer is not IEnumerable enumerable)
+            {
+                context.RecordExecutionError(
+                    CompareIssueCode.UnsupportedContainerType,
+                    path,
+                    modelIndex,
+                    null,
+                    $"container type '{rawContainer.GetType().Name}' is not supported.");
+                continue;
+            }
+
+            lists[modelIndex] = enumerable.Cast<object?>().ToList();
+            maxCount = Math.Max(maxCount, lists[modelIndex].Count);
+            if (context.IsTraceEnabled)
+            {
+                context.Trace(
+                    "container",
+                    path,
+                    ("modelIndex", modelIndex),
+                    ("container", containerCategory),
+                    ("runtimeType", rawContainer.GetType()),
+                    ("materializedCount", lists[modelIndex].Count));
+            }
+        }
+
+        var children = new List<IParallelNode>(maxCount);
+        for (var itemIndex = 0; itemIndex < maxCount; itemIndex++)
+        {
+            var slots = new NodeSlot[containerSlots.Length];
+            for (var modelIndex = 0; modelIndex < containerSlots.Length; modelIndex++)
+            {
+                if (itemIndex >= lists[modelIndex].Count)
+                {
+                    slots[modelIndex] = NodeSlot.Missing;
+                    continue;
+                }
+
+                var value = lists[modelIndex][itemIndex];
+                slots[modelIndex] = value is null ? NodeSlot.PresentNull : NodeSlot.PresentValue(value);
+            }
+
+            children.Add(BuildNode(elementType, slots, path, context, keyText: itemIndex.ToString(CultureInfo.InvariantCulture)));
         }
 
         return children;

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -33,6 +33,8 @@
 
 - Status: Done
 - Notes:
+  - T-085 を完了し、gist `XmlCustom.cs` と同等の E2E で `Document` 同士の比較が成功することを検証し、key なし sequence を ordinal 比較として扱う修正を sub-agent 実装で完了した
+  - T-085 では `CompareConfiguration.MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、旧来の skip + error は `SkipAndRecordError` 明示時の opt-in とした
   - T-084 を完了し、gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` の Source Generator 出力を根拠に、`Document.Root` 配下の generated member 展開不足を regression test で再現して修正した
   - T-084 では class / struct 型の direct object member を nested generated view として生成し、`root.Root.Name` / `root.Root.Attribute` / `root.Root.Range` 相当の型付きアクセスを可能にした
   - T-084 の generated API source shape 変更は `Design/BreakingChanges.md` に記録した

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -12,6 +12,46 @@
 
 ## Done
 
+- T-085: gist `XmlCustom` 同等 E2E 比較の修正
+  - Status: 完了（gist `XmlCustom.cs` と同等の XML custom model / parser を E2E に用意し、key なし sequence を ordinal 比較として扱うことで Source Generator 付き `Document` 同士の比較を成功させた）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-084 Source Generator の object member 展開不足修正
+  - Exit Criteria:
+    - E2E に gist `XmlCustom` と同等の `Document` / `Node` / `Content` / `XmlAttribute` / `TextRange` model と parser 利用ケースが追加されている
+    - `XmlCustom.Document` で parse した `Document` 同士を `ParallelCompareApi.Compare` して `HasError == false` になる
+    - `[CompareKey]` のない list / sequence element は skip + error ではなく ordinal index で比較される
+    - `[CompareKey]` のある list / sequence element は既存の key union 比較を維持する
+    - generated view で `Root` 配下の主要 member を辿れる
+    - failing proof、実装修正、検証、sub-agent review、PR 更新が完了している
+  - Output:
+    - PR #38
+    - `src/SSC/CompareConfiguration.cs`
+    - `src/SSC/ParallelCompareApi.cs`
+    - `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+    - `tests/SSC.E2E.Tests/CompareApiE2ETests.cs`
+    - `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+    - `tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj`
+    - `doc/design/basic/BasicDesign.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `doc/design/detail/03-ContainerRules.md`
+    - `doc/design/detail/05-ResultAndErrors.md`
+    - `doc/design/detail/08-ImplementationChecklist.md`
+    - `Design/BreakingChanges.md`
+    - `reports/task-t-085-implementation-20260625082652.md`
+    - `reports/task-t-085-review-20260625084004.md`
+    - `reports/task-t-085-review-r2-20260625084601.md`
+  - Verification:
+    - failing proof: gist `XmlCustom` E2E が production 修正前に `CompareKeyNotFoundOnSequenceElement` で失敗
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~CompareApiE2ETests.Compare_WhenSequenceElementHasNoCompareKey_AlignsByOrdinalIndex|FullyQualifiedName~CompareApiE2ETests.Compare_WhenMissingCompareKeyPolicySkips_RecordsErrorAndSkips|FullyQualifiedName~ContainerAndSelectManyE2ETests.Compare_DynamicProjection_RuntimeDerivedContainerMember_WithoutCompareKeyAlignsByOrdinalIndex|FullyQualifiedName~GeneratedProjection"` 成功（15 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 29 件 / E2E 66 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - gpt-5.5 medium implementation sub-agent 実施
+    - gpt-5.5 high review / re-review sub-agent 実施、最終指摘なし
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+
 - T-084: Source Generator の object member 展開不足修正
   - Status: 完了（gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` を根拠に、`Document.Root` が nested generated view にならず `Root` 配下の generated member が不完全になる問題を修正した）
   - Phase: Phase 3

--- a/tests/SSC.E2E.Tests/CompareApiE2ETests.cs
+++ b/tests/SSC.E2E.Tests/CompareApiE2ETests.cs
@@ -73,10 +73,55 @@ public sealed class CompareApiE2ETests
         Assert.DoesNotContain(result.Issues, issue => issue.Code == CompareIssueCode.CompareKeyNotFoundOnSequenceElement);
     }
 
+    /// <summary>
+    /// Verifies that sequence elements without CompareKey align by ordinal index and report missing trailing elements.
+    /// </summary>
     [Fact]
-    public void Compare_WhenSequenceElementHasNoCompareKey_RecordsErrorAndSkips()
+    public void Compare_WhenSequenceElementHasNoCompareKey_AlignsByOrdinalIndex()
     {
-        // Intent: List 要素に [CompareKey] が無い場合は Error を記録し、その配下ノードをスキップする。
+        var models = new[]
+        {
+            new NonKeyedRoot
+            {
+                Items =
+                [
+                    new NonKeyedItem { Value = 1 },
+                ],
+            },
+            new NonKeyedRoot
+            {
+                Items =
+                [
+                    new NonKeyedItem { Value = 2 },
+                    new NonKeyedItem { Value = 3 },
+                ],
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+
+        Assert.False(result.HasError);
+        Assert.DoesNotContain(result.Issues, issue => issue.Code == CompareIssueCode.CompareKeyNotFoundOnSequenceElement);
+
+        var root = Assert.IsType<ParallelNode<NonKeyedRoot>>(result.Root);
+        var items = root.GetChildren<NonKeyedItem>(nameof(NonKeyedRoot.Items));
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal("0", items[0].KeyText);
+        Assert.Equal(1, items[0][0]?.Value);
+        Assert.Equal(2, items[0][1]?.Value);
+        Assert.Equal(ValueState.Mismatched, items[0].GetState(0));
+        Assert.Equal("1", items[1].KeyText);
+        Assert.Equal(ValueState.Missing, items[1].GetState(0));
+        Assert.Equal(3, items[1][1]?.Value);
+    }
+
+    /// <summary>
+    /// Verifies that SkipAndRecordError preserves the previous missing CompareKey error-and-skip behavior.
+    /// </summary>
+    [Fact]
+    public void Compare_WhenMissingCompareKeyPolicySkips_RecordsErrorAndSkips()
+    {
         var models = new[]
         {
             new NonKeyedRoot
@@ -94,8 +139,12 @@ public sealed class CompareApiE2ETests
                 ],
             },
         };
+        var configuration = new CompareConfiguration
+        {
+            MissingCompareKeyListPolicy = MissingCompareKeyListPolicy.SkipAndRecordError,
+        };
 
-        var result = ParallelCompareApi.Compare(models);
+        var result = ParallelCompareApi.Compare(models, configuration);
 
         Assert.True(result.HasError);
         Assert.Contains(result.Issues, issue => issue.Code == CompareIssueCode.CompareKeyNotFoundOnSequenceElement);

--- a/tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs
@@ -491,10 +491,12 @@ public sealed class ContainerAndSelectManyE2ETests
         Assert.Equal("right-2", (string?)children[1].Label[1]);
     }
 
+    /// <summary>
+    /// Verifies that a runtime-derived container without CompareKey aligns by ordinal index through dynamic access.
+    /// </summary>
     [Fact]
-    public void Compare_DynamicProjection_RuntimeDerivedContainerMember_ThrowsWhenSequenceElementHasNoCompareKey()
+    public void Compare_DynamicProjection_RuntimeDerivedContainerMember_WithoutCompareKeyAlignsByOrdinalIndex()
     {
-        // Intent: runtime-derived container の正規化前提を満たさない場合は silent に握り潰さず例外で可視化する。
         var models = new[]
         {
             new DerivedDetailDataset
@@ -526,6 +528,7 @@ public sealed class ContainerAndSelectManyE2ETests
                             Children =
                             [
                                 new DerivedRuntimeChildWithoutKey { Label = "right-1" },
+                                new DerivedRuntimeChildWithoutKey { Label = "right-2" },
                             ],
                         },
                     },
@@ -536,10 +539,17 @@ public sealed class ContainerAndSelectManyE2ETests
         var result = ParallelCompareApi.Compare(models);
         dynamic root = result.AsDynamic()!;
 
-        var exception = Assert.Throws<CompareExecutionException>(
-            () => _ = ((IEnumerable<object?>)root.Items[0].Detail.Children).Cast<dynamic>().ToArray());
+        var children = ((IEnumerable<object?>)root.Items[0].Detail.Children).Cast<dynamic>().ToArray();
 
-        Assert.Equal(CompareIssueCode.CompareKeyNotFoundOnSequenceElement, exception.Code);
+        Assert.Equal(2, children.Length);
+        Assert.Equal("0", (string?)children[0].NodeKeyText);
+        Assert.Equal("left-1", (string?)children[0].Label[0]);
+        Assert.Equal("right-1", (string?)children[0].Label[1]);
+        Assert.Equal(ValueState.Mismatched, (ValueState)children[0].GetState(0));
+        Assert.Equal("1", (string?)children[1].NodeKeyText);
+        Assert.Null((string?)children[1].Label[0]);
+        Assert.Equal("right-2", (string?)children[1].Label[1]);
+        Assert.Equal(ValueState.Missing, (ValueState)children[1].GetState(0));
     }
 
     [Fact]

--- a/tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj
+++ b/tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
@@ -1,0 +1,350 @@
+using Sprache;
+using SSC;
+using SSC.Generated;
+
+namespace SSC.E2E.Tests;
+
+public sealed class XmlCustomGeneratedCompareE2ETests
+{
+    /// <summary>
+    /// Verifies that the gist-equivalent XmlCustom parser can produce documents that compare successfully through the generated view.
+    /// </summary>
+    [Fact]
+    public void Compare_GistXmlCustomParsedDocuments_SucceedsAndGeneratedViewCanAccessRootMembers()
+    {
+        var models = new[]
+        {
+            XmlCustom.Document.Parse(
+                """
+                <?xml version="1.0"?>
+                <root id="same" source="left">
+                    <section name="intro">Hello</section>
+                    <empty flag="true"/>
+                </root>
+                """),
+            XmlCustom.Document.Parse(
+                """
+                <?xml version="1.0"?>
+                <root id="same" source="right">
+                    <section name="intro">Hello</section>
+                    <empty flag="true"/>
+                </root>
+                """),
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+
+        Assert.False(
+            result.HasError,
+            string.Join(Environment.NewLine, result.Issues.Select(static issue =>
+                $"{issue.Level}: {issue.Code} path={issue.Path} model={issue.ModelIndex} key={issue.KeyText} message={issue.Message}")));
+        Assert.DoesNotContain(result.Issues, issue => issue.Level == CompareIssueLevel.Error);
+
+        var root = result.AsGeneratedView()!;
+
+        Assert.Equal("root", root.Root.Name[0]);
+        Assert.Equal("same", root.Root.Attribute[0].Value[0]);
+        Assert.Equal("right", root.Root.Attribute[1].Value[1]);
+        Assert.Equal(ValueState.Mismatched, root.Root.Attribute[1].Value.GetState(0));
+        Assert.True(root.Root.Attribute[0].Range.StartLine[0] > 0);
+        Assert.Equal("section", root.Root.ChildrenOfNode[0].Name[0]);
+        Assert.Equal("intro", root.Root.ChildrenOfNode[0].Attribute[0].Value[1]);
+    }
+}
+
+public struct TextRange
+{
+    public int StartPos;
+    public int EndPos;
+    public int StartLine;
+    public int StartColumn;
+    public int EndLine;
+    public int EndColumn;
+}
+
+public sealed class PositionedValue<T> : IPositionAware<PositionedValue<T>>
+{
+    public T Value = default!;
+    public int Pos;
+    public int Length;
+    public int Line;
+    public int Column;
+
+    public PositionedValue<T> SetPos(Position startPos, int length)
+    {
+        Pos = startPos.Pos;
+        Line = startPos.Line;
+        Column = startPos.Column;
+        Length = length;
+        return this;
+    }
+}
+
+public sealed class XmlAttribute
+{
+    public required string Name;
+    public required string Value;
+
+    public TextRange Range;
+}
+
+[GenerateParallelView]
+public sealed class Document
+{
+    public Node Root { get; init; } = new();
+}
+
+public class Item
+{
+}
+
+public sealed class Content : Item
+{
+    public string Text { get; init; } = string.Empty;
+
+    public TextRange Range;
+}
+
+public sealed class Node : Item
+{
+    public string Name { get; init; } = string.Empty;
+
+    public Dictionary<string, XmlAttribute>? Attribute;
+
+    public IEnumerable<Item>? Children;
+
+    public IEnumerable<Node>? ChildrenOfNode => Children?.Where(static child => child is Node).Cast<Node>();
+
+    public TextRange Range;
+
+    public TextRange BeginTagRange;
+
+    public TextRange EndTagRange;
+}
+
+public static class XmlCustom
+{
+    private static readonly Parser<Content> Content =
+        (
+            from text in Parse.CharExcept('<').AtLeastOnce().Text()
+            where !string.IsNullOrWhiteSpace(text)
+            select text
+        )
+        .Select(static text => new PositionedValue<string> { Value = text })
+        .Positioned()
+        .Select(static value => new Content
+        {
+            Text = value.Value,
+            Range = CreateTextRange(value),
+        });
+
+    private static readonly CommentParser Comment = new("<!--", "-->", "\r\n");
+
+    private static readonly Parser<Item> Item =
+        from leadingWs in Parse.WhiteSpace.Many()
+        from leading in Comment.MultiLineComment.Many()
+        from item in Node.Select(static node => (Item)node).XOr(Content)
+        from trailing in Comment.MultiLineComment.Many()
+        from trailingWs in Parse.WhiteSpace.Many()
+        select item;
+
+    private static readonly Parser<string> Identifier =
+        from rest in Parse.LetterOrDigit.XOr(Parse.Char('-')).XOr(Parse.Char('_')).Many()
+        select new string(rest.ToArray());
+
+    private static readonly Parser<XmlAttribute> Attribute =
+        (
+            from key in Identifier.Token()
+            from eq in Parse.Char('=').Token()
+            from bq in Parse.Char('"')
+            from val in Parse.CharExcept('"').Many().Text()
+            from eq2 in Parse.Char('"')
+            select new PositionedValue<(string key, string val)>
+            {
+                Value = (key, val),
+            }
+        )
+        .Positioned()
+        .Select(static value => new XmlAttribute
+        {
+            Name = value.Value.key,
+            Value = value.Value.val,
+            Range = new TextRange
+            {
+                StartPos = value.Pos,
+                EndPos = value.Pos + value.Length,
+                StartLine = value.Line,
+                StartColumn = value.Column,
+                EndLine = value.Line,
+                EndColumn = value.Column + value.Length,
+            },
+        });
+
+    private static readonly Parser<(string Name, IEnumerable<XmlAttribute> Attributes, TextRange Range)> BeginTag =
+        Tag(
+            from id in Identifier
+            from attributes in Attribute.Many()
+            select new PositionedValue<(string, IEnumerable<XmlAttribute>)>
+            {
+                Value = (id, attributes),
+            }
+        )
+        .Positioned()
+        .Select(static value => (
+            value.Value.Item1,
+            value.Value.Item2,
+            new TextRange
+            {
+                StartPos = value.Pos,
+                EndPos = value.Pos + value.Length,
+                StartLine = value.Line,
+                StartColumn = value.Column,
+                EndLine = value.Line,
+                EndColumn = value.Column + value.Length,
+            }));
+
+    private static readonly Parser<Node> FullNode =
+        from beginTag in BeginTag
+        from nodes in Parse.Ref(() => Item).Many()
+        from endTag in EndTag(beginTag.Name)
+        select new Node
+        {
+            Name = beginTag.Name,
+            Attribute = beginTag.Attributes.ToDictionary(static attribute => attribute.Name, static attribute => attribute),
+            Children = nodes,
+            BeginTagRange = beginTag.Range,
+            EndTagRange = endTag.Range,
+            Range = new TextRange
+            {
+                StartPos = beginTag.Range.StartPos,
+                EndPos = endTag.Range.EndPos,
+                StartLine = beginTag.Range.StartLine,
+                StartColumn = beginTag.Range.StartColumn,
+                EndLine = endTag.Range.EndLine,
+                EndColumn = endTag.Range.EndColumn,
+            },
+        };
+
+    private static readonly Parser<Node> ShortNode =
+        Tag(
+            from id in Identifier
+            from attributes in Attribute.Many()
+            from slash in Parse.Char('/')
+            select new PositionedValue<(string Id, IEnumerable<XmlAttribute> Attributes)>
+            {
+                Value = (id, attributes),
+            }
+        )
+        .Positioned()
+        .Select(static value =>
+        {
+            var range = new TextRange
+            {
+                StartPos = value.Pos,
+                EndPos = value.Pos + value.Length,
+                StartLine = value.Line,
+                StartColumn = value.Column,
+                EndLine = value.Line,
+                EndColumn = value.Column + value.Length,
+            };
+
+            return new Node
+            {
+                Name = value.Value.Id,
+                Attribute = value.Value.Attributes.ToDictionary(static attribute => attribute.Name, static attribute => attribute),
+                Range = range,
+                BeginTagRange = range,
+                EndTagRange = range,
+            };
+        });
+
+    private static readonly Parser<Node> Node = ShortNode.Or(FullNode);
+
+    private static readonly Parser<string> XmlVersion = Tag(
+        from q1 in Parse.Char('?')
+        from id in Identifier
+        from attribute in Attribute.AtLeastOnce()
+        from q2 in Parse.Char('?')
+        select attribute.First().Value);
+
+    public static readonly Parser<Document> Document =
+        (
+            from leading in Parse.WhiteSpace.Many()
+            from xmlVersion in XmlVersion.Many()
+            from whitespace in Parse.WhiteSpace.Many()
+            from node in Node
+            from trailing in Parse.WhiteSpace.Many()
+            select new Document { Root = node }
+        ).End();
+
+    private static TextRange CreateTextRange(PositionedValue<string> value)
+    {
+        var endLine = value.Line;
+        var endColumn = value.Column;
+
+        for (var index = 0; index < value.Value.Length; index++)
+        {
+            if (value.Value[index] == '\r')
+            {
+                if (index + 1 < value.Value.Length && value.Value[index + 1] == '\n')
+                {
+                    index++;
+                }
+
+                endLine++;
+                endColumn = 1;
+                continue;
+            }
+
+            if (value.Value[index] == '\n')
+            {
+                endLine++;
+                endColumn = 1;
+                continue;
+            }
+
+            endColumn++;
+        }
+
+        return new TextRange
+        {
+            StartPos = value.Pos,
+            EndPos = value.Pos + value.Length,
+            StartLine = value.Line,
+            StartColumn = value.Column,
+            EndLine = endLine,
+            EndColumn = endColumn,
+        };
+    }
+
+    private static Parser<T> Tag<T>(Parser<T> content)
+    {
+        return
+            from lt in Parse.Char('<')
+            from value in content
+            from gt in Parse.Char('>')
+            select value;
+    }
+
+    private static Parser<(string Name, TextRange Range)> EndTag(string name)
+    {
+        return Tag(
+            from slash in Parse.Char('/')
+            from id in Identifier
+            where id == name
+            select new PositionedValue<string> { Value = id }
+        )
+        .Positioned()
+        .Select(static value => (
+            value.Value,
+            new TextRange
+            {
+                StartPos = value.Pos,
+                EndPos = value.Pos + value.Length,
+                StartLine = value.Line,
+                StartColumn = value.Column,
+                EndLine = value.Line,
+                EndColumn = value.Column + value.Length,
+            }));
+    }
+}


### PR DESCRIPTION
## Summary
- Compare keyless sequence members by ordinal index by default so gist-style `XmlCustom` documents compare successfully.
- Keep keyed sequence behavior on the existing key-union path and preserve the old skip/error behavior via explicit `MissingCompareKeyListPolicy.SkipAndRecordError`.
- Add a gist-equivalent `XmlCustom` E2E using Sprache and generated view assertions.
- Update non-draft design docs and `Design/BreakingChanges.md` for the public behavior change.

## Reference
- Gist: https://gist.github.com/ssaattww/fbd4fa683d03cd03dd73df0fa37bf1a0
- No GitHub issue exists for this user-requested gist fix; this PR tracks the work.

## Validation
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~CompareApiE2ETests.Compare_WhenSequenceElementHasNoCompareKey_AlignsByOrdinalIndex|FullyQualifiedName~CompareApiE2ETests.Compare_WhenMissingCompareKeyPolicySkips_RecordsErrorAndSkips|FullyQualifiedName~ContainerAndSelectManyE2ETests.Compare_DynamicProjection_RuntimeDerivedContainerMember_WithoutCompareKeyAlignsByOrdinalIndex|FullyQualifiedName~GeneratedProjection"`
- `dotnet test SSC.sln --configuration Release`
- `dotnet format SSC.sln --verify-no-changes`
- `git diff --check`
- gpt-5.5 medium implementation sub-agent
- gpt-5.5 high review / re-review sub-agent: no findings remain
- `npm run lint:md` unsupported: package has no `lint:md` script

## Reports
- `reports/task-t-085-implementation-20260625082652.md`
- `reports/task-t-085-review-20260625084004.md`
- `reports/task-t-085-review-r2-20260625084601.md`

## Breaking Change
- `CompareConfiguration.MissingCompareKeyListPolicy` now defaults to `AlignByIndex`. Keyless sequences compare by ordinal index unless `SkipAndRecordError` is explicitly configured.