### PR TITLE
T-087: Add generated list key text access

### DIFF
--- a/doc/design/detail/01-DomainModel.md
+++ b/doc/design/detail/01-DomainModel.md
@@ -112,7 +112,8 @@ var keyText = typedRoot.Groups[0].Items[0].NodeMeta.KeyText;
 
 - `dynamic` 非依存で IDE 補完を利用できる
 - list index 範囲外は `ModelIndexOutOfRange`
-- key union 済み container は `Groups["1"]` / `Attribute["id"]` のように `NodeMeta.KeyText` と同じ key text で参照できる
+- Dictionary member は通常の dictionary に近い形で `Attribute["id"]` / `Scores[100]` のように key 型で参照できる
+- `GetDiffEntries().Path` の bracket 内 discriminator から参照する場合は `ByPathKey(discriminator)` を使う
 - key が見つからない場合は `KeyNotFound` の `CompareExecutionException` を返す
 - node メタ情報は `NodeMeta` 配下（`NodeMeta.Count` / `NodeMeta.KeyText`）で参照する
 - 投影切替の入口は `CompareResult` 拡張（`AsDynamic()` / `AsGeneratedView()`）に統一する

--- a/doc/design/detail/01-DomainModel.md
+++ b/doc/design/detail/01-DomainModel.md
@@ -112,6 +112,8 @@ var keyText = typedRoot.Groups[0].Items[0].NodeMeta.KeyText;
 
 - `dynamic` 非依存で IDE 補完を利用できる
 - list index 範囲外は `ModelIndexOutOfRange`
+- key union 済み container は `Groups["1"]` / `Attribute["id"]` のように `NodeMeta.KeyText` と同じ key text で参照できる
+- key が見つからない場合は `KeyNotFound` の `CompareExecutionException` を返す
 - node メタ情報は `NodeMeta` 配下（`NodeMeta.Count` / `NodeMeta.KeyText`）で参照する
 - 投影切替の入口は `CompareResult` 拡張（`AsDynamic()` / `AsGeneratedView()`）に統一する
 - 直下 child 探索は generated 専用型ではなく `IParallelNode` 共通面で扱う

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -143,6 +143,7 @@ public sealed class ParallelDiffValue
 - indexer の範囲外アクセスは `ModelIndexOutOfRange`
 - dynamic list index の範囲外アクセスも `ModelIndexOutOfRange`
 - generated list index の範囲外アクセスも `ModelIndexOutOfRange`
+- generated list の key text indexer で key が見つからない場合は `KeyNotFound`
 - `AllPresent == Values.All(v => v != null かつ Missing でない)`
 - `AnyPresent == Values.Any(v => Missing でない)`
 - `HasDifferences()` は current node 自体、または配下 subtree のいずれかに差分があれば `true`
@@ -737,6 +738,8 @@ var rightStateAt200 = root.Groups[0].Items[1].MetricA.GetState(1); // Missing
 var leftLabel = root.Groups[0].Items[0].Detail.Label[0]; // direct nested object view
 var leftLabelViaSelector = root.Groups[0].Items[0].Detail.Select(x => x.Label)[0]; // compatible nested value path
 var nodeCount = root.Groups[0].Items[0].NodeMeta.Count;
+var group1 = root.Groups["1"];
+var idAttributeValue = root.Root.Attribute["id"].Value[0];
 
 // model 単位で list を選択（Missing slot を除外）
 var leftGroups = root.Groups.SelectModel(0);
@@ -748,7 +751,10 @@ var leftGroupIdAt0 = leftGroups[0].GroupId[0];
 - generated view で取得する公開 `ValueState` の意味は `AsDynamic()` と同一
 - 投影切替の入口は `CompareResult` 拡張に統一する
 - generated API の node メタ情報は `NodeMeta` 配下に分離し、モデル同名メンバーと衝突させない
