### PR TITLE
T-088: Improve Parallel ToString value display

### DIFF
--- a/Design/BreakingChanges.md
+++ b/Design/BreakingChanges.md
@@ -2,6 +2,22 @@
 
 ## 2026-06-25
 
+### T-088 `ParallelNode<T>` / generated value `ToString()` の表示変更
+
+- 対象:
+  - `ParallelNode<T>.ToString()`
+  - `ParallelGeneratedValue<TModel, TValue>.ToString()`
+- 変更種別:
+  - public convenience display の変更
+- 影響:
+  - 従来は object 既定の型名表示だった
+  - T-088 以降は `[0]="left"(Mismatched), [1]="right"(Mismatched)` のように model slot 別 value/state を表示する
+  - `ToString()` の文字列を厳密に比較していた利用コードは期待値更新が必要になる可能性がある
+- 背景:
+  - デバッグ時に `Parallel` node そのものから Diff と同様に値を確認できるようにするため
+- 備考:
+  - 機械処理では indexer / `GetState(modelIndex)` / Diff entry の structured data を使う
+
 ### T-085 MissingCompareKeyListPolicy の既定値変更
 
 - 対象:

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -150,6 +150,7 @@ public sealed class ParallelDiffValue
 - `AnyPresent == Values.Any(v => Missing でない)`
 - `HasDifferences()` は current node 自体、または配下 subtree のいずれかに差分があれば `true`
 - `GetDirectChildren()` は current node の直下 property を `ParallelChildSet` 単位で返す
+- `ParallelNode<T>.ToString()` と generated value の `ToString()` は model slot 別 value/state を Diff と同じ形式で返す
 
 ### 4.0 Direct Child Traversal Contract
 
@@ -494,6 +495,17 @@ object/container node で child 側に差分があるだけの場合は、親 no
 
 #### 4.2.2.6 ToString Contract
 
+`ParallelNode<T>.ToString()` は、node 自身の model slot 別 value/state を 1 行で表す。
+generated value の `ToString()` も同じ形式で、対象 member の value/state を 1 行で表す。
+
+例:
+
+```text
+[0]="left"(Mismatched), [1]="right"(Mismatched)
+[0]=null(Matched), [1]=null(Matched)
+[0]=<missing>(Missing), [1]=10(Mismatched)
+```
+
 `ParallelDiffEntry.ToString()` は、path と model 別 value/state を 1 行で表す。
 
 例:
@@ -504,7 +516,7 @@ Groups[1].Items[200].Name: [0]="left"(Mismatched), [1]=<missing>(Missing)
 Items: [0]=null(Mismatched), [1]=<missing>(Missing)
 ```
 
-`ParallelDiffValue.ToString()` は `[modelIndex]=value(state)` 形式を返す。
+`ParallelDiffValue.ToString()`、`ParallelNode<T>.ToString()`、generated value の `ToString()` の各 slot は `[modelIndex]=value(state)` 形式を返す。
 
 value 表示:
 
@@ -513,7 +525,7 @@ value 表示:
 - string は `"` で囲む
 - その他は `Convert.ToString(value, CultureInfo.InvariantCulture)` 相当
 
-`ToString()` は人間確認用の便利表示であり、機械処理の安定契約は `Path` / `Values` / `State` / `Value` を使う。
+`ToString()` は人間確認用の便利表示であり、機械処理の安定契約は `Path` / `Values` / `State` / `Value` / indexer / `GetState(modelIndex)` を使う。
 ただし、同じライブラリ version 内では deterministic な表示を保つ。
 
 #### 4.2.2.7 CompareIssue.Path との違い

