### PR TITLE
T-086: Add parent references to diff entries

### DIFF
--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -115,7 +115,9 @@ public static class ParallelPathAccessExtensions
 public sealed class ParallelDiffEntry
 {
     public string Path { get; }
+    public string? ParentPath { get; }
     public ParallelDiffEntryKind Kind { get; }
+    public IParallelNode? ParentNode { get; }
     public IParallelNode? Node { get; }
     public IReadOnlyList<ParallelDiffValue> Values { get; }
 
@@ -432,12 +434,14 @@ key text が `#<digits>` 形式そのものの場合は、先頭の `#` を esca
 - root type 名は生成 path には含めない
 
 `Kind == Node` の diff entry で生成される path は、同一 `CompareResult<T>` 内で `GetNodeByPath(path)` に渡すと同じ node を解決できなければならない。
+同時に、entry の親 path / 親 node も traversal 中に保持し、利用者が `Path` を文字列分割して親へ戻る必要がないようにする。
 
 empty container の presence mismatch のように child node が存在しない差分は、
 特定 child path を生成できない。
 この場合は container member 名の path を持つ `Kind == ContainerPresence` の diff entry として表す。
 `ContainerPresence` entry は public node に対応しないため、`Node == null` とし、`GetNodeByPath(Path)` による node 解決は保証しない。
 それでも `Path` には該当 container member 名を入れ、差分表示で位置を失わない。
+`ContainerPresence` entry の `ParentNode` は、該当 container member を所有する親 node を指す。
 
 #### 4.2.2.5 Diff Entry Contract
 
@@ -447,9 +451,18 @@ empty container の presence mismatch のように child node が存在しない
   - XPath-like path
   - `Kind == Node` では `GetNodeByPath(Path)` で同じ node を解決できる
   - `Kind == ContainerPresence` では container member の位置を表すが、node 解決は保証しない
+- `ParentPath`
+  - 親 node の XPath-like path
+  - root 直下の diff entry では `null`
+  - `Kind == Node` / `Kind == ContainerPresence` のどちらでも同じ規則で設定する
+  - `ParentPath != null` の場合、同一 `CompareResult<T>` 内で `GetNodeByPath(ParentPath)` に渡すと `ParentNode` と同じ node を解決できる
 - `Kind`
   - `Node`: `IParallelNode` に対応する差分
   - `ContainerPresence`: child node を持たない container presence mismatch
+- `ParentNode`
+  - diff entry の直接の親 `IParallelNode`
+  - root 直下の diff entry では compare root を指す
+  - `Kind == ContainerPresence` では container member を所有する親 node を指す
 - `Node`
   - `Kind == Node` では差分が観測された `IParallelNode`
   - `Kind == ContainerPresence` では `null`

--- a/doc/design/detail/08-ImplementationChecklist.md
+++ b/doc/design/detail/08-ImplementationChecklist.md
@@ -64,3 +64,4 @@
 36. `HasDifferences()` が leaf/object/container の各 node で subtree 差分を正しく判定するか
 37. `GetDirectChildren()` が scalar/object member を `Nodes.Count == 1`、container member を正規化済み child 集合として返すか
 38. `GetDirectChildren()` の `ParallelChildSet` 順序と `Nodes` 順序が既存 property / key union 契約を崩していないか
+39. `GetDiffEntries()` が `Kind == Node` / `Kind == ContainerPresence` の両方で親 path / 親 node を保持しているか

--- a/reports/task-t-086-implementation-20260625130859.md
+++ b/reports/task-t-086-implementation-20260625130859.md
@@ -1,0 +1,58 @@
+# Sub-agent実行レポート
+
+## タスク
+T-086: `GetDiffEntries()` entry から親 node を直接参照できる API 追加の実装
+
+## sub-agentを使う理由
+ユーザー指定により実装を sub-agent に委譲する。public API / traversal / tests の変更を、設計済みスコープ内で独立して実装するため。
+
+## 対象範囲
+- `ParallelDiffEntry` に `ParentPath` / `ParentNode` を追加する
+- `GetDiffEntries()` の traversal 中に親 path / 親 node を設定する
+- `Kind == Node` と `Kind == ContainerPresence` の両方をテストする
+- root 直下 diff、nested diff、escaped key を含む path の親参照を検証する
+
+## 対象外
+- `GetNodeByPath()` の path grammar 変更
+- Source Generator の仕様変更
+- 既存 comparison semantics の変更
+- PR 作成、最終 review、tracking 完了処理
+
+## 実行コマンド
+- `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"`
+  - 実装前: `ParallelDiffEntry.ParentPath` / `ParentNode` 未定義の compile error を確認
+  - 実装後: Passed 5 tests
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`
+  - Passed 5 tests
+  - 既存警告: `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs(34,47) CS8603`
+- `git diff --check`
+  - 問題なし
+- 追加対応: `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"`
+  - Passed 6 tests
+  - 既存警告: `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs(34,47) CS8603`
+- 追加対応: `git diff --check`
+  - 問題なし
+
+## 対象ファイル
+- `src/SSC/ParallelDiffContracts.cs`
+- `src/SSC/ParallelPathAccessExtensions.cs`
+- `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+- `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+- `reports/task-t-086-implementation-20260625130859.md`
+
+## 指摘事項
+- `ParallelDiffEntry` に public `ParentPath` / `ParentNode` を追加した。
+- `GetDiffEntries()` traversal が保持している `parentPath` / `parentNode` を entry 生成まで渡すようにした。
+- `Kind == ContainerPresence` は `Node == null` のまま、container member を所有する親 node を `ParentNode` に設定する。
+- root 直下 entry は `ParentPath == null`、`ParentNode == result.Root` とする。
+- container child node 自体の親は公開 container node ではなく、container member を所有する node とする。これにより `ParentPath != null` の場合は `result.GetNodeByPath(ParentPath)` が `ParentNode` と一致する。
+
+## 結果
+- T-086 の実装スコープは完了。
+- nested node diff、root 直下 node diff、ContainerPresence、escaped key path の親参照をテストで確認した。
+- escaped key を含む path でも、利用者が path を split せず `ParentNode` を直接参照できることを確認した。
+- 追加対応として、`Groups[1].Items` の nested `ContainerPresence` entry で `ParentPath == "Groups[1]"`、`ParentNode == result.GetNodeByPath("Groups[1]")`、`Node == null` を E2E で確認した。
+
+## リスク
+- `ParentPath` は公開 node として解決できる path のみを返すため、container child node 自体の親 path は `Groups[1].Items` ではなく `Groups[1]` のような所有 node path になる。
+- E2E 実行時に既存の nullable warning が 1 件残っているが、今回変更したファイルではない。

--- a/reports/task-t-086-review-20260625131324.md
+++ b/reports/task-t-086-review-20260625131324.md
@@ -1,0 +1,71 @@
+# Sub-agent実行レポート
+
+## タスク
+T-086: `GetDiffEntries()` entry から親 node を直接参照できる API 追加のコードレビュー
+
+## sub-agentを使う理由
+review-enforcer によりレビューは mandatory sub-agent work。gpt-5.5 high で normal path を壊す問題がないか独立確認する。
+
+## 対象範囲
+- `ParallelDiffEntry` の `ParentPath` / `ParentNode` 追加
+- `GetDiffEntries()` traversal の親情報設定
+- unit / E2E test coverage
+- 設計書・tracking との整合
+- Markdown lint disposition: `npm run lint:md` は missing script のため unsupported、`git diff --check` は成功
+
+## 対象外
+- Source Generator 仕様
+- CompareKey / keyless ordinal 比較 semantics
+- PR 作成、commit、progress sync
+
+## 実行コマンド
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+- `sed -n '1,220p' /home/ibis/dotnet_ws/SSC/AGENTS.md`
+- `sed -n '1,260p' /home/ibis/dotnet_ws/SSC/reports/task-t-086-review-20260625131324.md`
+- `sed -n '1,260p' /home/ibis/dotnet_ws/SSC/doc/design/detail/02-PublicApi.md`
+- `sed -n '1,260p' /home/ibis/dotnet_ws/SSC/reports/task-t-086-implementation-20260625130859.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/session-review-shape-policy.md`
+- `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-documentation-policy.md`
+- `git status --short --branch`
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+- `git diff --unified=80 origin/main...HEAD -- doc/design/detail/02-PublicApi.md doc/design/detail/08-ImplementationChecklist.md tasks/tasks-status.md tasks/phases-status.md`
+- `git diff --unified=80 -- src/SSC/ParallelDiffContracts.cs src/SSC/ParallelPathAccessExtensions.cs tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+- `rg -n "TODO|ParentPath|ParentNode|GetDiffEntries|ContainerPresence|lint:md" reports/task-t-086-review-20260625131324.md src/SSC/ParallelDiffContracts.cs src/SSC/ParallelPathAccessExtensions.cs tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs doc/design/detail/02-PublicApi.md doc/design/detail/08-ImplementationChecklist.md tasks/tasks-status.md tasks/phases-status.md package.json`
+- `nl -ba src/SSC/ParallelDiffContracts.cs | sed -n '1,120p'`
+- `nl -ba src/SSC/ParallelPathAccessExtensions.cs | sed -n '1,340p'`
+- `nl -ba tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs | sed -n '1,220p'`
+- `nl -ba tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs | sed -n '1,240p'`
+- `nl -ba doc/design/detail/02-PublicApi.md | sed -n '420,490p'`
+- `nl -ba tasks/tasks-status.md | sed -n '1,110p'`
+- `find . -maxdepth 2 -name package.json -print -exec sed -n '1,160p' {} \;`
+- `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"` 成功（5 件）
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"` 成功（5 件）
+- `git diff --check` 成功
+- `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+
+## 対象ファイル
+- `src/SSC/ParallelDiffContracts.cs`
+- `src/SSC/ParallelPathAccessExtensions.cs`
+- `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+- `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+- `doc/design/detail/02-PublicApi.md`
+- `doc/design/detail/08-ImplementationChecklist.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
+- `reports/task-t-086-implementation-20260625130859.md`
+- `reports/task-t-086-review-20260625131324.md`
+
+## 指摘事項
+- blocking findings: なし。`ParentPath != null` の場合は `GetNodeByPath(ParentPath)` と `ParentNode` が一致する実装になっており、root 直下 diff は `ParentPath == null` / `ParentNode == result.Root` を返す。`ContainerPresence` も `Node == null` を維持しつつ owner node を `ParentNode` に設定している。
+- user-confirmation-required capability gap: なし。public API 設計書の `ParentPath` / `ParentNode` 契約と実装は一致している。
+- P2 non-blocking concern: nested `ContainerPresence` の `ParentPath != null` round-trip を直接守るテストがない。設計書は `ParentPath != null` なら `GetNodeByPath(ParentPath)` が `ParentNode` と同じ node を解決すると定義し、`ContainerPresence` では owner node を指すとしている（`doc/design/detail/02-PublicApi.md:454`, `doc/design/detail/02-PublicApi.md:462`）。現行テストの `ContainerPresence` 親参照確認は root 直下の `Items` / `Scores` に限られており（`tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs:108`, `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs:142`、`tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs:56`）、`Groups[1].Items` のような nested empty container で `ParentPath == "Groups[1]"` かつ `ParentNode == result.GetNodeByPath("Groups[1]")` になることは未検証。実装上は `CreateContainerPresenceEntry(... ToEntryParentPath(parentPath), parentNode, ...)` により満たしているため通常パスを壊す blocker ではないが、回帰防止として追加テスト対象にするのが望ましい。
+
+## 結果
+- レビュー完了。通常利用パスを壊す blocking finding はなし。
+- focused Unit / E2E test と `git diff --check` は成功。
+- Markdown lint は repository の `package.json` に `lint:md` script がなく unsupported。今回の disposition は、`git diff --check` 成功とあわせて保留可能と判断する。
+
+## リスク
+- nested `ContainerPresence` の親 path / 親 node round-trip は実装から成立すると読めるが、専用テストがないため将来回帰を検出しにくい。
+- Markdown lint は missing script により実行不能のため、Markdown wording の自動検査は未実施。

--- a/reports/task-t-086-review-r2-20260625131809.md
+++ b/reports/task-t-086-review-r2-20260625131809.md
@@ -1,0 +1,57 @@
+# Sub-agent実行レポート
+
+## タスク
+T-086: nested ContainerPresence 親参照テスト追加後の再レビュー
+
+## sub-agentを使う理由
+review-enforcer によりレビュー指摘対応後の再レビューを同じ reviewer sub-agent で確認するため。
+
+## 対象範囲
+- 初回レビュー P2: nested `ContainerPresence` の `ParentPath != null` round-trip テスト不足への対応
+- 追加 E2E と既存 T-086 差分全体の regressions
+
+## 対象外
+- T-086 以外の比較 semantics
+- PR 作成、commit、progress sync
+
+## 実行コマンド
+- `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+- `sed -n '1,260p' /home/ibis/dotnet_ws/SSC/reports/task-t-086-review-r2-20260625131809.md`
+- `sed -n '1,260p' /home/ibis/dotnet_ws/SSC/reports/task-t-086-review-20260625131324.md`
+- `sed -n '1,260p' /home/ibis/dotnet_ws/SSC/reports/task-t-086-implementation-20260625130859.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/session-review-shape-policy.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/references/source-documentation-policy.md`
+- `git status --short --branch`
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+- `git diff --unified=100 -- tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+- `git diff --unified=80 -- src/SSC/ParallelDiffContracts.cs src/SSC/ParallelPathAccessExtensions.cs tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+- `nl -ba tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs | sed -n '1,360p'`
+- `nl -ba src/SSC/ParallelPathAccessExtensions.cs | sed -n '110,250p'`
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"` 成功（6 件）
+- `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"` 成功（5 件）
+- `git diff --check` 成功
+- `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+
+## 対象ファイル
+- `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+- `src/SSC/ParallelDiffContracts.cs`
+- `src/SSC/ParallelPathAccessExtensions.cs`
+- `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+- `reports/task-t-086-review-r2-20260625131809.md`
+- `reports/task-t-086-review-20260625131324.md`
+- `reports/task-t-086-implementation-20260625130859.md`
+
+## 指摘事項
+- no findings。
+- 前回 P2 は解消済み。追加 E2E `GetDiffEntries_ReturnsNestedContainerPresenceWithResolvableParent` が `Groups[1].Items` の nested `ContainerPresence` entry を直接検証し、`ParentPath == "Groups[1]"`、`ParentNode == result.GetNodeByPath(entry.ParentPath)`、`Node == null` を確認している（`tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs:155`）。
+- T-086 差分全体を再確認したが、通常利用パスを壊す新規 blocking finding はなし。
+
+## 結果
+- 再レビュー完了。前回 P2 の non-blocking concern は追加 E2E により解消済み。
+- focused E2E / Unit test と `git diff --check` は成功。
+- Markdown lint は repository の `package.json` に `lint:md` script がないため unsupported。前回 disposition から変更なし。
+
+## リスク
+- 現時点で T-086 の通常利用パスを阻害する既知リスクはなし。
+- Markdown lint は missing script により実行不能のため、Markdown wording の自動検査は未実施。

--- a/reports/task-t-086-verification-20260625132024.md
+++ b/reports/task-t-086-verification-20260625132024.md
@@ -1,0 +1,49 @@
+# Sub-agent実行レポート
+
+## タスク
+T-086: full validation
+
+## sub-agentを使う理由
+codex-delegation-executor により test/build/verification evidence は mandatory sub-agent work として実施するため。
+
+## 対象範囲
+- T-086 差分適用後の solution test
+- format check
+- whitespace diff check
+- Markdown lint availability check
+
+## 対象外
+- コード編集
+- PR 作成、commit、tracking 更新
+
+## 実行コマンド
+- `dotnet test SSC.sln --configuration Release`
+  - Passed
+  - Unit: Passed 30 tests
+  - E2E: Passed 67 tests
+- `dotnet format SSC.sln --verify-no-changes`
+  - Passed
+- `git diff --check`
+  - Passed
+- `npm run lint:md`
+  - Unsupported: missing `lint:md` script
+  - npm output: `Missing script: "lint:md"`
+
+## 対象ファイル
+- `SSC.sln`
+- `reports/task-t-086-verification-20260625132024.md`
+
+## 指摘事項
+- full validation の required gate は `npm run lint:md` を除き通過した。
+- Markdown lint は repository の `package.json` に `lint:md` script がないため unsupported として記録する。
+- npm は `/home/ibis/.npm/_logs` へ log file を書き込めなかったが、missing script 判定自体には影響しない。
+
+## 結果
+- `dotnet test SSC.sln --configuration Release`: pass
+- `dotnet format SSC.sln --verify-no-changes`: pass
+- `git diff --check`: pass
+- `npm run lint:md`: unsupported due to missing script
+
+## リスク
+- Markdown lint は missing script のため未実行。repo 側に `lint:md` script が追加されるまで pass としては扱えない。
+- npm log directory への書き込み権限がなく、npm debug log は出力されていない。

--- a/src/SSC/ParallelDiffContracts.cs
+++ b/src/SSC/ParallelDiffContracts.cs
@@ -12,7 +12,11 @@ public sealed class ParallelDiffEntry
 {
     public string Path { get; init; } = string.Empty;
 
+    public string? ParentPath { get; init; }
+
     public ParallelDiffEntryKind Kind { get; init; }
+
+    public IParallelNode? ParentNode { get; init; }
 
     public IParallelNode? Node { get; init; }
 

--- a/src/SSC/ParallelPathAccessExtensions.cs
+++ b/src/SSC/ParallelPathAccessExtensions.cs
@@ -110,11 +110,13 @@ public static class ParallelPathAccessExtensions
     private static void AddNodeDiffEntries(
         List<ParallelDiffEntry> entries,
         IParallelNode node,
-        string path)
+        string path,
+        string? parentPath,
+        IParallelNode parentNode)
     {
         if (HasOwnPresenceMismatch(node))
         {
-            entries.Add(CreateNodeEntry(path, node));
+            entries.Add(CreateNodeEntry(path, parentPath, parentNode, node));
             return;
         }
 
@@ -123,7 +125,7 @@ public static class ParallelPathAccessExtensions
         {
             if (node.HasDifferences())
             {
-                entries.Add(CreateNodeEntry(path, node));
+                entries.Add(CreateNodeEntry(path, parentPath, parentNode, node));
             }
 
             return;
@@ -149,7 +151,12 @@ public static class ParallelPathAccessExtensions
         if (parentNode is IParallelNodeInternal internalParent
             && internalParent.TryGetMemberNode(childSet.Name, out var memberNode))
         {
-            AddNodeDiffEntries(entries, memberNode, CombinePath(parentPath, childSet.Name));
+            AddNodeDiffEntries(
+                entries,
+                memberNode,
+                CombinePath(parentPath, childSet.Name),
+                ToEntryParentPath(parentPath),
+                parentNode);
             return;
         }
 
@@ -158,7 +165,11 @@ public static class ParallelPathAccessExtensions
             if (parentNode is IParallelNodeInternal containerParent
                 && containerParent.TryGetContainerPresenceStates(childSet.Name, out var states))
             {
-                entries.Add(CreateContainerPresenceEntry(CombinePath(parentPath, childSet.Name), states));
+                entries.Add(CreateContainerPresenceEntry(
+                    CombinePath(parentPath, childSet.Name),
+                    ToEntryParentPath(parentPath),
+                    parentNode,
+                    states));
             }
 
             return;
@@ -170,11 +181,20 @@ public static class ParallelPathAccessExtensions
             var selector = childNode.KeyText is null
                 ? $"#{ordinal}"
                 : EscapeKeyText(childNode.KeyText);
-            AddNodeDiffEntries(entries, childNode, CombinePath(parentPath, $"{childSet.Name}[{selector}]"));
+            AddNodeDiffEntries(
+                entries,
+                childNode,
+                CombinePath(parentPath, $"{childSet.Name}[{selector}]"),
+                ToEntryParentPath(parentPath),
+                parentNode);
         }
     }
 
-    private static ParallelDiffEntry CreateNodeEntry(string path, IParallelNode node)
+    private static ParallelDiffEntry CreateNodeEntry(
+        string path,
+        string? parentPath,
+        IParallelNode parentNode,
+        IParallelNode node)
     {
         var values = new ParallelDiffValue[node.Count];
         for (var modelIndex = 0; modelIndex < node.Count; modelIndex++)
@@ -190,7 +210,9 @@ public static class ParallelPathAccessExtensions
         return new ParallelDiffEntry
         {
             Path = path,
+            ParentPath = parentPath,
             Kind = ParallelDiffEntryKind.Node,
+            ParentNode = parentNode,
             Node = node,
             Values = values,
         };
@@ -198,6 +220,8 @@ public static class ParallelPathAccessExtensions
 
     private static ParallelDiffEntry CreateContainerPresenceEntry(
         string path,
+        string? parentPath,
+        IParallelNode parentNode,
         IReadOnlyList<NodePresenceState> states)
     {
         var values = new ParallelDiffValue[states.Count];
@@ -216,7 +240,9 @@ public static class ParallelPathAccessExtensions
         return new ParallelDiffEntry
         {
             Path = path,
+            ParentPath = parentPath,
             Kind = ParallelDiffEntryKind.ContainerPresence,
+            ParentNode = parentNode,
             Node = null,
             Values = values,
         };
@@ -246,6 +272,11 @@ public static class ParallelPathAccessExtensions
         return string.IsNullOrEmpty(parentPath)
             ? segment
             : $"{parentPath}.{segment}";
+    }
+
+    private static string? ToEntryParentPath(string parentPath)
+    {
+        return string.IsNullOrEmpty(parentPath) ? null : parentPath;
     }
 
     private static string EscapeKeyText(string keyText)

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -12,9 +12,9 @@
 
 ## Phase 2: 詳細設計確定
 
-- Status: In Progress
+- Status: Done
 - Notes:
-  - T-086 で `GetDiffEntries()` が返す `ParallelDiffEntry` から親 path / 親 node を直接参照できる public API を設計中
+  - T-086 で `ParallelDiffEntry` の親 path / 親 node を public API として確定した
   - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加し、実装単位を T-077 から T-082 へ分割した
   - `doc/draft/DetailDesignDraft.md` に粒度基準・章別必須項目・仕様確定結果を追記
   - Draft/非Draft を `doc/draft` と `doc/design` に分離
@@ -32,9 +32,9 @@
 
 ## Phase 3: 実装
 
-- Status: In Progress
+- Status: Done
 - Notes:
-  - T-086 の設計完了後、実装サブエージェントで親 path / 親 node を `ParallelDiffEntry` に追加する
+  - T-086 を完了し、`GetDiffEntries()` の `Kind == Node` / `Kind == ContainerPresence` entry から `ParentPath` / `ParentNode` を取得できるようにした
   - T-085 を完了し、gist `XmlCustom.cs` と同等の E2E で `Document` 同士の比較が成功することを検証し、key なし sequence を ordinal 比較として扱う修正を sub-agent 実装で完了した
   - T-085 では `CompareConfiguration.MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、旧来の skip + error は `SkipAndRecordError` 明示時の opt-in とした
   - T-084 を完了し、gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` の Source Generator 出力を根拠に、`Document.Root` 配下の generated member 展開不足を regression test で再現して修正した
@@ -143,6 +143,7 @@
 
 - Status: Done
 - Notes:
+  - T-086 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-082 を完了し、`dotnet test SSC.sln --configuration Release` が成功した（Unit tests 29 件、E2E tests 61 件）
   - T-082 では `git diff --check`、PR #32 body 確認、最終レビューを実施し、最終レビュー指摘なしを確認した
   - Markdown 検査はユーザー指示により未実施

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -12,8 +12,9 @@
 
 ## Phase 2: 詳細設計確定
 
-- Status: Done
+- Status: In Progress
 - Notes:
+  - T-086 で `GetDiffEntries()` が返す `ParallelDiffEntry` から親 path / 親 node を直接参照できる public API を設計中
   - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加し、実装単位を T-077 から T-082 へ分割した
   - `doc/draft/DetailDesignDraft.md` に粒度基準・章別必須項目・仕様確定結果を追記
   - Draft/非Draft を `doc/draft` と `doc/design` に分離
@@ -31,8 +32,9 @@
 
 ## Phase 3: 実装
 
-- Status: Done
+- Status: In Progress
 - Notes:
+  - T-086 の設計完了後、実装サブエージェントで親 path / 親 node を `ParallelDiffEntry` に追加する
   - T-085 を完了し、gist `XmlCustom.cs` と同等の E2E で `Document` 同士の比較が成功することを検証し、key なし sequence を ordinal 比較として扱う修正を sub-agent 実装で完了した
   - T-085 では `CompareConfiguration.MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、旧来の skip + error は `SkipAndRecordError` 明示時の opt-in とした
   - T-084 を完了し、gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` の Source Generator 出力を根拠に、`Document.Root` 配下の generated member 展開不足を regression test で再現して修正した

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,7 +4,20 @@
 
 ## In Progress
 
-- なし
+- T-086: `GetDiffEntries()` entry から親 node を直接参照できる API 追加
+  - Status: 設計中（`ParallelDiffEntry` に親 path / 親 node を持たせ、`GetDiffEntries()` 利用者が path 文字列を再解析せず親へ辿れる public API を追加する）
+  - Phase: Phase 2
+  - Estimate: S
+  - Depends on:
+    - T-079 通常 node 差分の `GetDiffEntries()` 追加
+    - T-080 empty container 差分の `ContainerPresence` entry 追加
+  - Exit Criteria:
+    - `ParallelDiffEntry` の public contract に親 path / 親 node の扱いが設計されている
+    - `Kind == Node` の diff entry で、親 node と親 path が取得できる
+    - `Kind == ContainerPresence` の diff entry でも、entry 自身の node がない一方で container を所有する親 node が取得できる
+    - root 直下 diff の親は compare root として扱われる
+    - key text 内の `.` / `]` / `\` を含む path でも、利用者側で文字列 split せずに親を参照できる
+    - TDD、実装修正、検証、sub-agent review、PR 更新が完了している
 
 ## Backlog
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,9 +4,17 @@
 
 ## In Progress
 
+- なし
+
+## Backlog
+
+- なし
+
+## Done
+
 - T-086: `GetDiffEntries()` entry から親 node を直接参照できる API 追加
-  - Status: 設計中（`ParallelDiffEntry` に親 path / 親 node を持たせ、`GetDiffEntries()` 利用者が path 文字列を再解析せず親へ辿れる public API を追加する）
-  - Phase: Phase 2
+  - Status: 完了（`ParallelDiffEntry` に親 path / 親 node を追加し、`GetDiffEntries()` 利用者が path 文字列を再解析せず親へ辿れるようにした）
+  - Phase: Phase 3
   - Estimate: S
   - Depends on:
     - T-079 通常 node 差分の `GetDiffEntries()` 追加
@@ -18,12 +26,28 @@
     - root 直下 diff の親は compare root として扱われる
     - key text 内の `.` / `]` / `\` を含む path でも、利用者側で文字列 split せずに親を参照できる
     - TDD、実装修正、検証、sub-agent review、PR 更新が完了している
-
-## Backlog
-
-- なし
-
-## Done
+  - Output:
+    - PR #39
+    - `src/SSC/ParallelDiffContracts.cs`
+    - `src/SSC/ParallelPathAccessExtensions.cs`
+    - `tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`
+    - `tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs`
+    - `doc/design/detail/02-PublicApi.md`
+    - `doc/design/detail/08-ImplementationChecklist.md`
+    - `reports/task-t-086-implementation-20260625130859.md`
+    - `reports/task-t-086-review-20260625131324.md`
+    - `reports/task-t-086-review-r2-20260625131809.md`
+    - `reports/task-t-086-verification-20260625132024.md`
+  - Verification:
+    - TDD 赤確認: `ParentPath` / `ParentNode` 未定義の compile error
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"` 成功（5 件）
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"` 成功（6 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 30 件 / E2E 67 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+    - gpt-5.5 medium implementation / verification sub-agent 実施
+    - gpt-5.5 high review / re-review sub-agent 実施、最終指摘なし
 
 - T-085: gist `XmlCustom` 同等 E2E 比較の修正
   - Status: 完了（gist `XmlCustom.cs` と同等の XML custom model / parser を E2E に用意し、key なし sequence を ordinal 比較として扱うことで Source Generator 付き `Document` 同士の比較を成功させた）