-- Dictionary も List と同様に key union 順の index でアクセスする（例: `root.Scores[0][1]`）
+- generated container は key union 順の index でアクセスできる（例: `root.Scores[0][1]`）
+- `NodeMeta.KeyText` を持つ generated container child は key text でもアクセスできる（例: `root.Groups["1"]` / `root.Root.Attribute["id"]`）
+- key text indexer は `StringComparer.Ordinal` で lookup し、繰り返し利用時に線形探索を繰り返さない
+- key text が存在しない場合は `KeyNotFound` の `CompareExecutionException` を送出する
 - class / struct 型の object member は nested generated view として直接辿れる（例: `root.Root.Name[0]`）
 - object member view は互換導線として `Select(...)` も提供し、既存の nested value path 利用を維持する
 - `SelectModel(modelIndex)` は指定 model で `Missing` でない要素のみを返し、順序は key union 順を維持する

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -740,6 +740,8 @@ var leftLabelViaSelector = root.Groups[0].Items[0].Detail.Select(x => x.Label)[0
 var nodeCount = root.Groups[0].Items[0].NodeMeta.Count;
 var group1 = root.Groups["1"];
 var idAttributeValue = root.Root.Attribute["id"].Value[0];
+var score100 = root.Scores[100][0];
+var attributeFromDiffPath = root.Root.Attribute.ByPathKey("A\\]B").Value[0];
 
 // model 単位で list を選択（Missing slot を除外）
 var leftGroups = root.Groups.SelectModel(0);
@@ -751,12 +753,13 @@ var leftGroupIdAt0 = leftGroups[0].GroupId[0];
 - generated view で取得する公開 `ValueState` の意味は `AsDynamic()` と同一
 - 投影切替の入口は `CompareResult` 拡張に統一する
 - generated API の node メタ情報は `NodeMeta` 配下に分離し、モデル同名メンバーと衝突させない
-- generated container は key union 順の index でアクセスできる（例: `root.Scores[0][1]`）
-- `NodeMeta.KeyText` を持つ generated container child は key text でもアクセスできる（例: `root.Groups["1"]` / `root.Root.Attribute["id"]`）
-- key text indexer は raw key text と、`GetDiffEntries().Path` の bracket 内に現れる XPath-like escaped discriminator text の両方を受け付ける
-- key text indexer は有効な XPath-like escape を含む入力では escaped discriminator を unescape した lookup を raw lookup より優先し、見つからない場合だけ raw lookup に fallback する
-- key text indexer は `StringComparer.Ordinal` で lookup し、繰り返し利用時に線形探索を繰り返さない
-- key text が存在しない場合は `KeyNotFound` の `CompareExecutionException` を送出する
+- generated sequence container は key union 順の index でアクセスできる
+- `NodeMeta.KeyText` を持つ generated sequence child は key text でもアクセスできる（例: `root.Groups["1"]`）
+- Dictionary member は `ParallelGeneratedDictionary<TKey, TElement, TView>` として生成し、通常の dictionary に近い形で key 型の indexer を使う（例: `root.Root.Attribute["id"]` / `root.Scores[100]`）
+- Dictionary member の key union 順 access が必要な場合は `AtIndex(index)` を使う
+- Dictionary member で `GetDiffEntries().Path` の bracket 内に現れる XPath-like escaped discriminator text からアクセスする場合は `ByPathKey(discriminator)` を使う
+- key lookup は繰り返し利用時に線形探索を繰り返さない
+- key が存在しない場合は `KeyNotFound` の `CompareExecutionException` を送出する
 - class / struct 型の object member は nested generated view として直接辿れる（例: `root.Root.Name[0]`）
 - object member view は互換導線として `Select(...)` も提供し、既存の nested value path 利用を維持する
 - `SelectModel(modelIndex)` は指定 model で `Missing` でない要素のみを返し、順序は key union 順を維持する

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -753,6 +753,8 @@ var leftGroupIdAt0 = leftGroups[0].GroupId[0];
 - generated API の node メタ情報は `NodeMeta` 配下に分離し、モデル同名メンバーと衝突させない
 - generated container は key union 順の index でアクセスできる（例: `root.Scores[0][1]`）
 - `NodeMeta.KeyText` を持つ generated container child は key text でもアクセスできる（例: `root.Groups["1"]` / `root.Root.Attribute["id"]`）
+- key text indexer は raw key text と、`GetDiffEntries().Path` の bracket 内に現れる XPath-like escaped discriminator text の両方を受け付ける
+- key text indexer は有効な XPath-like escape を含む入力では escaped discriminator を unescape した lookup を raw lookup より優先し、見つからない場合だけ raw lookup に fallback する
 - key text indexer は `StringComparer.Ordinal` で lookup し、繰り返し利用時に線形探索を繰り返さない
 - key text が存在しない場合は `KeyNotFound` の `CompareExecutionException` を送出する
 - class / struct 型の object member は nested generated view として直接辿れる（例: `root.Root.Name[0]`）

--- a/doc/design/detail/05-ResultAndErrors.md
+++ b/doc/design/detail/05-ResultAndErrors.md
@@ -36,6 +36,7 @@ public enum CompareIssueLevel { Error, Warning }
 - `CompareKeyValueIsNull`: CompareKey 値 / dictionary key / sequence element が null
 - `DuplicateCompareKeyDetected`: 重複キー
 - `ModelIndexOutOfRange`: indexer 範囲外
+- `KeyNotFound`: key text indexer の key 未検出
 - `ReflectionMetadataBuildFailed`: 反射メタデータ構築失敗
 
 ## 4. Strict Mode Matrix

--- a/doc/design/detail/08-ImplementationChecklist.md
+++ b/doc/design/detail/08-ImplementationChecklist.md
@@ -54,13 +54,15 @@
 29. `GenerateParallelViewAttribute` を追加し、生成対象の明示契約を定義したか
 30. Source Generator で `AsGeneratedView()` と型付き view を生成できるか
 31. generated API で `list index -> model index` アクセスを再現できるか
-32. generated API の範囲外 index が `ModelIndexOutOfRange` で失敗するか
-33. `AsDynamic()` の既存挙動が回帰していないか
-34. 複数 namespace / nested type / internal type で生成コードがコンパイルできるか
-35. `Count/KeyText` 衝突系と nullable value-path 系で dynamic 回帰がないか
+32. generated API で `key text -> generated view` アクセスを再現できるか
+33. generated API の範囲外 index が `ModelIndexOutOfRange` で失敗するか
+34. generated API の missing key が `KeyNotFound` で失敗するか
+35. `AsDynamic()` の既存挙動が回帰していないか
+36. 複数 namespace / nested type / internal type で生成コードがコンパイルできるか
+37. `Count/KeyText` 衝突系と nullable value-path 系で dynamic 回帰がないか
 
 ## 9. Difference Traversal
 
-36. `HasDifferences()` が leaf/object/container の各 node で subtree 差分を正しく判定するか
-37. `GetDirectChildren()` が scalar/object member を `Nodes.Count == 1`、container member を正規化済み child 集合として返すか
-38. `GetDirectChildren()` の `ParallelChildSet` 順序と `Nodes` 順序が既存 property / key union 契約を崩していないか
+38. `HasDifferences()` が leaf/object/container の各 node で subtree 差分を正しく判定するか
+39. `GetDirectChildren()` が scalar/object member を `Nodes.Count == 1`、container member を正規化済み child 集合として返すか
+40. `GetDirectChildren()` の `ParallelChildSet` 順序と `Nodes` 順序が既存 property / key union 契約を崩していないか

--- a/reports/task-t-087-attribute-model-index-access-review-20260625154715.md
+++ b/reports/task-t-087-attribute-model-index-access-review-20260625154715.md
@@ -1,0 +1,44 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-087 follow-up の Attribute key + model index access test 追記レビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer により完了前の dedicated review が必須であり、ユーザー指定の流れに合わせて gpt-5.5 high の sub-agent で確認するため。
+
+## 対象範囲
+
+- 対象: `Attribute["id"][0]` / `Attribute["source"][1]` と node/member `GetState` の E2E 追加、および key 指定と model index 指定の意味を説明するテスト内コメント。
+
+## 対象外
+
+- 対象外: production 実装修正、設計書更新、既存 generated dictionary API の再設計。
+
+## 実行コマンド
+
+- 実行コマンド: `git diff --check`（pass）
+- 実行コマンド: `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（pass: 15 tests）
+- 実行コマンド: `find tools -maxdepth 4 -print` / `cat package.json` 相当の確認（Markdown lint 設定なし）
+
+## 対象ファイル
+
+- 変更または確認したファイル: `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- 変更または確認したファイル: `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- 変更または確認したファイル: `src/SSC/GeneratedProjectionRuntime.cs`
+- 変更または確認したファイル: `src/SSC.Generators/ParallelViewGenerator.cs`
+- 変更または確認したファイル: `reports/task-t-087-attribute-model-index-access-review-20260625154715.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。
+
+## 結果
+
+- 結果: `Attribute["id"]` / `Attribute["source"]` が dictionary key で child view を取り、続く `[0]` / `[1]` が generated child view の model index として元 Attribute object を返すことを E2E で検証している。`Attribute["id"].Value[0]` / `Attribute["source"].Value[1]` は member value access として別に assertion されており、child view 自体の `GetState(modelIndex)` と `Value.GetState(modelIndex)` も別々に確認されている。追加コメントは method contract ではなく assertion group の implementation note として妥当で、将来仕様を過剰に約束していない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: なし。Markdown lint は `package.json` に lint script がなく `tools/lint` 配下にも設定ファイルがないため unsupported と判断した。

--- a/reports/task-t-087-followup-dictionary-key-20260625135623.md
+++ b/reports/task-t-087-followup-dictionary-key-20260625135623.md
@@ -1,0 +1,74 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087 follow-up: Dictionary generated access を key 型 indexer にする
+
+## sub-agentを使う理由
+既存 PR #40 の follow-up として generator/runtime/tests の複数領域を TDD で修正するため。
+
+## 対象範囲
+- Dictionary member を `ParallelGeneratedDictionary<TKey, TElement, TView>` として生成する
+- `dict[key]` を typed raw key access にする
+- path bracket discriminator access は `ByPathKey(string)` で提供する
+- key union 順 access は `AtIndex(int)` へ分離する
+- string key と non-string key の E2E を追加する
+
+## 対象外
+- dynamic projection の key access 変更
+- sequence/List の key access 全般の再設計
+- object/composite key の path 復元
+- PR 作成、最終 review、tracking 完了処理
+
+## 実行コマンド
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_DictionaryIntKeyAccess_UsesRawKey"`
+  - 実装前 failing proof: `root.Scores[100]` が key access ではなく `ParallelGeneratedList` の ordinal index access として解決され、`CompareExecutionException: list index '100' is out of range for count '3'.` で失敗することを確認。
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests|FullyQualifiedName~XmlCustomGeneratedCompareE2ETests"`
+  - 実装後: Passed. Failed: 0, Passed: 13, Skipped: 0.
+  - レビュー対応後: Passed. Failed: 0, Passed: 15, Skipped: 0.
+  - Attribute value key access test 追加後: Passed. Failed: 0, Passed: 15, Skipped: 0.
+  - 既存 warning: `ContainerAndSelectManyE2ETests.cs(34,47): warning CS8603`。
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_DictionaryStringKeyAccess_UsesConfiguredKeyComparison|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_DictionaryDateTimeKeyAccess_UsesNormalizedKey"`
+  - レビュー対応前 failing proof: case-insensitive string key の `root.Scores["a"]` と DateTime normalized key が `KeyNotFound` で失敗することを確認。
+  - レビュー対応後: Passed. Failed: 0, Passed: 2, Skipped: 0.
+- `git diff --check`
+  - Passed.
+- `dotnet test SSC.sln --configuration Release`
+  - Passed. E2E: Failed 0, Passed 71, Skipped 0. Unit: Failed 0, Passed 29, Skipped 0.
+- `dotnet format SSC.sln --verify-no-changes`
+  - Passed.
+- Markdown lint
+  - Unsupported: repo-local `tools/lint/` が空で、`package.json` の lint script も未設定。
+
+## 対象ファイル
+- `src/SSC.Generators/ParallelViewGenerator.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `src/SSC/ParallelCompareApi.cs`
+- `src/SSC/ParallelNode.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `reports/task-t-087-followup-dictionary-key-20260625135623.md`
+
+## 指摘事項
+- Dictionary member の generated property を `ParallelGeneratedList<TElement,TView>` から `ParallelGeneratedDictionary<TKey,TElement,TView>` へ分離。
+- Dictionary の `this[TKey]` は raw key 型アクセスとして扱い、key union 順の ordinal access は `AtIndex(int)` に分離。
+- `GetDiffEntries().Path` の bracket 内 discriminator は `ByPathKey(string)` で unescape してアクセスする形に更新。
+- `CompareIssueCode.KeyNotFound` は enum 末尾のまま変更なし。
+- レビュー対応として、child node に compare runtime の normalized key object と key comparer を internal metadata として保持。
+- `ParallelGeneratedDictionary<TKey,TElement,TView>` の raw key indexer は `KeyText` ではなく `KeyValue` cache で lookup。
+- `ByPathKey(discriminator)` と `ParallelGeneratedList` の string keyText access は引き続き `KeyText` cache を使用。
+
+## 結果
+- `Dictionary<int, int>` の generated member で `root.Scores[100]` が int key としてアクセスできる E2E を追加。
+- `Dictionary<string, GeneratedXmlAttribute>` の `root.Root.Attribute["id"]` raw key access は維持。
+- CustomXML の `Attribute["source"].Value` と nested `Attribute["name"].Value` を E2E で直接検証。
+- `StringKeyComparison.OrdinalIgnoreCase` の `Dictionary<string, int>` generated access で `root.Scores["A"]` / `root.Scores["a"]` が同じ child を引ける E2E を追加。
+- `Dictionary<DateTime, int>` generated access で元 key と `DateTime.ToUniversalTime()` 相当 key のどちらでも同じ child を引ける E2E を追加。
+- 既存 dictionary ordinal access は `AtIndex(...)` に更新。
+- diff path selector access は `ByPathKey(selector)` に更新。
+- missing key は `CompareExecutionException` / `CompareIssueCode.KeyNotFound` で検証。
+- 指定 E2E フィルタ、full test、format verify、whitespace check は成功。
+
+## リスク
+- object/composite key の path 復元は対象外。
+- `KeyValue` を持たない ordinal keyless sequence は対象外で、既存の list/index behavior を維持。
+- Markdown lint は repo-local wiring がないため未実行。

--- a/reports/task-t-087-followup-dictionary-key-review-20260625140236.md
+++ b/reports/task-t-087-followup-dictionary-key-review-20260625140236.md
@@ -1,0 +1,59 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087 follow-up: Dictionary key 型 indexer 化のコードレビュー
+
+## sub-agentを使う理由
+review-enforcer によりレビューは mandatory sub-agent work。Dictionary wrapper 分離が通常利用パスを壊さないか独立確認するため。
+
+## 対象範囲
+- `ParallelGeneratedDictionary<TKey,TElement,TView>` 追加
+- generator の Dictionary member property 型変更
+- `dict[key]` / `AtIndex(index)` / `ByPathKey(discriminator)` の E2E
+- 設計書・tracking との整合
+- Markdown lint disposition: unsupported
+
+## 対象外
+- dynamic projection の key access 変更
+- object/composite key の path 復元
+- PR 作成、commit、progress sync
+
+## 実行コマンド
+- `git diff origin/main...HEAD -- src/SSC/GeneratedProjectionRuntime.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs doc/design/detail/01-DomainModel.md doc/design/detail/02-PublicApi.md tasks/tasks-status.md tasks/phases-status.md`
+- `git diff -- src/SSC.Generators/ParallelViewGenerator.cs src/SSC/GeneratedProjectionRuntime.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs doc/design/detail/01-DomainModel.md doc/design/detail/02-PublicApi.md tasks/tasks-status.md tasks/phases-status.md`
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests|FullyQualifiedName~XmlCustomGeneratedCompareE2ETests"`
+  - Passed. Failed: 0, Passed: 13, Skipped: 0.
+- `git diff --check`
+  - Passed.
+- `npm run lint:md`
+  - Unsupported: `Missing script: "lint:md"`.
+
+## 対象ファイル
+- `src/SSC.Generators/ParallelViewGenerator.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `doc/design/detail/01-DomainModel.md`
+- `doc/design/detail/02-PublicApi.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
+- 周辺確認: `src/SSC/ParallelCompareApi.cs`, `doc/design/detail/03-ContainerRules.md`, `doc/design/detail/07-NonFunctional.md`, `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs`
+
+## 指摘事項
+- Blocking findings
+  - `src/SSC/GeneratedProjectionRuntime.cs:42` / `src/SSC/GeneratedProjectionRuntime.cs:84` / `src/SSC/GeneratedProjectionRuntime.cs:250`: `ParallelGeneratedDictionary<TKey,TElement,TView>` の typed indexer は `TKey.ToString()` を `StringComparer.Ordinal` の `KeyText` cache に照合しているため、既存の `CompareConfiguration.StringKeyComparison = OrdinalIgnoreCase` パスと一致しない。比較本体は `src/SSC/ParallelCompareApi.cs:217` の `KeyComparer` と `src/SSC/ParallelCompareApi.cs:795` の canonical `KeyText` 選択で `"a"` / `"A"` を同一 key に統合できるが、generated dictionary は canonical 表記だけを ordinal lookup する。結果として、比較では存在する string dictionary key でも `root.Scores["a"]` が `KeyNotFound` になり得る。`doc/design/detail/03-ContainerRules.md:73` と既存 E2E `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs:721` がこの設定を通常の supported path として扱っているため、typed key indexer の通常パス blocker。
+- User-confirmation-required capability gap
+  - `src/SSC/GeneratedProjectionRuntime.cs:47`: typed key lookup は実キーではなく `TKey.ToString()` と `KeyText` の一致に依存している。`doc/design/detail/03-ContainerRules.md:104` の DateTime key UTC 正規化など、比較本体側で `NormalizeKey` / `KeyComparer` が `ToString()` 以上の意味を持つ key 型では、同値 key を typed indexer で引ける保証がない。この follow-up で全 `Dictionary<TKey,TValue>` の比較 key semantics まで generated access に持ち込むか、今回の正常系を string/int の `KeyText` 安定型に限定するかは明示確認が必要。
+- Non-blocking concerns
+  - `ParallelGeneratedList` 側の sequence/List access、LINQ enumeration、`SelectModel` は focused E2E 13 件で維持されている。List の既存 string key text indexer は従来どおり `KeyText` lookup であり、Dictionary typed key blocker とは別扱い。
+
+## 結果
+- Review completed with blocking finding.
+- Dictionary member が generator で `ParallelGeneratedDictionary<TKey,TElement,TView>` として生成される差分は確認した。
+- `Dictionary<int, TValue>` の `root.Scores[100]`、Dictionary ordinal access の `AtIndex(index)`、diff path discriminator access の `ByPathKey(discriminator)`、string key dictionary の `root.Root.Attribute["id"]` は focused E2E 上は通っている。
+- ただし `StringKeyComparison.OrdinalIgnoreCase` の supported path で generated dictionary typed key lookup が比較本体と同じ key semantics を持てないため、完了扱いにはしない。
+
+## リスク
+- Blocking finding を直す場合、generated wrapper が `CompareConfiguration.StringKeyComparison` もしくは compare runtime と同じ key comparer/canonicalization 情報へアクセスできる設計が必要になる可能性がある。
+- DateTime 正規化、nullable key annotation、culture-sensitive `ToString()`、object/composite key は今回の focused E2E では未検証。
+- Markdown lint は repo-local script が無いため unsupported。

--- a/reports/task-t-087-followup-dictionary-key-review-r2-20260625141147.md
+++ b/reports/task-t-087-followup-dictionary-key-review-r2-20260625141147.md
@@ -1,0 +1,65 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087 follow-up: KeyValue/comparer 対応後の再レビュー
+
+## sub-agentを使う理由
+review-enforcer によりレビュー指摘対応後の再レビューを同じ reviewer sub-agent で確認するため。
+
+## 対象範囲
+- `ParallelNode` への normalized key object / comparer metadata 追加
+- generated dictionary の `KeyValue` lookup
+- `OrdinalIgnoreCase` string key access
+- `DateTime` normalized key access
+- T-087 follow-up 差分全体の regression
+
+## 対象外
+- object/composite key の path 復元
+- dynamic projection の key access 変更
+- PR 作成、commit、progress sync
+
+## 実行コマンド
+- `git status --short`
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+- `git diff -- src/SSC/ParallelNode.cs src/SSC/ParallelCompareApi.cs src/SSC/GeneratedProjectionRuntime.cs src/SSC.Generators/ParallelViewGenerator.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests|FullyQualifiedName~XmlCustomGeneratedCompareE2ETests"`
+  - Passed. Failed: 0, Passed: 15, Skipped: 0.
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_DictionaryStringKeyAccess_UsesConfiguredKeyComparison|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_DictionaryDateTimeKeyAccess_UsesNormalizedKey"`
+  - Passed. Failed: 0, Passed: 2, Skipped: 0.
+- `git diff --check`
+  - Passed.
+- `npm run lint:md`
+  - Unsupported: `Missing script: "lint:md"`.
+
+## 対象ファイル
+- `src/SSC/ParallelNode.cs`
+- `src/SSC/ParallelCompareApi.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `src/SSC.Generators/ParallelViewGenerator.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `doc/design/detail/01-DomainModel.md`
+- `doc/design/detail/02-PublicApi.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
+
+## 指摘事項
+- No findings.
+- Blocking findings: none.
+- User-confirmation-required capability gap: none.
+- Non-blocking concerns: Markdown lint remains unsupported because the repository has no `lint:md` script.
+
+## 結果
+- Previous blocking finding is resolved.
+- `src/SSC/ParallelNode.cs:13` now stores internal `KeyValue` and `KeyComparer` metadata on child nodes.
+- `src/SSC/ParallelCompareApi.cs:318` and `src/SSC/ParallelCompareApi.cs:499` pass normalized key object and compare runtime key comparer into dictionary/keyed sequence child nodes.
+- `src/SSC/GeneratedProjectionRuntime.cs:43` uses `NormalizeKey(key)` and `ResolveByKeyValue(...)` for raw generated dictionary key access instead of `KeyText` lookup.
+- `src/SSC/GeneratedProjectionRuntime.cs:144` builds a comparer-backed `KeyValue` cache, so configured string key comparison and DateTime normalization are reused for generated dictionary access.
+- `ByPathKey(discriminator)` remains `KeyText`/diff path discriminator based at `src/SSC/GeneratedProjectionRuntime.cs:58`, preserving path selector compatibility.
+- Focused tests cover `root.Scores["A"]` / `root.Scores["a"]`, DateTime original/UTC key access, `ByPathKey`, `AtIndex`, and existing generated sequence/list paths.
+
+## リスク
+- object/composite key path復元は引き続き対象外。
+- `KeyValue` を持たない ordinal keyless sequence は generated dictionary の対象外で、既存 list/index behavior を維持。
+- Markdown lint は repo-local script が無いため unsupported。

--- a/reports/task-t-087-followup-dictionary-key-review-r3-20260625141638.md
+++ b/reports/task-t-087-followup-dictionary-key-review-r3-20260625141638.md
@@ -1,0 +1,79 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-087 follow-up の Attribute key access test 追加を含む差分レビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer により完了前の dedicated review が必須であり、ユーザー指定により gpt-5.5 high の sub-agent でレビューするため。
+
+## 対象範囲
+
+- 対象: PR #40 follow-up 差分全体、特に `Attribute["..."].Value` による E2E 検証が `AtIndex` 依存を残していないか。
+
+## 対象外
+
+- 対象外: 新規仕様追加、object/composite key の path 復元、dynamic projection の再設計。
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `sed -n '1,240p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `sed -n '1,240p' /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - `sed -n '1,260p' reports/task-t-087-followup-dictionary-key-review-r3-20260625141638.md`
+  - `git status --short`
+  - `git diff --stat`
+  - `git diff --check`
+  - `git diff -- src/SSC.Generators/ParallelViewGenerator.cs`
+  - `git diff -- src/SSC/GeneratedProjectionRuntime.cs`
+  - `git diff -- src/SSC/ParallelCompareApi.cs src/SSC/ParallelNode.cs`
+  - `sed -n '1,260p' reports/task-t-087-followup-dictionary-key-20260625135623.md`
+  - `git diff -- tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - `git diff -- tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+  - `git diff -- doc/design/detail/01-DomainModel.md doc/design/detail/02-PublicApi.md`
+  - `git diff -- tasks/phases-status.md tasks/tasks-status.md`
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`
+    - Passed. Failed: 0, Passed: 15, Skipped: 0.
+  - `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/markdown-word-checker/SKILL.md`
+  - `find tools/lint -maxdepth 2 -type f -print`
+    - `tools/lint` 配下の lint 設定ファイルなし。
+  - `test -f package.json && sed -n '1,220p' package.json || true`
+    - `package.json` は `{}`。
+  - `npm run lint:md`
+    - Unsupported: `Missing script: "lint:md"`。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC.Generators/ParallelViewGenerator.cs`
+  - `src/SSC/GeneratedProjectionRuntime.cs`
+  - `src/SSC/ParallelCompareApi.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+  - `doc/design/detail/01-DomainModel.md`
+  - `doc/design/detail/02-PublicApi.md`
+  - `tasks/phases-status.md`
+  - `tasks/tasks-status.md`
+  - `reports/task-t-087-followup-dictionary-key-20260625135623.md`
+  - `reports/task-t-087-followup-dictionary-key-review-r3-20260625141638.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。
+  - Attribute key access test は `root.Root.Attribute["id"].Value`、`root.Root.Attribute["source"].Value`、nested `root.Root.ChildrenOfNode[0].Attribute["name"].Value` を直接検証しており、Attribute の値アクセスは `AtIndex` 依存に戻っていない。
+  - Dictionary generated access は generator が Dictionary member を `ParallelGeneratedDictionary<TKey, TElement, TView>` として生成し、runtime が compare 時の normalized `KeyValue` と `KeyComparer` で `dict[key]` lookup するため、string key 限定ではなく typed key access になっている。
+  - diff path bracket discriminator access は Dictionary 側で `ByPathKey(string)` に分離され、key union 順 access は `AtIndex(int)` に分離されている。
+  - key なし List は従来どおり index 順 access で、今回の Dictionary typed key indexer とは分離されている。
+
+## 結果
+
+- 結果: T-087 follow-up 差分はレビュー観点を満たしており、blocking finding はなし。`git diff --check` と指定 E2E は成功。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - object/composite key の path 復元と dynamic projection の再設計は対象外。
+  - Markdown lint は repository 側に `lint:md` script と repo-local `tools/lint` 設定がないため unsupported。Markdown 文言の機械チェックは pass として扱っていない。

--- a/reports/task-t-087-implementation-20260625132744.md
+++ b/reports/task-t-087-implementation-20260625132744.md
@@ -1,0 +1,58 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087: generated projection list の key text indexer 追加
+
+## sub-agentを使う理由
+ユーザー報告の CustomXML Attribute key access 不具合について、TDD による実装を sub-agent に委譲するため。
+
+## 対象範囲
+- `ParallelGeneratedList<TElement, TView>` に `this[string keyText]` を追加する
+- key text lookup を generated list instance 内で cache する
+- missing key を `CompareExecutionException` / `CompareIssueCode.KeyNotFound` で失敗させる
+- CustomXML の `root.Root.Attribute["id"]` key access を E2E で検証する
+
+## 対象外
+- dynamic projection の key access 変更
+- container normalization semantics の変更
+- Source Generator の model shape 変更
+- PR 作成、最終 review、tracking 完了処理
+
+## 実行コマンド
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（実装前 failing proof: `root.Root.Attribute["id"].Value[0]` / `root.Groups["1"]` などが `CS1503: Argument 1: cannot convert from 'string' to 'int'`、`CompareIssueCode.KeyNotFound` が `CS0117`）
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（実装後: Passed 11 / Failed 0 / Skipped 0）
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests"`（追加要件実装前 failing proof: diff path selector `A\]B` が `KeyNotFound`）
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（追加要件実装後: Passed 12 / Failed 0 / Skipped 0）
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（レビュー対応後: Passed 12 / Failed 0 / Skipped 0）
+- `git diff --check`（成功）
+
+## 対象ファイル
+- `src/SSC/Contracts.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+
+## 指摘事項
+- 実装前は generated list に `string` indexer がなく、CustomXML の `Attribute["id"]` と通常 generated projection container の key text access が compile error になった。
+- `CompareIssueCode.KeyNotFound` も未定義だったため、missing key の契約を表現できなかった。
+- 追加要件の実装前は raw `NodeMeta.KeyText` のみ検索していたため、`GetDiffEntries()` の `Attribute[A\]B]` から取り出した bracket text `A\]B` では generated access できなかった。
+- レビューで `CompareIssueCode.KeyNotFound` の enum 追加位置、escaped discriminator と raw key の曖昧性、テスト helper の selector 抽出ロジックが指摘された。
+
+## 結果
+- `CompareIssueCode.KeyNotFound` を追加した。
+- `ParallelGeneratedList<TElement, TView>` に `this[string keyText]` を追加し、`_nodes[index].KeyText` を `StringComparer.Ordinal` の lazy `Dictionary<string, int>` cache で検索するようにした。
+- key 未検出時は `CompareExecutionException` / `CompareIssueCode.KeyNotFound` を投げるようにした。
+- CustomXML の `root.Root.Attribute["id"].Value[0]` と、通常 generated projection の `Groups["1"]` / `Items["100"]` / `Scores["A"]` を E2E で検証した。
+- missing key は `CompareIssueCode.KeyNotFound` の `CompareExecutionException` になることを E2E で検証した。
+- 既存の index access と `SelectModel` は対象 E2E 内で継続して検証され、成功した。
+- raw key lookup で未検出の場合に XPath-like escaped discriminator として `\]` / `\\` / `\#` を unescape し、再検索する fallback を追加した。
+- `GetDiffEntries()` の path から bracket 内 selector を取り出し、`root.Root.Attribute[selector]` で `A]B` と `#0` の dictionary child にアクセスできることを E2E で検証した。
+- `CompareIssueCode.KeyNotFound` を enum 末尾へ移動し、既存 underlying value を維持した。
+- 有効な XPath-like escape を含む入力では unescape lookup を raw lookup より優先し、見つからない場合だけ raw lookup に fallback するようにした。
+- `A]B` と raw key `A\]B` が共存するケースを E2E に追加し、diff path selector `A\]B` は `A]B` 側へ、raw key `A\]B` の diff path selector は raw key 側へ解決されることを検証した。
+- テスト helper の selector 抽出を bracket 内 escape state で閉じ bracket を判定する実装へ変更した。
+
+## リスク
+- 検証は指定された E2E フィルタと `git diff --check` に限定した。全 test suite は未実行。
+- key index cache は generated list instance 単位の lazy 構築で、同一 key が万一重複した場合は最初の node を保持する。通常の normalized container では key union により重複しない前提。
+- 不正 escape は raw key としても見つからない場合に `KeyNotFound` として失敗する。object/composite key の完全復元は対象外。