--- a/reports/task-t-088-parallel-tostring-values-20260625163131.md
+++ b/reports/task-t-088-parallel-tostring-values-20260625163131.md
@@ -1,0 +1,66 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-088 `Parallel` の `ToString()` に model slot 別 value/state 表示を追加
+- タスク種別: implementation
+
+## sub-agentを使う理由
+
+- 理由: 今回の実装は小規模のため親 agent で実施。review と検証 evidence は別途 sub-agent review で確認する。
+
+## 対象範囲
+
+- 対象: `ParallelNode<T>.ToString()`、`ParallelGeneratedValue<TModel, TValue>.ToString()`、Diff と共有する value formatter、設計・tracking・breaking changes・テスト。
+
+## 対象外
+
+- 対象外: dynamic projection の `ToString()` 再設計、collection view の `ToString()`、Diff entry path 表示の変更。
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~ParallelNodeUnitTests.ToString_FormatsModelSlotValuesLikeDiffValues"`
+    - 実装前 failing proof: object 既定表示 `SSC.ParallelNode\`1[System.String]` で失敗。
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
+    - 実装前 failing proof: generated value の object 既定表示 `SSC.ParallelGeneratedValue\`2[...]` で失敗。
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~ParallelNodeUnitTests.ToString_FormatsModelSlotValuesLikeDiffValues|FullyQualifiedName~ParallelDiffResultUnitTests"`
+    - Passed. Failed: 0, Passed: 3, Skipped: 0.
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
+    - Passed. Failed: 0, Passed: 1, Skipped: 0.
+  - `dotnet test SSC.sln --configuration Release`
+    - Passed. Unit: Failed 0, Passed 31, Skipped 0. E2E: Failed 0, Passed 72, Skipped 0.
+  - `dotnet format SSC.sln --verify-no-changes`
+    - Passed.
+  - `git diff --check`
+    - Passed.
+  - `npm run lint:md`
+    - Unsupported: `Missing script: "lint:md"`。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelDisplayFormatter.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/GeneratedProjectionRuntime.cs`
+  - `tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs`
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - `doc/design/detail/02-PublicApi.md`
+  - `Design/BreakingChanges.md`
+  - `tasks/tasks-status.md`
+  - `tasks/phases-status.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: gpt-5.5 high review sub-agent による指摘なし。
+
+## 結果
+
+- 結果: `ParallelNode<T>` と generated value の `ToString()` が Diff と同じ `[modelIndex]=value(State)` 形式で表示されるようにした。Missing/null/string/数値の表示規則は `ParallelDisplayFormatter` に集約した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - dynamic projection の `ToString()` は対象外。
+  - `ToString()` は人間確認用の便利表示であり、機械処理は structured API を使う前提。

--- a/reports/task-t-088-parallel-tostring-values-review-20260625163131.md
+++ b/reports/task-t-088-parallel-tostring-values-review-20260625163131.md
@@ -1,0 +1,62 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-088 `Parallel` の `ToString()` value/state 表示改善レビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer により完了前の dedicated review が必須であり、public convenience display と設計文書を変更しているため。
+
+## 対象範囲
+
+- 対象: `ParallelNode<T>.ToString()`、`ParallelGeneratedValue<TModel, TValue>.ToString()`、`ParallelDisplayFormatter`、Diff formatter 共有、設計・breaking changes・tracking・テスト。
+
+## 対象外
+
+- 対象外: dynamic projection の `ToString()` 再設計、collection view の `ToString()`、Diff path 形式変更。
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `git diff --check`
+    - Passed.
+  - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~ParallelNodeUnitTests.ToString_FormatsModelSlotValuesLikeDiffValues|FullyQualifiedName~ParallelDiffResultUnitTests"`
+    - Passed. Failed: 0, Passed: 3, Skipped: 0.
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
+    - Passed. Failed: 0, Passed: 1, Skipped: 0.
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/ParallelDisplayFormatter.cs`
+  - `src/SSC/ParallelDiffContracts.cs`
+  - `src/SSC/ParallelNode.cs`
+  - `src/SSC/GeneratedProjectionRuntime.cs`
+  - `tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs`
+  - `tests/SSC.Unit.Tests/ParallelDiffResultUnitTests.cs`
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - `doc/design/detail/02-PublicApi.md`
+  - `Design/BreakingChanges.md`
+  - `tasks/tasks-status.md`
+  - `tasks/phases-status.md`
+  - `reports/task-t-088-parallel-tostring-values-20260625163131.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - `ParallelNode<T>.ToString()` は `ParallelDisplayFormatter.FormatSlots` 経由で Diff と同じ `[modelIndex]=value(State)` 形式を model slot 順に返している。
+  - `ParallelGeneratedValue<TModel, TValue>.ToString()` は全 slot の generated member value/presence を先に解決し、cached array から state を計算して表示しているため、`ToString()` 内で getter を不必要に再評価しない。
+  - Missing/null/string/数値の表示規則は `ParallelDisplayFormatter` に集約され、`ParallelDiffValue.ToString()` も同じ `FormatSlot` を使っている。数値表示は `CultureInfo.InvariantCulture` 相当で維持されている。
+  - 設計書、`Design/BreakingChanges.md`、tracking は public convenience display の変更として同期されている。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - なし。full solution test / format / `npm run lint:md` unsupported の evidence は implementation report の親実行結果を参照した。