--- a/tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XPathLikeDiffEntriesE2ETests.cs
@@ -14,6 +14,10 @@ public sealed class XPathLikeDiffEntriesE2ETests
         var metric = Assert.Single(entries, entry => entry.Path == "Groups[1].Items[100].MetricA");
 
         Assert.Equal(ParallelDiffEntryKind.Node, metric.Kind);
+        Assert.Equal("Groups[1].Items[100]", metric.ParentPath);
+        Assert.NotNull(metric.ParentPath);
+        Assert.NotNull(metric.ParentNode);
+        Assert.Same(metric.ParentNode, result.GetNodeByPath(metric.ParentPath));
         Assert.NotNull(metric.Node);
         Assert.Same(metric.Node, result.GetNodeByPath(metric.Path));
         Assert.Equal(2, metric.Values.Count);
@@ -36,6 +40,10 @@ public sealed class XPathLikeDiffEntriesE2ETests
         var missingItem = Assert.Single(entries, entry => entry.Path == "Groups[1].Items[200]");
 
         Assert.Equal(ParallelDiffEntryKind.Node, missingItem.Kind);
+        Assert.Equal("Groups[1]", missingItem.ParentPath);
+        Assert.NotNull(missingItem.ParentPath);
+        Assert.NotNull(missingItem.ParentNode);
+        Assert.Same(missingItem.ParentNode, result.GetNodeByPath(missingItem.ParentPath));
         Assert.NotNull(missingItem.Node);
         Assert.Same(missingItem.Node, result.GetNodeByPath(missingItem.Path));
         Assert.Equal(200, ((Item?)missingItem.Values[0].Value)?.ItemId);