--- a/reports/task-t-087-review-20260625133338.md
+++ b/reports/task-t-087-review-20260625133338.md
@@ -1,0 +1,62 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087: generated projection list key text access のコードレビュー
+
+## sub-agentを使う理由
+review-enforcer によりレビューは mandatory sub-agent work。gpt-5.5 high で key access と diff path selector 互換を独立確認する。
+
+## 対象範囲
+- `ParallelGeneratedList<TElement, TView>` の string key indexer
+- `CompareIssueCode.KeyNotFound`
+- CustomXML Attribute key access E2E
+- `GetDiffEntries().Path` の escaped discriminator 互換 E2E
+- 設計書・tracking との整合
+- Markdown lint disposition: `npm run lint:md` は missing script のため unsupported、`git diff --check` は成功
+
+## 対象外
+- dynamic projection の key access 変更
+- container normalization semantics の変更
+- Source Generator の type graph 変更
+- PR 作成、commit、progress sync
+
+## 実行コマンド
+- `git status --short --branch`
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+- `git diff origin/main...HEAD -- doc/design/detail/01-DomainModel.md doc/design/detail/02-PublicApi.md doc/design/detail/05-ResultAndErrors.md doc/design/detail/08-ImplementationChecklist.md tasks/tasks-status.md tasks/phases-status.md`
+- `git diff -- src/SSC/Contracts.cs src/SSC/GeneratedProjectionRuntime.cs tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs doc/design/detail/02-PublicApi.md`
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（Passed 12 / Failed 0 / Skipped 0）
+- `git diff --check`（成功）
+- `npm run lint:md`（Missing script: `lint:md` のため unsupported）
+
+## 対象ファイル
+- `src/SSC/Contracts.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- `doc/design/detail/01-DomainModel.md`
+- `doc/design/detail/02-PublicApi.md`
+- `doc/design/detail/05-ResultAndErrors.md`
+- `doc/design/detail/08-ImplementationChecklist.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
+
+## 指摘事項
+- Blocking findings:
+  - Medium: `src/SSC/Contracts.cs:25` で public enum `CompareIssueCode` に `KeyNotFound` を `ReflectionMetadataBuildFailed` の前へ挿入しており、既存 member `ReflectionMetadataBuildFailed` の underlying value が変わる。enum の数値値を永続化・ログ連携・外部境界で使う通常利用者を壊し得るため、`KeyNotFound` は末尾追加または明示値指定にして既存値を維持する必要がある。
+- Capability gap requiring user confirmation:
+  - Medium: `src/SSC/GeneratedProjectionRuntime.cs:62` から raw key lookup を先に行い、未検出時だけ `src/SSC/GeneratedProjectionRuntime.cs:67` で XPath-like escaped discriminator を unescape している。このため同じ container に raw key `A\]B` と key `A]B` が共存する場合、`GetDiffEntries().Path` の bracket selector `A\]B` は raw key `A\]B` に先に一致し、diff path selector として key `A]B` を指せない。単一の `this[string keyText]` で raw key text と escaped discriminator text の両方を受ける設計では曖昧性があるため、raw 優先を仕様化するか、escaped selector 優先または別 API を設けるかの確認が必要。
+- Non-blocking concerns:
+  - Low: `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs:497` からの `ExtractSelector` は closing `]` の直前が `\` なら常に escaped とみなすため、selector が escaped backslash で終わる path（例: key text `A\` の `Attribute[A\\].Value`）を正しく切り出せない。現行 runtime の通常パスを壊すものではないが、diff path 互換の regression test helper としては脆く、連続 backslash の奇偶で escaped closing bracket を判定する helper へ置き換えるか、既存 parser 相当の切り出しに寄せる余地がある。
+
+## 結果
+- 指摘あり。CustomXML の `root.Root.Attribute["id"].Value[0]`、generated projection の raw key access、missing key の `CompareExecutionException` / `CompareIssueCode.KeyNotFound`、focused E2E 12 件は確認できた。
+- `git diff --check` は成功した。
+- Markdown lint は repository の `package.json` が `{}` で `lint:md` script がないため unsupported。現時点では lint pass ではなく、review report 上の documented risk として扱う。
+- public enum value 変更は通常利用者を壊し得る blocking finding として修正が必要。
+
+## リスク
+- 全 test suite は未実行。検証は T-087 関連の focused E2E と whitespace check に限定した。
+- Markdown lint は unsupported のため、Markdown 文言・表記ゆれの自動 gate は通っていない。今回の変更は設計・tracking・report の限定更新であり、`git diff --check` は成功しているため、残リスクとして記録する。
+- raw key text と escaped discriminator text の曖昧性は、通常の `id` / numeric key / `A]B` 単独 key では表面化しないが、literal escape sequence を含む key と unescaped key が共存する場合に仕様確認が必要。

--- a/reports/task-t-087-review-r2-20260625133952.md
+++ b/reports/task-t-087-review-r2-20260625133952.md
@@ -1,0 +1,53 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087: review finding 対応後の再レビュー
+
+## sub-agentを使う理由
+review-enforcer によりレビュー指摘対応後の再レビューを同じ reviewer sub-agent で確認するため。
+
+## 対象範囲
+- `CompareIssueCode.KeyNotFound` enum 追加位置の修正
+- escaped discriminator と raw key の曖昧性解消
+- `ExtractSelector` test helper 修正
+- T-087 差分全体の regression
+
+## 対象外
+- dynamic projection の key access 変更
+- PR 作成、commit、progress sync
+
+## 実行コマンド
+- `git status --short --branch`
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+- `git diff -- src/SSC/Contracts.cs src/SSC/GeneratedProjectionRuntime.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs doc/design/detail/02-PublicApi.md`
+- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"`（Passed 12 / Failed 0 / Skipped 0）
+- `git diff --check`（成功）
+- `npm run lint:md`（Missing script: `lint:md` のため unsupported）
+
+## 対象ファイル
+- `src/SSC/Contracts.cs`
+- `src/SSC/GeneratedProjectionRuntime.cs`
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+- `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+- `doc/design/detail/02-PublicApi.md`
+- `reports/task-t-087-review-20260625133338.md`
+- `reports/task-t-087-implementation-20260625132744.md`
+
+## 指摘事項
+- No findings.
+- 前回 blocking finding の `CompareIssueCode.KeyNotFound` は `src/SSC/Contracts.cs:26` で enum 末尾に追加されており、既存 `ReflectionMetadataBuildFailed` の underlying value は維持される。
+- 前回 capability gap の escaped discriminator と raw key の曖昧性は、`src/SSC/GeneratedProjectionRuntime.cs:62` から有効な XPath-like escape 入力を unescape lookup 優先にし、未検出時のみ raw lookup へ fallback する形で解消されている。
+- `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs:216` から raw key `A\]B` と key `A]B` の共存ケースを追加し、`GetDiffEntries()` 由来 selector がそれぞれ正しい child を引くことを検証している。
+- 前回 non-blocking concern の `ExtractSelector` は `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs:516` から bracket 内 escape state で closing bracket を判定する実装へ修正されている。
+
+## 結果
+- 再レビューで新規 blocker は見つからなかった。
+- 前回指摘 3 点は対応済みと判断する。
+- focused E2E は Passed 12 / Failed 0 / Skipped 0。
+- `git diff --check` は成功した。
+- Markdown lint は repository の `package.json` が `{}` で `lint:md` script がないため unsupported。lint pass ではなく、残リスクとして記録する。
+
+## リスク
+- 全 test suite は未実行。検証は T-087 関連の focused E2E と whitespace check に限定した。
+- Markdown lint は unsupported のため、Markdown 文言・表記ゆれの自動 gate は通っていない。今回の再レビューでは、`git diff --check` 成功と report 上の unsupported 記録を disposition とする。

--- a/reports/task-t-087-verification-20260625134141.md
+++ b/reports/task-t-087-verification-20260625134141.md
@@ -1,0 +1,42 @@
+# Sub-agent実行レポート
+
+## タスク
+T-087: full validation
+
+## sub-agentを使う理由
+codex-delegation-executor により test/build/verification evidence は mandatory sub-agent work として実施するため。
+
+## 対象範囲
+- T-087 差分適用後の solution test
+- format check
+- whitespace diff check
+- Markdown lint availability check
+
+## 対象外
+- コード編集
+- PR 作成、commit、tracking 更新
+
+## 実行コマンド
+- `dotnet test SSC.sln --configuration Release`
+- `dotnet format SSC.sln --verify-no-changes`
+- `git diff --check`
+- `npm run lint:md`
+
+## 対象ファイル
+- `SSC.sln`
+- T-087 差分全体
+- `reports/task-t-087-verification-20260625134141.md`
+
+## 指摘事項
+- `npm run lint:md` は `Missing script: "lint:md"` で unsupported。
+- `npm run lint:md` 実行時に `/home/ibis/.npm/_logs` へログを書き込めない旨の npm error が出力された。
+
+## 結果
+- `dotnet test SSC.sln --configuration Release`: 成功。E2E Tests 68 passed、Unit Tests 29 passed。
+- `dotnet format SSC.sln --verify-no-changes`: 成功。
+- `git diff --check`: 成功。
+- `npm run lint:md`: unsupported。`lint:md` script が存在しないため実行不可。
+
+## リスク
+- Markdown lint は repository script 不在のため未検証。
+- npm log directory 書き込み不可のため、npm の詳細ログは生成されていない。

--- a/src/SSC.Generators/ParallelViewGenerator.cs
+++ b/src/SSC.Generators/ParallelViewGenerator.cs
@@ -171,8 +171,18 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
                 }
 
                 var elementTypeName = member.ElementType.ToDisplayString(TypeDisplayFormat);
-                source.AppendLine($"    public global::SSC.ParallelGeneratedList<{elementTypeName}, {childViewName}> {memberName} =>");
-                source.AppendLine($"        new(_node.GetChildren<{elementTypeName}>(nameof({modelTypeName}.{memberName})), _node.Count, static child => new {childViewName}(child));");
+                if (member.KeyType is not null)
+                {
+                    var keyTypeName = member.KeyType.ToDisplayString(TypeDisplayFormat);
+                    source.AppendLine($"    public global::SSC.ParallelGeneratedDictionary<{keyTypeName}, {elementTypeName}, {childViewName}> {memberName} =>");
+                    source.AppendLine($"        new(_node.GetChildren<{elementTypeName}>(nameof({modelTypeName}.{memberName})), _node.Count, static child => new {childViewName}(child));");
+                }
+                else
+                {
+                    source.AppendLine($"    public global::SSC.ParallelGeneratedList<{elementTypeName}, {childViewName}> {memberName} =>");
+                    source.AppendLine($"        new(_node.GetChildren<{elementTypeName}>(nameof({modelTypeName}.{memberName})), _node.Count, static child => new {childViewName}(child));");
+                }
+
                 source.AppendLine();
                 continue;
             }
@@ -219,10 +229,10 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
             var members = new List<MemberShape>();
             foreach (var property in GetComparableMembers(type))
             {
-                if (TryGetDictionaryValueType(property.Type, out var dictionaryElementType)
+                if (TryGetDictionaryTypes(property.Type, out var dictionaryKeyType, out var dictionaryElementType)
                     && dictionaryElementType is INamedTypeSymbol dictionaryElementNamedType)
                 {
-                    members.Add(MemberShape.Container(property.Name, dictionaryElementNamedType));
+                    members.Add(MemberShape.Dictionary(property.Name, dictionaryKeyType, dictionaryElementNamedType));
                     queue.Enqueue(dictionaryElementNamedType);
                     continue;
                 }
@@ -313,7 +323,7 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
             attribute.AttributeClass?.ToDisplayString() == fullTypeName);
     }
 
-    private static bool TryGetDictionaryValueType(ITypeSymbol type, out ITypeSymbol valueType)
+    private static bool TryGetDictionaryTypes(ITypeSymbol type, out ITypeSymbol keyType, out ITypeSymbol valueType)
     {
         foreach (var candidate in EnumerateSelfAndInterfaces(type))
         {
@@ -328,10 +338,12 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
                 continue;
             }
 
+            keyType = named.TypeArguments[0];
             valueType = named.TypeArguments[1];
             return true;
         }
 
+        keyType = null!;
         valueType = null!;
         return false;
     }
@@ -364,7 +376,7 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
             return false;
         }
 
-        if (TryGetDictionaryValueType(type, out _))
+        if (TryGetDictionaryTypes(type, out _, out _))
         {
             elementType = null!;
             return false;
@@ -556,12 +568,14 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         private MemberShape(
             string memberName,
             MemberKind kind,
+            ITypeSymbol? keyType,
             INamedTypeSymbol? elementType,
             INamedTypeSymbol? objectType,
             ITypeSymbol? valueType)
         {
             MemberName = memberName;
             Kind = kind;
+            KeyType = keyType;
             ElementType = elementType;
             ObjectType = objectType;
             ValueType = valueType;
@@ -571,6 +585,8 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
 
         public MemberKind Kind { get; }
 
+        public ITypeSymbol? KeyType { get; }
+
         public INamedTypeSymbol? ElementType { get; }
 
         public INamedTypeSymbol? ObjectType { get; }
@@ -578,12 +594,15 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
         public ITypeSymbol? ValueType { get; }
 
         public static MemberShape Container(string memberName, INamedTypeSymbol elementType) =>
-            new(memberName, MemberKind.Container, elementType, null, null);
+            new(memberName, MemberKind.Container, null, elementType, null, null);
+
+        public static MemberShape Dictionary(string memberName, ITypeSymbol keyType, INamedTypeSymbol elementType) =>
+            new(memberName, MemberKind.Container, keyType, elementType, null, null);
 
         public static MemberShape Object(string memberName, INamedTypeSymbol objectType) =>
-            new(memberName, MemberKind.Object, null, objectType, null);
+            new(memberName, MemberKind.Object, null, null, objectType, null);
 
         public static MemberShape Value(string memberName, ITypeSymbol valueType) =>
-            new(memberName, MemberKind.Value, null, null, valueType);
+            new(memberName, MemberKind.Value, null, null, null, valueType);
     }
 }

--- a/src/SSC/Contracts.cs
+++ b/src/SSC/Contracts.cs
@@ -23,6 +23,7 @@ public enum CompareIssueCode
     DuplicateCompareKeyDetected,
     ModelIndexOutOfRange,
     ReflectionMetadataBuildFailed,
+    KeyNotFound,
 }
 
 public sealed class CompareIssue

--- a/src/SSC/GeneratedProjectionRuntime.cs
+++ b/src/SSC/GeneratedProjectionRuntime.cs
@@ -16,6 +16,158 @@ public readonly struct ParallelGeneratedMeta
     public ValueState GetState(int modelIndex) => _node.GetState(modelIndex);
 }
 
+public sealed class ParallelGeneratedDictionary<TKey, TElement, TView> : IEnumerable<TView>
+    where TKey : notnull
+{
+    private readonly IReadOnlyList<ParallelNode<TElement>> _nodes;
+    private readonly int _modelCount;
+    private readonly Func<ParallelNode<TElement>, TView> _viewFactory;
+    private Dictionary<string, int>? _keyIndexCache;
+    private Dictionary<object, int>? _keyValueIndexCache;
+
+    public ParallelGeneratedDictionary(
+        IReadOnlyList<ParallelNode<TElement>> nodes,
+        int modelCount,
+        Func<ParallelNode<TElement>, TView> viewFactory)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentOutOfRangeException.ThrowIfNegative(modelCount);
+        ArgumentNullException.ThrowIfNull(viewFactory);
+        _nodes = nodes;
+        _modelCount = modelCount;
+        _viewFactory = viewFactory;
+    }
+
+    public int Count => _nodes.Count;
+
+    public TView this[TKey key]
+    {
+        get
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            return ResolveByKeyValue(NormalizeKey(key));
+        }
+    }
+
+    public TView AtIndex(int index)
+    {
+        ValidateIndex(index);
+        return _viewFactory(_nodes[index]);
+    }
+
+    public TView ByPathKey(string discriminator)
+    {
+        ArgumentNullException.ThrowIfNull(discriminator);
+        if (!ParallelGeneratedKeyText.TryUnescapeXPathLikeDiscriminator(discriminator, out var keyText))
+        {
+            keyText = discriminator;
+        }
+
+        return ResolveByKeyText(keyText, "generated dictionary");
+    }
+
+    public ParallelGeneratedModelList<TElement, TView> SelectModel(int modelIndex)
+    {
+        ValidateModelIndex(modelIndex);
+        return new ParallelGeneratedModelList<TElement, TView>(_nodes, _viewFactory, modelIndex);
+    }
+
+    public IEnumerator<TView> GetEnumerator()
+    {
+        for (var index = 0; index < _nodes.Count; index++)
+        {
+            yield return _viewFactory(_nodes[index]);
+        }
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private TView ResolveByKeyText(string keyText, string containerName)
+    {
+        if (GetKeyIndexCache().TryGetValue(keyText, out var index))
+        {
+            return _viewFactory(_nodes[index]);
+        }
+
+        throw new CompareExecutionException(
+            CompareIssueCode.KeyNotFound,
+            $"key '{keyText}' was not found in {containerName}.");
+    }
+
+    private TView ResolveByKeyValue(object key)
+    {
+        if (GetKeyValueIndexCache().TryGetValue(key, out var index))
+        {
+            return _viewFactory(_nodes[index]);
+        }
+
+        throw new CompareExecutionException(
+            CompareIssueCode.KeyNotFound,
+            $"key '{key}' was not found in generated dictionary.");
+    }
+
+    private void ValidateIndex(int index)
+    {
+        if (index >= 0 && index < _nodes.Count)
+        {
+            return;
+        }
+
+        throw new CompareExecutionException(
+            CompareIssueCode.ModelIndexOutOfRange,
+            $"dictionary index '{index}' is out of range for count '{_nodes.Count}'.");
+    }
+
+    private void ValidateModelIndex(int modelIndex)
+    {
+        if (modelIndex >= 0 && modelIndex < _modelCount)
+        {
+            return;
+        }
+
+        throw new CompareExecutionException(
+            CompareIssueCode.ModelIndexOutOfRange,
+            $"model index '{modelIndex}' is out of range for count '{_modelCount}'.");
+    }
+
+    private Dictionary<string, int> GetKeyIndexCache()
+    {
+        if (_keyIndexCache is not null)
+        {
+            return _keyIndexCache;
+        }
+
+        _keyIndexCache = ParallelGeneratedKeyText.CreateKeyIndexCache(_nodes);
+        return _keyIndexCache;
+    }
+
+    private Dictionary<object, int> GetKeyValueIndexCache()
+    {
+        if (_keyValueIndexCache is not null)
+        {
+            return _keyValueIndexCache;
+        }
+
+        var comparer = _nodes.FirstOrDefault(static node => node.KeyComparer is not null)?.KeyComparer
+            ?? EqualityComparer<object>.Default;
+        var keyValueIndexCache = new Dictionary<object, int>(comparer);
+        for (var index = 0; index < _nodes.Count; index++)
+        {
+            var keyValue = _nodes[index].KeyValue;
+            if (keyValue is not null)
+            {
+                keyValueIndexCache.TryAdd(keyValue, index);
+            }
+        }
+
+        _keyValueIndexCache = keyValueIndexCache;
+        return _keyValueIndexCache;
+    }
+
+    private static object NormalizeKey(object key) =>
+        key is DateTime dateTime ? dateTime.ToUniversalTime() : key;
+}
+
 public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView>
 {
     private readonly IReadOnlyList<ParallelNode<TElement>> _nodes;
@@ -59,7 +211,7 @@ public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView
             ArgumentNullException.ThrowIfNull(keyText);
 
             var keyIndexCache = GetKeyIndexCache();
-            if (TryUnescapeXPathLikeDiscriminator(keyText, out var unescapedKeyText)
+            if (ParallelGeneratedKeyText.TryUnescapeXPathLikeDiscriminator(keyText, out var unescapedKeyText)
                 && keyIndexCache.TryGetValue(unescapedKeyText, out var index))
             {
                 return _viewFactory(_nodes[index]);
@@ -113,21 +265,43 @@ public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView
             return _keyIndexCache;
         }
 
-        var keyIndexCache = new Dictionary<string, int>(StringComparer.Ordinal);
+        _keyIndexCache = ParallelGeneratedKeyText.CreateKeyIndexCache(_nodes);
+        return _keyIndexCache;
+    }
+
+    public TView AtIndex(int index) => this[index];
+
+    public TView ByPathKey(string discriminator) => this[discriminator];
+
+    public IEnumerator<TView> GetEnumerator()
+    {
         for (var index = 0; index < _nodes.Count; index++)
         {
-            var keyText = _nodes[index].KeyText;
+            yield return _viewFactory(_nodes[index]);
+        }
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal static class ParallelGeneratedKeyText
+{
+    public static Dictionary<string, int> CreateKeyIndexCache<TElement>(IReadOnlyList<ParallelNode<TElement>> nodes)
+    {
+        var keyIndexCache = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var index = 0; index < nodes.Count; index++)
+        {
+            var keyText = nodes[index].KeyText;
             if (keyText is not null)
             {
                 keyIndexCache.TryAdd(keyText, index);
             }
         }
 
-        _keyIndexCache = keyIndexCache;
         return keyIndexCache;
     }
 
-    private static bool TryUnescapeXPathLikeDiscriminator(string keyText, out string unescapedKeyText)
+    public static bool TryUnescapeXPathLikeDiscriminator(string keyText, out string unescapedKeyText)
     {
         var builder = new System.Text.StringBuilder(keyText.Length);
         var changed = false;
@@ -160,16 +334,6 @@ public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView
         unescapedKeyText = changed ? builder.ToString() : keyText;
         return changed;
     }
-
-    public IEnumerator<TView> GetEnumerator()
-    {
-        for (var index = 0; index < _nodes.Count; index++)
-        {
-            yield return _viewFactory(_nodes[index]);
-        }
-    }
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }
 
 public sealed class ParallelGeneratedModelList<TElement, TView> : IReadOnlyList<TView>

--- a/src/SSC/GeneratedProjectionRuntime.cs
+++ b/src/SSC/GeneratedProjectionRuntime.cs
@@ -21,6 +21,7 @@ public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView
     private readonly IReadOnlyList<ParallelNode<TElement>> _nodes;
     private readonly int _modelCount;
     private readonly Func<ParallelNode<TElement>, TView> _viewFactory;
+    private Dictionary<string, int>? _keyIndexCache;
 
     public ParallelGeneratedList(IReadOnlyList<ParallelNode<TElement>> nodes, Func<ParallelNode<TElement>, TView> viewFactory)
         : this(nodes, nodes.Count > 0 ? nodes[0].Count : 0, viewFactory)
@@ -48,6 +49,30 @@ public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView
         {
             ValidateIndex(index);
             return _viewFactory(_nodes[index]);
+        }
+    }
+
+    public TView this[string keyText]
+    {
+        get
+        {
+            ArgumentNullException.ThrowIfNull(keyText);
+
+            var keyIndexCache = GetKeyIndexCache();
+            if (TryUnescapeXPathLikeDiscriminator(keyText, out var unescapedKeyText)
+                && keyIndexCache.TryGetValue(unescapedKeyText, out var index))
+            {
+                return _viewFactory(_nodes[index]);
+            }
+
+            if (keyIndexCache.TryGetValue(keyText, out index))
+            {
+                return _viewFactory(_nodes[index]);
+            }
+
+            throw new CompareExecutionException(
+                CompareIssueCode.KeyNotFound,
+                $"key '{keyText}' was not found in generated list.");
         }
     }
 
@@ -79,6 +104,61 @@ public sealed class ParallelGeneratedList<TElement, TView> : IReadOnlyList<TView
         throw new CompareExecutionException(
             CompareIssueCode.ModelIndexOutOfRange,
             $"model index '{modelIndex}' is out of range for count '{_modelCount}'.");
+    }
+
+    private Dictionary<string, int> GetKeyIndexCache()
+    {
+        if (_keyIndexCache is not null)
+        {
+            return _keyIndexCache;
+        }
+
+        var keyIndexCache = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var index = 0; index < _nodes.Count; index++)
+        {
+            var keyText = _nodes[index].KeyText;
+            if (keyText is not null)
+            {
+                keyIndexCache.TryAdd(keyText, index);
+            }
+        }
+
+        _keyIndexCache = keyIndexCache;
+        return keyIndexCache;
+    }
+
+    private static bool TryUnescapeXPathLikeDiscriminator(string keyText, out string unescapedKeyText)
+    {
+        var builder = new System.Text.StringBuilder(keyText.Length);
+        var changed = false;
+        for (var index = 0; index < keyText.Length; index++)
+        {
+            var current = keyText[index];
+            if (current != '\\')
+            {
+                builder.Append(current);
+                continue;
+            }
+
+            if (index + 1 >= keyText.Length)
+            {
+                unescapedKeyText = string.Empty;
+                return false;
+            }
+
+            var escaped = keyText[++index];
+            if (escaped is not (']' or '\\' or '#'))
+            {
+                unescapedKeyText = string.Empty;
+                return false;
+            }
+
+            builder.Append(escaped);
+            changed = true;
+        }
+
+        unescapedKeyText = changed ? builder.ToString() : keyText;
+        return changed;
     }
 
     public IEnumerator<TView> GetEnumerator()

--- a/src/SSC/ParallelCompareApi.cs
+++ b/src/SSC/ParallelCompareApi.cs
@@ -59,7 +59,7 @@ public static class ParallelCompareApi
             slots[index] = new NodeSlot(models[index], NodePresenceState.PresentValue);
         }
 
-        var root = (ParallelNode<T>)BuildNode(typeof(T), slots, typeof(T).Name, context, keyText: null);
+        var root = (ParallelNode<T>)BuildNode(typeof(T), slots, typeof(T).Name, context, keyText: null, keyValue: null, keyComparer: null);
         return BuildResult(root, context.Issues, config);
     }
 
@@ -74,12 +74,19 @@ public static class ParallelCompareApi
         };
     }
 
-    private static IParallelNode BuildNode(Type nodeType, NodeSlot[] slots, string path, CompareContext context, string? keyText)
+    private static IParallelNode BuildNode(
+        Type nodeType,
+        NodeSlot[] slots,
+        string path,
+        CompareContext context,
+        string? keyText,
+        object? keyValue,
+        IEqualityComparer<object>? keyComparer)
     {
         var generic = BuildNodeMethod.MakeGenericMethod(nodeType);
         try
         {
-            return (IParallelNode)generic.Invoke(null, [slots, path, context, keyText])!;
+            return (IParallelNode)generic.Invoke(null, [slots, path, context, keyText, keyValue, keyComparer])!;
         }
         catch (TargetInvocationException ex) when (ex.InnerException is CompareInputException)
         {
@@ -91,7 +98,13 @@ public static class ParallelCompareApi
         }
     }
 
-    private static IParallelNode BuildNodeGeneric<TNode>(NodeSlot[] slots, string path, CompareContext context, string? keyText)
+    private static IParallelNode BuildNodeGeneric<TNode>(
+        NodeSlot[] slots,
+        string path,
+        CompareContext context,
+        string? keyText,
+        object? keyValue,
+        IEqualityComparer<object>? keyComparer)
     {
         var typedValues = new TNode?[slots.Length];
         var states = new NodePresenceState[slots.Length];
@@ -105,7 +118,7 @@ public static class ParallelCompareApi
         }
 
         var isScalarNode = IsScalarType(typeof(TNode));
-        var node = new ParallelNode<TNode>(typedValues, states, keyText, isScalarNode);
+        var node = new ParallelNode<TNode>(typedValues, states, keyText, keyValue, keyComparer, isScalarNode);
         if (isScalarNode)
         {
             if (context.IsTraceEnabled)
@@ -156,7 +169,7 @@ public static class ParallelCompareApi
                 continue;
             }
 
-            var memberNode = BuildNode(property.MemberType, memberSlots, propertyPath, context, keyText: null);
+            var memberNode = BuildNode(property.MemberType, memberSlots, propertyPath, context, keyText: null, keyValue: null, keyComparer: null);
             node.SetMemberNode(property.Name, memberNode);
         }
 
@@ -307,7 +320,9 @@ public static class ParallelCompareApi
                 slots,
                 path,
                 context,
-                keyText: keyTexts.TryGetValue(key, out var keyText) ? keyText : KeyToText(key));
+                keyText: keyTexts.TryGetValue(key, out var keyText) ? keyText : KeyToText(key),
+                keyValue: key,
+                keyComparer: comparer);
             children.Add(childNode);
         }
 
@@ -486,7 +501,9 @@ public static class ParallelCompareApi
                 slots,
                 path,
                 context,
-                keyText: keyTexts.TryGetValue(key, out var keyText) ? keyText : KeyToText(key));
+                keyText: keyTexts.TryGetValue(key, out var keyText) ? keyText : KeyToText(key),
+                keyValue: key,
+                keyComparer: comparer);
             children.Add(childNode);
         }
 
@@ -563,7 +580,14 @@ public static class ParallelCompareApi
                 slots[modelIndex] = value is null ? NodeSlot.PresentNull : NodeSlot.PresentValue(value);
             }
 
-            children.Add(BuildNode(elementType, slots, path, context, keyText: itemIndex.ToString(CultureInfo.InvariantCulture)));
+            children.Add(BuildNode(
+                elementType,
+                slots,
+                path,
+                context,
+                keyText: itemIndex.ToString(CultureInfo.InvariantCulture),
+                keyValue: null,
+                keyComparer: null));
         }
 
         return children;

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -10,15 +10,27 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     private readonly Dictionary<string, IParallelNode> _memberNodes = new(StringComparer.Ordinal);
     private readonly List<string> _directChildOrder = [];
 
-    internal ParallelNode(T?[] values, NodePresenceState[] states, string? keyText, bool isScalarNode = false)
+    internal ParallelNode(
+        T?[] values,
+        NodePresenceState[] states,
+        string? keyText,
+        object? keyValue = null,
+        IEqualityComparer<object>? keyComparer = null,
+        bool isScalarNode = false)
     {
         _values = values;
         _states = states;
         _isScalarNode = isScalarNode;
         KeyText = keyText;
+        KeyValue = keyValue;
+        KeyComparer = keyComparer;
     }
 
     public string? KeyText { get; }
+
+    internal object? KeyValue { get; }
+
+    internal IEqualityComparer<object>? KeyComparer { get; }
 
     public int Count => _values.Length;
 

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -34,6 +34,7 @@
 
 - Status: Done
 - Notes:
+  - T-087 follow-up を完了し、Dictionary member の generated access を string key text 限定から key 型 indexer へ拡張した
   - T-087 を完了し、generated projection list で `Attribute["id"]` のような raw key text access と `GetDiffEntries().Path` の escaped discriminator access を実装した
   - T-085 を完了し、gist `XmlCustom.cs` と同等の E2E で `Document` 同士の比較が成功することを検証し、key なし sequence を ordinal 比較として扱う修正を sub-agent 実装で完了した
   - T-085 では `CompareConfiguration.MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、旧来の skip + error は `SkipAndRecordError` 明示時の opt-in とした