--- a/src/SSC/GeneratedProjectionRuntime.cs
+++ b/src/SSC/GeneratedProjectionRuntime.cs
@@ -416,6 +416,23 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
     public ValueState GetState(int modelIndex)
     {
         var selectedValue = ResolveValue(modelIndex, out var selectedPresence);
+        return GetState(
+            modelIndex,
+            selectedValue,
+            selectedPresence,
+            index =>
+            {
+                var value = ResolveValue(index, out var presence);
+                return new ResolvedGeneratedValue(value, presence);
+            });
+    }
+
+    private ValueState GetState(
+        int modelIndex,
+        TValue selectedValue,
+        NodePresenceState selectedPresence,
+        Func<int, ResolvedGeneratedValue> getResolvedValue)
+    {
         if (selectedPresence == NodePresenceState.Missing)
         {
             return ValueState.Missing;
@@ -434,21 +451,21 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
                 continue;
             }
 
-            var otherValue = ResolveValue(index, out var otherPresence);
-            if (otherPresence == NodePresenceState.Missing)
+            var other = getResolvedValue(index);
+            if (other.Presence == NodePresenceState.Missing)
             {
                 matched = false;
                 break;
             }
 
-            if (otherPresence != selectedPresence)
+            if (other.Presence != selectedPresence)
             {
                 matched = false;
                 break;
             }
 
             if (selectedPresence == NodePresenceState.PresentValue
-                && !EqualityComparer<TValue>.Default.Equals(selectedValue, otherValue))
+                && !EqualityComparer<TValue>.Default.Equals(selectedValue, other.Value))
             {
                 matched = false;
                 break;
@@ -474,6 +491,39 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
 
                 return selector(value);
             });
+    }
+
+    public override string ToString()
+    {
+        var resolvedValues = new ResolvedGeneratedValue[_node.Count];
+        for (var modelIndex = 0; modelIndex < resolvedValues.Length; modelIndex++)
+        {
+            var value = ResolveValue(modelIndex, out var presence);
+            resolvedValues[modelIndex] = new ResolvedGeneratedValue(value, presence);
+        }
+
+        return ParallelDisplayFormatter.FormatSlots(
+            _node.Count,
+            modelIndex =>
+            {
+                var selected = resolvedValues[modelIndex];
+                return new ParallelDisplaySlot(
+                    selected.Value,
+                    GetState(modelIndex, selected.Value, selected.Presence, index => resolvedValues[index]));
+            });
+    }
+
+    private readonly struct ResolvedGeneratedValue
+    {
+        public ResolvedGeneratedValue(TValue value, NodePresenceState presence)
+        {
+            Value = value;
+            Presence = presence;
+        }
+
+        public TValue Value { get; }
+
+        public NodePresenceState Presence { get; }
     }
 
     private TValue ResolveValue(int modelIndex, out NodePresenceState state)

--- a/src/SSC/ParallelDiffContracts.cs
+++ b/src/SSC/ParallelDiffContracts.cs
@@ -40,28 +40,6 @@ public sealed class ParallelDiffValue
 
     public override string ToString()
     {
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"[{ModelIndex}]={FormatValue()}({State})");
-    }
-
-    private string FormatValue()
-    {
-        if (State == ValueState.Missing)
-        {
-            return "<missing>";
-        }
-
-        if (Value is null)
-        {
-            return "null";
-        }
-
-        if (Value is string text)
-        {
-            return string.Create(CultureInfo.InvariantCulture, $"\"{text}\"");
-        }
-
-        return Convert.ToString(Value, CultureInfo.InvariantCulture) ?? string.Empty;
+        return ParallelDisplayFormatter.FormatSlot(ModelIndex, Value, State);
     }
 }