@@ -73,9 +81,9 @@ public sealed class XPathLikeDiffEntriesE2ETests
 
         var entries = result.GetDiffEntries();
 
-        AssertResolvablePath(entries, result, "Items[A\\]B].Label");
-        AssertResolvablePath(entries, result, "Items[A\\\\B].Label");
-        AssertResolvablePath(entries, result, "Items[\\#0].Label");
+        AssertResolvablePath(entries, result, "Items[A\\]B].Label", "Items[A\\]B]");
+        AssertResolvablePath(entries, result, "Items[A\\\\B].Label", "Items[A\\\\B]");
+        AssertResolvablePath(entries, result, "Items[\\#0].Label", "Items[\\#0]");
     }
 
     [Fact]
@@ -98,6 +106,8 @@ public sealed class XPathLikeDiffEntriesE2ETests
         var entry = Assert.Single(entries, candidate => candidate.Path == "Items");
 
         Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Null(entry.ParentPath);
+        Assert.Same(result.Root, entry.ParentNode);
         Assert.Null(entry.Node);
         Assert.Null(result.GetNodeByPath(entry.Path));
         Assert.Equal(2, entry.Values.Count);
@@ -130,6 +140,8 @@ public sealed class XPathLikeDiffEntriesE2ETests
         var entry = Assert.Single(entries, candidate => candidate.Path == "Scores");
 
         Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Null(entry.ParentPath);