@@ -143,6 +144,7 @@
 
 - Status: Done
 - Notes:
+  - T-087 follow-up で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-087 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-082 を完了し、`dotnet test SSC.sln --configuration Release` が成功した（Unit tests 29 件、E2E tests 61 件）
   - T-082 では `git diff --check`、PR #32 body 確認、最終レビューを実施し、最終レビュー指摘なしを確認した

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -12,8 +12,9 @@
 
 ## Phase 2: 詳細設計確定
 
-- Status: Done
+- Status: In Progress
 - Notes:
+  - T-087 で generated projection list の key text indexer を設計中
   - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加し、実装単位を T-077 から T-082 へ分割した
   - `doc/draft/DetailDesignDraft.md` に粒度基準・章別必須項目・仕様確定結果を追記
   - Draft/非Draft を `doc/draft` と `doc/design` に分離
@@ -31,8 +32,9 @@
 
 ## Phase 3: 実装
 
-- Status: Done
+- Status: In Progress
 - Notes:
+  - T-087 の設計完了後、generated projection list へ key text indexer を実装する
   - T-085 を完了し、gist `XmlCustom.cs` と同等の E2E で `Document` 同士の比較が成功することを検証し、key なし sequence を ordinal 比較として扱う修正を sub-agent 実装で完了した
   - T-085 では `CompareConfiguration.MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、旧来の skip + error は `SkipAndRecordError` 明示時の opt-in とした
   - T-084 を完了し、gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` の Source Generator 出力を根拠に、`Document.Root` 配下の generated member 展開不足を regression test で再現して修正した

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -12,9 +12,9 @@
 
 ## Phase 2: 詳細設計確定
 