--- a/src/SSC/ParallelDisplayFormatter.cs
+++ b/src/SSC/ParallelDisplayFormatter.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+
+namespace SSC;
+
+internal readonly struct ParallelDisplaySlot
+{
+    public ParallelDisplaySlot(object? value, ValueState state)
+    {
+        Value = value;
+        State = state;
+    }
+
+    public object? Value { get; }
+
+    public ValueState State { get; }
+}
+
+internal static class ParallelDisplayFormatter
+{
+    public static string FormatSlots(int count, Func<int, ParallelDisplaySlot> getSlot)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentNullException.ThrowIfNull(getSlot);
+
+        var slots = new string[count];
+        for (var modelIndex = 0; modelIndex < count; modelIndex++)
+        {
+            var slot = getSlot(modelIndex);
+            slots[modelIndex] = FormatSlot(modelIndex, slot.Value, slot.State);
+        }
+
+        return string.Join(", ", slots);
+    }
+
+    public static string FormatSlot(int modelIndex, object? value, ValueState state)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(modelIndex);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"[{modelIndex}]={FormatValue(value, state)}({state})");
+    }
+
+    private static string FormatValue(object? value, ValueState state)
+    {
+        if (state == ValueState.Missing)
+        {
+            return "<missing>";
+        }
+
+        if (value is null)
+        {
+            return "null";
+        }
+
+        if (value is string text)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"\"{text}\"");
+        }
+
+        return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+}

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -150,6 +150,13 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         return _states[modelIndex] == NodePresenceState.PresentValue ? _values[modelIndex] : null;
     }
 