+        Assert.Same(result.Root, entry.ParentNode);
         Assert.Null(entry.Node);
         Assert.Null(result.GetNodeByPath(entry.Path));
         Assert.Equal(2, entry.Values.Count);
@@ -140,12 +152,57 @@ public sealed class XPathLikeDiffEntriesE2ETests
         Assert.Equal("Scores: [0]=null(Mismatched), [1]=null(Mismatched)", entry.ToString());
     }
 
+    [Fact]
+    public void GetDiffEntries_ReturnsNestedContainerPresenceWithResolvableParent()
+    {
+        // Intent: nested ContainerPresence entry でも ParentPath/ParentNode が所有 node を直接指す。
+        var result = ParallelCompareApi.Compare(
+        [
+            new OptionalNestedContainerDataset
+            {
+                Groups =
+                [
+                    new OptionalNestedContainerGroup
+                    {
+                        GroupId = 1,
+                        Items = [],
+                    },
+                ],
+            },
+            new OptionalNestedContainerDataset
+            {
+                Groups =
+                [
+                    new OptionalNestedContainerGroup
+                    {
+                        GroupId = 1,
+                        Items = null,
+                    },
+                ],
+            },
+        ]);
+
+        var entries = result.GetDiffEntries();
+        var entry = Assert.Single(entries, candidate => candidate.Path == "Groups[1].Items");
+
+        Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Equal("Groups[1]", entry.ParentPath);
+        Assert.NotNull(entry.ParentPath);
+        Assert.NotNull(entry.ParentNode);
+        Assert.Same(entry.ParentNode, result.GetNodeByPath(entry.ParentPath));
+        Assert.Null(entry.Node);
+    }
+
     private static void AssertResolvablePath<T>(
         IReadOnlyList<ParallelDiffEntry> entries,
         CompareResult<T> result,
-        string path)
+        string path,
+        string parentPath)
     {
         var entry = Assert.Single(entries, candidate => candidate.Path == path);
+        Assert.Equal(parentPath, entry.ParentPath);
+        Assert.NotNull(entry.ParentNode);
+        Assert.Same(entry.ParentNode, result.GetNodeByPath(parentPath));
         Assert.Same(entry.Node, result.GetNodeByPath(path));
     }
 