-- Status: In Progress
+- Status: Done
 - Notes:
-  - T-087 で generated projection list の key text indexer を設計中
+  - T-087 で generated projection list の key text indexer と diff path selector 互換を public API として確定した
   - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加し、実装単位を T-077 から T-082 へ分割した
   - `doc/draft/DetailDesignDraft.md` に粒度基準・章別必須項目・仕様確定結果を追記
   - Draft/非Draft を `doc/draft` と `doc/design` に分離
@@ -32,9 +32,9 @@
 
 ## Phase 3: 実装
 
-- Status: In Progress
+- Status: Done
 - Notes:
-  - T-087 の設計完了後、generated projection list へ key text indexer を実装する
+  - T-087 を完了し、generated projection list で `Attribute["id"]` のような raw key text access と `GetDiffEntries().Path` の escaped discriminator access を実装した
   - T-085 を完了し、gist `XmlCustom.cs` と同等の E2E で `Document` 同士の比較が成功することを検証し、key なし sequence を ordinal 比較として扱う修正を sub-agent 実装で完了した
   - T-085 では `CompareConfiguration.MissingCompareKeyListPolicy` の既定値を `AlignByIndex` に変更し、旧来の skip + error は `SkipAndRecordError` 明示時の opt-in とした
   - T-084 を完了し、gist `YXml.cs` と生成済み `global_Document.ParallelGenerated.g.cs` の Source Generator 出力を根拠に、`Document.Root` 配下の generated member 展開不足を regression test で再現して修正した