+    public override string ToString()
+    {
+        return ParallelDisplayFormatter.FormatSlots(
+            Count,
+            modelIndex => new ParallelDisplaySlot(GetValue(modelIndex), GetState(modelIndex)));
+    }
+
     public bool HasDifferences()
     {
         if (_states.Length <= 1)

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -14,6 +14,7 @@
 
 - Status: Done
 - Notes:
+  - T-088 で `ParallelNode<T>` と generated value の `ToString()` の model slot 別 value/state 表示契約を追加する
   - T-087 で generated projection list の key text indexer と diff path selector 互換を public API として確定した
   - T-086 で `ParallelDiffEntry` の親 path / 親 node を public API として確定した
   - T-076 で XPath-like path access と差分表示 helper の public API 設計を追加し、実装単位を T-077 から T-082 へ分割した
@@ -35,6 +36,7 @@
 
 - Status: Done
 - Notes:
+  - T-088 を完了し、`ParallelNode<T>` と generated value の `ToString()` を Diff と同じ value/state 表示へ改善した
   - T-087 follow-up を完了し、Dictionary member の generated access を string key text 限定から key 型 indexer へ拡張した
   - T-087 を完了し、generated projection list で `Attribute["id"]` のような raw key text access と `GetDiffEntries().Path` の escaped discriminator access を実装した
   - T-086 を完了し、`GetDiffEntries()` の `Kind == Node` / `Kind == ContainerPresence` entry から `ParentPath` / `ParentNode` を取得できるようにした
@@ -146,6 +148,7 @@
 
 - Status: Done
 - Notes:
+  - T-088 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-087 follow-up で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-087 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-086 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -12,6 +12,42 @@
 
 ## Done
 
+- T-088: `Parallel` の `ToString()` に model slot 別 value/state 表示を追加
+  - Status: 完了（`ParallelNode<T>` と generated value の `ToString()` を Diff 表示と同じ model slot 別 value/state 形式にした）
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-077 XPath-like path parser と public result 型の追加
+    - T-079 通常 node 差分の `GetDiffEntries()` 追加
+  - Exit Criteria:
+    - `ParallelNode<T>.ToString()` が `[modelIndex]=value(State)` を model slot 順に返す
+    - generated value の `ToString()` が同じ形式を返す
+    - Missing/null/string/数値の表示規則が `ParallelDiffValue.ToString()` と一致する
+    - 表示は `CultureInfo.InvariantCulture` 相当で current culture に依存しない
+    - 既存 `ParallelDiffValue.ToString()` と値フォーマット実装を共有し、重複を増やさない
+    - TDD、設計更新、実装修正、検証、sub-agent review、PR 作成が完了している
+  - Output:
+    - `src/SSC/ParallelDisplayFormatter.cs`
+    - `src/SSC/ParallelDiffContracts.cs`
+    - `src/SSC/ParallelNode.cs`
+    - `src/SSC/GeneratedProjectionRuntime.cs`
+    - `tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs`
+    - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+    - `doc/design/detail/02-PublicApi.md`
+    - `Design/BreakingChanges.md`
+    - `reports/task-t-088-parallel-tostring-values-20260625163131.md`
+    - `reports/task-t-088-parallel-tostring-values-review-20260625163131.md`
+  - Verification:
+    - TDD 赤確認: `ParallelNode<T>.ToString()` が object 既定表示で失敗
+    - TDD 赤確認: generated value の `ToString()` が object 既定表示で失敗
+    - `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~ParallelNodeUnitTests.ToString_FormatsModelSlotValuesLikeDiffValues|FullyQualifiedName~ParallelDiffResultUnitTests"` 成功（3 件）
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"` 成功（1 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 31 件 / E2E 72 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+    - gpt-5.5 high review sub-agent 実施、指摘なし
+
 - T-087: generated projection dictionary key 型 access follow-up
   - Status: 完了（Dictionary member を string key text 限定ではなく、通常の Dictionary に近い key 型 indexer で参照できるようにした）
   - Phase: Phase 3

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -40,12 +40,14 @@ public sealed class GeneratedProjectionE2ETests
         var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
 
         Assert.Equal("root", root.Root.Name[0]);
+        Assert.Equal("[0]=\"root\"(Matched), [1]=\"root\"(Matched)", root.Root.Name.ToString());
         // Attribute["id"] は dictionary key の指定で、続く [0] / [1] は model index の指定。
         Assert.Equal("id", root.Root.Attribute["id"][0]!.Name);
         Assert.Equal("left", root.Root.Attribute["id"][0]!.Value);
         Assert.Equal("right", root.Root.Attribute["id"][1]!.Value);
         // child view 自体の GetState と、Value member の GetState は別々に取得できる。
         Assert.Equal("right", root.Root.Attribute["id"].Value[1]);
+        Assert.Equal("[0]=\"left\"(Mismatched), [1]=\"right\"(Mismatched)", root.Root.Attribute["id"].Value.ToString());
         Assert.Equal(ValueState.Mismatched, root.Root.Attribute["id"].GetState(0));
         Assert.Equal(ValueState.Mismatched, root.Root.Attribute["id"].Value.GetState(0));
         Assert.Equal(1, root.Root.Range.StartLine[0]);

--- a/tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs
+++ b/tests/SSC.Unit.Tests/ParallelNodeUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using SSC;
 
 namespace SSC.Unit.Tests;
@@ -49,6 +50,28 @@ public sealed class ParallelNodeUnitTests
 
         Assert.Equal(ValueState.Missing, node.GetState(0));
         Assert.Equal(ValueState.Missing, node.GetState(1));
+    }
+
+    [Fact]
+    public void ToString_FormatsModelSlotValuesLikeDiffValues()
+    {
+        // Intent: デバッグ時に Parallel node 自体から Diff と同じ value/state 表示を確認できる。
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        try
+        {
+            var textNode = ParallelNode<string>.CreateLeaf(["left", "right"], [ValueState.Mismatched, ValueState.Mismatched], keyText: "k");
+            var nullNode = ParallelNode<string>.CreateLeaf([null, null], [ValueState.Matched, ValueState.Matched], keyText: "k");
+            var missingNode = ParallelNode<decimal?>.CreateLeaf([1.5m, null], [ValueState.Mismatched, ValueState.Missing], keyText: "k");
+
+            Assert.Equal("[0]=\"left\"(Mismatched), [1]=\"right\"(Mismatched)", textNode.ToString());
+            Assert.Equal("[0]=null(Matched), [1]=null(Matched)", nullNode.ToString());
+            Assert.Equal("[0]=1.5(Mismatched), [1]=<missing>(Missing)", missingNode.ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `ParallelNode<T>.ToString()` output in Diff-like `[modelIndex]=value(State)` format.
- Add the same value/state output to generated value paths such as `root.Root.Name.ToString()`.
- Share Missing/null/string/numeric formatting through `ParallelDisplayFormatter` so `ParallelDiffValue.ToString()` and `Parallel` displays stay aligned.
- Document the public convenience-display change and record it in `Design/BreakingChanges.md`.

## Issue
- No GitHub issue exists for this user-reported T-088 task.

## Reports
- `reports/task-t-088-parallel-tostring-values-20260625163131.md`
- `reports/task-t-088-parallel-tostring-values-review-20260625163131.md`

## Validation
- `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter "FullyQualifiedName~ParallelNodeUnitTests.ToString_FormatsModelSlotValuesLikeDiffValues|FullyQualifiedName~ParallelDiffResultUnitTests"` passed 3 tests.
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"` passed 1 test.
- `dotnet test SSC.sln --configuration Release` passed: Unit 31, E2E 72.
- `dotnet format SSC.sln --verify-no-changes` passed.
- `git diff --check` passed.
- `npm run lint:md` unsupported: missing `lint:md` script.

## Review
- gpt-5.5 high sub-agent review: no findings.

## Risks
- Dynamic projection `ToString()` and collection view `ToString()` are out of scope.
- `ToString()` is convenience output for human inspection; structured APIs remain the stable machine-readable contract.