@@ -241,5 +298,18 @@ public sealed class XPathLikeDiffEntriesE2ETests
     public sealed class OptionalDictionaryDataset
     {
         public Dictionary<string, int>? Scores { get; init; }
+    }
+
+    public sealed class OptionalNestedContainerDataset
+    {
+        public List<OptionalNestedContainerGroup> Groups { get; init; } = [];
+    }
+
+    public sealed class OptionalNestedContainerGroup
+    {
+        [CompareKey]
+        public int GroupId { get; init; }
+
+        public List<Item>? Items { get; init; }
     }
 }

--- a/tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs
+++ b/tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs
@@ -18,8 +18,29 @@ public sealed class XPathLikeDiffEntriesUnitTests
         var entry = Assert.Single(result.GetDiffEntries());
 
         Assert.Equal("Items[#0].Name", entry.Path);
+        Assert.Equal("Items[#0]", entry.ParentPath);
+        Assert.NotNull(entry.ParentPath);
+        Assert.Same(itemNode, entry.ParentNode);
         Assert.Same(nameNode, entry.Node);
+        Assert.Same(entry.ParentNode, result.GetNodeByPath(entry.ParentPath));
         Assert.Same(entry.Node, result.GetNodeByPath(entry.Path));
+    }
+
+    [Fact]
+    public void GetDiffEntries_WithRootDirectNodeDiff_ReturnsRootParent()
+    {
+        // Intent: root 直下 node 差分は ParentPath を null にし、ParentNode で root を直接返す。
+        var nameNode = new FakeNode(value: "left", state: ValueState.Mismatched);
+        var root = new FakeRootNode();
+        root.SetMember("Name", nameNode);
+        var result = new CompareResult<FakeRoot> { Root = root };
+
+        var entry = Assert.Single(result.GetDiffEntries());
+
+        Assert.Equal("Name", entry.Path);
+        Assert.Null(entry.ParentPath);
+        Assert.Same(root, entry.ParentNode);
+        Assert.Same(nameNode, entry.Node);
     }
 
     [Fact]