@@ -143,6 +143,7 @@
 
 - Status: Done
 - Notes:
+  - T-087 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-082 を完了し、`dotnet test SSC.sln --configuration Release` が成功した（Unit tests 29 件、E2E tests 61 件）
   - T-082 では `git diff --check`、PR #32 body 確認、最終レビューを実施し、最終レビュー指摘なしを確認した
   - Markdown 検査はユーザー指示により未実施

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,9 +4,17 @@
 
 ## In Progress
 
+- なし
+
+## Backlog
+
+- なし
+
+## Done
+
 - T-087: generated projection list の key text indexer 追加
-  - Status: 設計中（CustomXML の `Attribute` のように key union 済みの generated container を、ordinal index だけでなく key text で直接参照できるようにする）
-  - Phase: Phase 2
+  - Status: 完了（CustomXML の `Attribute` のように key union 済みの generated container を、ordinal index だけでなく key text と diff path selector で直接参照できるようにした）
+  - Phase: Phase 3
   - Estimate: S
   - Depends on:
     - T-084 Source Generator の object member 展開不足修正
@@ -17,12 +25,30 @@
     - missing key は `CompareExecutionException` と専用 `CompareIssueCode` で失敗する
     - key access は繰り返し利用時に線形探索を避ける
     - TDD、実装修正、検証、sub-agent review、PR 更新が完了している