@@ -34,6 +55,8 @@ public sealed class XPathLikeDiffEntriesUnitTests
 
         Assert.Equal("Items", entry.Path);
         Assert.Equal(ParallelDiffEntryKind.ContainerPresence, entry.Kind);
+        Assert.Null(entry.ParentPath);
+        Assert.Same(root, entry.ParentNode);
         Assert.Null(entry.Node);
         Assert.Null(result.GetNodeByPath(entry.Path));
         Assert.Equal(ValueState.Mismatched, entry.Values[0].State);


### PR DESCRIPTION
## Summary
- Add `ParentPath` / `ParentNode` to `ParallelDiffEntry`
- Populate parent references during `GetDiffEntries()` traversal without reparsing paths
- Cover root-level, nested node, `ContainerPresence`, and escaped-key parent reference behavior

## Issue
- No GitHub issue exists for this user-requested T-086 task.

## Reports
- `reports/task-t-086-implementation-20260625130859.md`
- `reports/task-t-086-review-20260625131324.md`
- `reports/task-t-086-review-r2-20260625131809.md`
- `reports/task-t-086-verification-20260625132024.md`

## Validation
- `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesUnitTests|FullyQualifiedName~ParallelDiffResultUnitTests"` passed 5 tests
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XPathLikeDiffEntriesE2ETests"` passed 6 tests
- `dotnet test SSC.sln --configuration Release` passed: Unit 30, E2E 67
- `dotnet format SSC.sln --verify-no-changes` passed
- `git diff --check` passed
- `npm run lint:md` unsupported: missing `lint:md` script

## Review
- gpt-5.5 high review found one non-blocking P2 test coverage concern for nested `ContainerPresence`
- Added the nested `ContainerPresence` E2E coverage
- gpt-5.5 high re-review: no findings

## Risks
- Markdown lint is not runnable until the repository defines a `lint:md` script.