-
-## Backlog
-
-- なし
-
-## Done
+  - Output:
+    - PR #40
+    - `src/SSC/Contracts.cs`
+    - `src/SSC/GeneratedProjectionRuntime.cs`
+    - `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+    - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+    - `doc/design/detail/01-DomainModel.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `doc/design/detail/05-ResultAndErrors.md`
+    - `doc/design/detail/08-ImplementationChecklist.md`
+    - `reports/task-t-087-implementation-20260625132744.md`
+    - `reports/task-t-087-review-20260625133338.md`
+    - `reports/task-t-087-review-r2-20260625133952.md`
+    - `reports/task-t-087-verification-20260625134141.md`
+  - Verification:
+    - TDD 赤確認: generated list の string indexer 不在による compile error
+    - TDD 赤確認: diff path selector `A\]B` が generated key access で `KeyNotFound`
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"` 成功（12 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（E2E 68 件 / Unit 29 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+    - gpt-5.5 medium implementation / verification sub-agent 実施
+    - gpt-5.5 high review / re-review sub-agent 実施、最終指摘なし
 
 - T-085: gist `XmlCustom` 同等 E2E 比較の修正
   - Status: 完了（gist `XmlCustom.cs` と同等の XML custom model / parser を E2E に用意し、key なし sequence を ordinal 比較として扱うことで Source Generator 付き `Document` 同士の比較を成功させた）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,7 +4,19 @@
 
 ## In Progress
 
-- なし
+- T-087: generated projection list の key text indexer 追加
+  - Status: 設計中（CustomXML の `Attribute` のように key union 済みの generated container を、ordinal index だけでなく key text で直接参照できるようにする）
+  - Phase: Phase 2
+  - Estimate: S
+  - Depends on:
+    - T-084 Source Generator の object member 展開不足修正
+    - T-085 gist `XmlCustom` 同等 E2E 比較の修正
+  - Exit Criteria:
+    - `ParallelGeneratedList<TElement, TView>` で `this[string keyText]` による key access ができる
+    - `root.Root.Attribute["id"].Value[0]` のように CustomXML の attribute を key で参照できる
+    - missing key は `CompareExecutionException` と専用 `CompareIssueCode` で失敗する
+    - key access は繰り返し利用時に線形探索を避ける
+    - TDD、実装修正、検証、sub-agent review、PR 更新が完了している
 
 ## Backlog
 

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -4,15 +4,54 @@
 
 ## In Progress
 
-- なし
+なし
 
 ## Backlog
 
-- なし
+なし
 
 ## Done
 
-- T-087: generated projection list の key text indexer 追加
+- T-087: generated projection dictionary key 型 access follow-up
+  - Status: 完了（Dictionary member を string key text 限定ではなく、通常の Dictionary に近い key 型 indexer で参照できるようにした）
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-084 Source Generator の object member 展開不足修正
+    - T-085 gist `XmlCustom` 同等 E2E 比較の修正
+  - Exit Criteria:
+    - Dictionary member が `ParallelGeneratedDictionary<TKey, TElement, TView>` として生成される
+    - `root.Root.Attribute["id"].Value[0]` のような string key dictionary access ができる
+    - `root.Scores[100][0]` のような non-string key dictionary access ができる
+    - `GetDiffEntries().Path` の bracket discriminator は `ByPathKey(discriminator)` で参照できる
+    - Dictionary の key union 順 access は `AtIndex(index)` で維持される
+    - missing key は `CompareExecutionException` と `CompareIssueCode.KeyNotFound` で失敗する
+    - TDD、実装修正、検証、sub-agent review、PR 更新が完了している
+  - Output:
+    - PR #40
+    - `src/SSC.Generators/ParallelViewGenerator.cs`
+    - `src/SSC/GeneratedProjectionRuntime.cs`
+    - `src/SSC/ParallelCompareApi.cs`
+    - `src/SSC/ParallelNode.cs`
+    - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+    - `tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs`
+    - `doc/design/detail/01-DomainModel.md`
+    - `doc/design/detail/02-PublicApi.md`
+    - `reports/task-t-087-followup-dictionary-key-20260625135623.md`
+    - `reports/task-t-087-followup-dictionary-key-review-20260625140236.md`
+    - `reports/task-t-087-followup-dictionary-key-review-r2-20260625141147.md`
+    - `reports/task-t-087-followup-dictionary-key-review-r3-20260625141638.md`
+  - Verification:
+    - TDD 赤確認: `root.Scores[100]` が ordinal index access として解決され、範囲外で失敗
+    - TDD 赤確認: case-insensitive string key と DateTime normalized key が `KeyNotFound` で失敗
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"` 成功（15 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（E2E 71 件 / Unit 29 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+    - gpt-5.5 high review / re-review sub-agent 実施、最終指摘なし
+
+- T-087: generated projection list の key text indexer 追加（初回実装）
   - Status: 完了（CustomXML の `Attribute` のように key union 済みの generated container を、ordinal index だけでなく key text と diff path selector で直接参照できるようにした）
   - Phase: Phase 3
   - Estimate: S

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -40,8 +40,8 @@ public sealed class GeneratedProjectionE2ETests
         var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
 
         Assert.Equal("root", root.Root.Name[0]);
-        Assert.Equal("right", root.Root.Attribute[0].Value[1]);
-        Assert.Equal(ValueState.Mismatched, root.Root.Attribute[0].Value.GetState(0));
+        Assert.Equal("right", root.Root.Attribute["id"].Value[1]);
+        Assert.Equal(ValueState.Mismatched, root.Root.Attribute["id"].Value.GetState(0));
         Assert.Equal(1, root.Root.Range.StartLine[0]);
         Assert.Equal(4, root.Root.Range.EndLine[1]);
     }
@@ -171,8 +171,110 @@ public sealed class GeneratedProjectionE2ETests
         Assert.Equal(1.0, root.Groups["1"].Items["100"].MetricA[0]);
         Assert.Equal(10, root.Scores["A"][0]);
 
-        Assert.Equal(10, root.Scores[0][0]);
-        Assert.Equal(20, root.Scores[0][1]);
+        Assert.Equal(10, root.Scores.AtIndex(0)[0]);
+        Assert.Equal(20, root.Scores.AtIndex(0)[1]);
+    }
+
+    [Fact]
+    public void Compare_GeneratedProjection_DictionaryIntKeyAccess_UsesRawKey()
+    {
+        // Intent: generated dictionary access は ordinal ではなく Dictionary<TKey,TValue> と同じ key 型で引ける。
+        var models = new[]
+        {
+            new GeneratedIntScoreDataset
+            {
+                Scores = new Dictionary<int, int>
+                {
+                    [100] = 10,
+                    [200] = 11,
+                },
+            },
+            new GeneratedIntScoreDataset
+            {
+                Scores = new Dictionary<int, int>
+                {
+                    [100] = 20,
+                    [300] = 21,
+                },
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        Assert.Equal(10, root.Scores[100][0]);
+        Assert.Equal(20, root.Scores[100][1]);
+        Assert.Equal(ValueState.Missing, root.Scores[200].GetState(1));
+
+        var exception = Assert.Throws<CompareExecutionException>(() =>
+        {
+            var _ = root.Scores[999];
+        });
+
+        Assert.Equal(CompareIssueCode.KeyNotFound, exception.Code);
+    }
+
+    [Fact]
+    public void Compare_GeneratedProjection_DictionaryStringKeyAccess_UsesConfiguredKeyComparison()
+    {
+        // Intent: generated dictionary access は compare runtime と同じ string key comparer を使う。
+        var models = new[]
+        {
+            new GeneratedDataset
+            {
+                Scores = new Dictionary<string, int>
+                {
+                    ["A"] = 10,
+                },
+            },
+            new GeneratedDataset
+            {
+                Scores = new Dictionary<string, int>
+                {
+                    ["a"] = 20,
+                },
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(
+            models,
+            new CompareConfiguration { StringKeyComparison = StringComparison.OrdinalIgnoreCase }).AsGeneratedView()!;
+
+        Assert.Equal(10, root.Scores["A"][0]);
+        Assert.Equal(20, root.Scores["A"][1]);
+        Assert.Equal(10, root.Scores["a"][0]);
+        Assert.Equal(20, root.Scores["a"][1]);
+    }
+
+    [Fact]
+    public void Compare_GeneratedProjection_DictionaryDateTimeKeyAccess_UsesNormalizedKey()
+    {
+        // Intent: generated dictionary access は compare runtime と同じ DateTime UTC 正規化 key を使う。
+        var localKey = new DateTime(2026, 6, 25, 9, 0, 0, DateTimeKind.Local);
+        var utcKey = localKey.ToUniversalTime();
+        var models = new[]
+        {
+            new GeneratedDateTimeScoreDataset
+            {
+                Scores = new Dictionary<DateTime, int>
+                {
+                    [localKey] = 10,
+                },
+            },
+            new GeneratedDateTimeScoreDataset
+            {
+                Scores = new Dictionary<DateTime, int>
+                {
+                    [utcKey] = 20,
+                },
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        Assert.Equal(10, root.Scores[localKey][0]);
+        Assert.Equal(20, root.Scores[localKey][1]);
+        Assert.Equal(10, root.Scores[utcKey][0]);
+        Assert.Equal(20, root.Scores[utcKey][1]);
     }
 
     [Fact]
@@ -241,12 +343,12 @@ public sealed class GeneratedProjectionE2ETests
         var escapedBracketSelector = ExtractSelector(FindDiffPathByLeftValue(entries, "left-escaped-bracket"));
         var hashSelector = ExtractSelector(FindDiffPathByLeftValue(entries, "left-hash"));
 
-        Assert.Equal("left-bracket", root.Root.Attribute[bracketSelector].Value[0]);
-        Assert.Equal("right-bracket", root.Root.Attribute[bracketSelector].Value[1]);
-        Assert.Equal("left-escaped-bracket", root.Root.Attribute[escapedBracketSelector].Value[0]);
-        Assert.Equal("right-escaped-bracket", root.Root.Attribute[escapedBracketSelector].Value[1]);
-        Assert.Equal("left-hash", root.Root.Attribute[hashSelector].Value[0]);
-        Assert.Equal("right-hash", root.Root.Attribute[hashSelector].Value[1]);
+        Assert.Equal("left-bracket", root.Root.Attribute.ByPathKey(bracketSelector).Value[0]);
+        Assert.Equal("right-bracket", root.Root.Attribute.ByPathKey(bracketSelector).Value[1]);
+        Assert.Equal("left-escaped-bracket", root.Root.Attribute.ByPathKey(escapedBracketSelector).Value[0]);
+        Assert.Equal("right-escaped-bracket", root.Root.Attribute.ByPathKey(escapedBracketSelector).Value[1]);
+        Assert.Equal("left-hash", root.Root.Attribute.ByPathKey(hashSelector).Value[0]);
+        Assert.Equal("right-hash", root.Root.Attribute.ByPathKey(hashSelector).Value[1]);
     }
 
     [Fact]
@@ -589,6 +691,18 @@ public sealed class GeneratedDataset
     public Dictionary<string, int> Scores { get; init; } = new(StringComparer.Ordinal);
 
     public IEnumerable<GeneratedFieldChild>? FieldChildren;
+}
+
+[GenerateParallelView]
+public sealed class GeneratedIntScoreDataset
+{
+    public Dictionary<int, int> Scores { get; init; } = [];
+}
+
+[GenerateParallelView]
+public sealed class GeneratedDateTimeScoreDataset
+{
+    public Dictionary<DateTime, int> Scores { get; init; } = [];
 }
 
 public sealed class GeneratedFieldChild

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -40,7 +40,13 @@ public sealed class GeneratedProjectionE2ETests
         var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
 
         Assert.Equal("root", root.Root.Name[0]);
+        // Attribute["id"] は dictionary key の指定で、続く [0] / [1] は model index の指定。
+        Assert.Equal("id", root.Root.Attribute["id"][0]!.Name);
+        Assert.Equal("left", root.Root.Attribute["id"][0]!.Value);
+        Assert.Equal("right", root.Root.Attribute["id"][1]!.Value);
+        // child view 自体の GetState と、Value member の GetState は別々に取得できる。
         Assert.Equal("right", root.Root.Attribute["id"].Value[1]);
+        Assert.Equal(ValueState.Mismatched, root.Root.Attribute["id"].GetState(0));
         Assert.Equal(ValueState.Mismatched, root.Root.Attribute["id"].Value.GetState(0));
         Assert.Equal(1, root.Root.Range.StartLine[0]);
         Assert.Equal(4, root.Root.Range.EndLine[1]);

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -167,9 +167,86 @@ public sealed class GeneratedProjectionE2ETests
         Assert.Equal("left-100", leftDetailLabel);
         Assert.Equal(ValueState.Missing, rightMissingDetailState);
         Assert.Equal("100", firstItemKey);
+        Assert.Equal(1, root.Groups["1"].GroupId[0]);
+        Assert.Equal(1.0, root.Groups["1"].Items["100"].MetricA[0]);
+        Assert.Equal(10, root.Scores["A"][0]);
 
         Assert.Equal(10, root.Scores[0][0]);
         Assert.Equal(20, root.Scores[0][1]);
+    }
+
+    [Fact]
+    public void Compare_GeneratedProjection_KeyTextAccess_WhenMissingKey_ThrowsExecutionException()
+    {
+        // Intent: generated list の key text indexer は未検出 key を KeyNotFound で返す。
+        var models = new[]
+        {
+            new GeneratedDataset
+            {
+                Groups =
+                [
+                    new GeneratedGroup { GroupId = 1 },
+                ],
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        var exception = Assert.Throws<CompareExecutionException>(() =>
+        {
+            var _ = root.Groups["missing"];
+        });
+
+        Assert.Equal(CompareIssueCode.KeyNotFound, exception.Code);
+    }
+
+    [Fact]
+    public void Compare_GeneratedProjection_KeyTextAccess_AcceptsDiffPathEscapedDiscriminator()
+    {
+        // Intent: GetDiffEntries の bracket 内 discriminator を generated key text indexer へ渡して同じ child を引ける。
+        var models = new[]
+        {
+            new GeneratedDocument
+            {
+                Root = new GeneratedXmlNode
+                {
+                    Name = "root",
+                    Attribute = new Dictionary<string, GeneratedXmlAttribute>
+                    {
+                        ["A]B"] = new() { Name = "A]B", Value = "left-bracket" },
+                        ["A\\]B"] = new() { Name = "A\\]B", Value = "left-escaped-bracket" },
+                        ["#0"] = new() { Name = "#0", Value = "left-hash" },
+                    },
+                },
+            },
+            new GeneratedDocument
+            {
+                Root = new GeneratedXmlNode
+                {
+                    Name = "root",
+                    Attribute = new Dictionary<string, GeneratedXmlAttribute>
+                    {
+                        ["A]B"] = new() { Name = "A]B", Value = "right-bracket" },
+                        ["A\\]B"] = new() { Name = "A\\]B", Value = "right-escaped-bracket" },
+                        ["#0"] = new() { Name = "#0", Value = "right-hash" },
+                    },
+                },
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+        var root = result.AsGeneratedView()!;
+        var entries = result.GetDiffEntries();
+        var bracketSelector = ExtractSelector(FindDiffPathByLeftValue(entries, "left-bracket"));
+        var escapedBracketSelector = ExtractSelector(FindDiffPathByLeftValue(entries, "left-escaped-bracket"));
+        var hashSelector = ExtractSelector(FindDiffPathByLeftValue(entries, "left-hash"));
+
+        Assert.Equal("left-bracket", root.Root.Attribute[bracketSelector].Value[0]);
+        Assert.Equal("right-bracket", root.Root.Attribute[bracketSelector].Value[1]);
+        Assert.Equal("left-escaped-bracket", root.Root.Attribute[escapedBracketSelector].Value[0]);
+        Assert.Equal("right-escaped-bracket", root.Root.Attribute[escapedBracketSelector].Value[1]);
+        Assert.Equal("left-hash", root.Root.Attribute[hashSelector].Value[0]);
+        Assert.Equal("right-hash", root.Root.Attribute[hashSelector].Value[1]);
     }
 
     [Fact]
@@ -419,6 +496,46 @@ public sealed class GeneratedProjectionE2ETests
         var exception = Assert.Throws<ArgumentException>(() => result.AsGeneratedView());
 
         Assert.Contains("compare result nodes", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static string FindDiffPathByLeftValue(IReadOnlyList<ParallelDiffEntry> entries, string leftValue)
+    {
+        return Assert.Single(
+            entries,
+            entry => entry.Path.StartsWith("Root.Attribute[", StringComparison.Ordinal)
+                && entry.Path.EndsWith("].Value", StringComparison.Ordinal)
+                && entry.Values.Count > 0
+                && string.Equals(entry.Values[0].Value as string, leftValue, StringComparison.Ordinal)).Path;
+    }
+
+    private static string ExtractSelector(string path)
+    {
+        var selectorStart = path.IndexOf('[', StringComparison.Ordinal);
+        Assert.True(selectorStart >= 0);
+
+        var escaping = false;
+        for (var index = selectorStart + 1; index < path.Length; index++)
+        {
+            var current = path[index];
+            if (escaping)
+            {
+                escaping = false;
+                continue;
+            }
+
+            if (current == '\\')
+            {
+                escaping = true;
+                continue;
+            }
+
+            if (current == ']')
+            {
+                return path[(selectorStart + 1)..index];
+            }
+        }
+
+        throw new InvalidOperationException($"Path '{path}' does not contain a closed selector.");
     }
 
     private sealed class FakeGeneratedParallel : Parallel<GeneratedDataset>

--- a/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
@@ -43,8 +43,16 @@ public sealed class XmlCustomGeneratedCompareE2ETests
         var root = result.AsGeneratedView()!;
 
         Assert.Equal("root", root.Root.Name[0]);
+        // Attribute["id"] は dictionary key の指定で、続く [0] は model index の指定。
+        Assert.Equal("id", root.Root.Attribute["id"][0]!.Name);
+        Assert.Equal("same", root.Root.Attribute["id"][0]!.Value);
         Assert.Equal("same", root.Root.Attribute["id"].Value[0]);
+        Assert.Equal(ValueState.Matched, root.Root.Attribute["id"].GetState(0));
+        // child view 自体の GetState と、Value member の GetState は別々に取得できる。
+        Assert.Equal("source", root.Root.Attribute["source"][1]!.Name);
+        Assert.Equal("right", root.Root.Attribute["source"][1]!.Value);
         Assert.Equal("right", root.Root.Attribute["source"].Value[1]);
+        Assert.Equal(ValueState.Mismatched, root.Root.Attribute["source"].GetState(0));
         Assert.Equal(ValueState.Mismatched, root.Root.Attribute["source"].Value.GetState(0));
         Assert.True(root.Root.Attribute["id"].Range.StartLine[0] > 0);
         Assert.Equal("section", root.Root.ChildrenOfNode[0].Name[0]);

--- a/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
@@ -43,6 +43,7 @@ public sealed class XmlCustomGeneratedCompareE2ETests
         var root = result.AsGeneratedView()!;
 
         Assert.Equal("root", root.Root.Name[0]);
+        Assert.Equal("same", root.Root.Attribute["id"].Value[0]);
         Assert.Equal("same", root.Root.Attribute[0].Value[0]);
         Assert.Equal("right", root.Root.Attribute[1].Value[1]);
         Assert.Equal(ValueState.Mismatched, root.Root.Attribute[1].Value.GetState(0));

--- a/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
+++ b/tests/SSC.E2E.Tests/XmlCustomGeneratedCompareE2ETests.cs
@@ -44,12 +44,11 @@ public sealed class XmlCustomGeneratedCompareE2ETests
 
         Assert.Equal("root", root.Root.Name[0]);
         Assert.Equal("same", root.Root.Attribute["id"].Value[0]);
-        Assert.Equal("same", root.Root.Attribute[0].Value[0]);
-        Assert.Equal("right", root.Root.Attribute[1].Value[1]);
-        Assert.Equal(ValueState.Mismatched, root.Root.Attribute[1].Value.GetState(0));
-        Assert.True(root.Root.Attribute[0].Range.StartLine[0] > 0);
+        Assert.Equal("right", root.Root.Attribute["source"].Value[1]);
+        Assert.Equal(ValueState.Mismatched, root.Root.Attribute["source"].Value.GetState(0));
+        Assert.True(root.Root.Attribute["id"].Range.StartLine[0] > 0);
         Assert.Equal("section", root.Root.ChildrenOfNode[0].Name[0]);
-        Assert.Equal("intro", root.Root.ChildrenOfNode[0].Attribute[0].Value[1]);
+        Assert.Equal("intro", root.Root.ChildrenOfNode[0].Attribute["name"].Value[1]);
     }
 }
 


### PR DESCRIPTION
## Summary
- Split generated container access so Dictionary members generate as `ParallelGeneratedDictionary<TKey, TElement, TView>`.
- Enable normal typed Dictionary access such as `root.Root.Attribute["id"].Value[0]`, `root.Root.Attribute["source"].Value[1]`, and `root.Scores[100][0]`.
- Verify combined key + model index access such as `root.Root.Attribute["id"][0]`, with comments documenting that the first indexer selects the dictionary key and the second selects the model slot.
- Keep key-union ordinal access explicit through `AtIndex(index)` and diff path bracket selector access explicit through `ByPathKey(discriminator)`.
- Merge latest `origin/main` after #39 and keep #39 `ParentPath` / `ParentNode` API records alongside #40 generated Dictionary access records.

## Issue
- No GitHub issue exists for this user-reported T-087 task.

## Reports
- `reports/task-t-087-implementation-20260625132744.md`
- `reports/task-t-087-review-20260625133338.md`
- `reports/task-t-087-review-r2-20260625133952.md`
- `reports/task-t-087-verification-20260625134141.md`
- `reports/task-t-087-followup-dictionary-key-20260625135623.md`
- `reports/task-t-087-followup-dictionary-key-review-20260625140236.md`
- `reports/task-t-087-followup-dictionary-key-review-r2-20260625141147.md`
- `reports/task-t-087-followup-dictionary-key-review-r3-20260625141638.md`
- `reports/task-t-087-attribute-model-index-access-review-20260625154715.md`
- `reports/task-t-087-conflict-resolution-review-20260625155611.md`

## Validation
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~XmlCustomGeneratedCompareE2ETests|FullyQualifiedName~GeneratedProjectionE2ETests"` passed 15 tests.
- After merging latest `origin/main`: `dotnet test SSC.sln --configuration Release` passed: E2E 72, Unit 30.
- `dotnet format SSC.sln --verify-no-changes` passed.
- `git diff --check` passed.
- `npm run lint:md` unsupported: missing `lint:md` script and repo-local `tools/lint` config.

## Review
- gpt-5.5 high review found initial follow-up issues around string comparer and DateTime normalized key lookup.
- Addressed those findings by using normalized `KeyValue` plus `KeyComparer` for Dictionary lookup.
- gpt-5.5 high re-review: no findings.
- Additional gpt-5.5 high review after Attribute value key-access tests: no findings.
- Additional gpt-5.5 high review after Attribute key + model index access tests: no findings.
- Additional gpt-5.5 high review after #39 conflict resolution: no findings.

## Risks
- Markdown lint is not runnable until the repository defines a `lint:md` script and repo-local lint configuration.
- Object/composite key full reconstruction from path text remains out of scope.
- Dynamic projection Dictionary typed-key redesign remains out of scope.
