### PR TITLE
T-089: Delegate generated ToString display to nodes

### DIFF
--- a/Design/BreakingChanges.md
+++ b/Design/BreakingChanges.md
@@ -2,6 +2,23 @@
 
 ## 2026-06-25
 
+### T-089 generated object view `ToString()` の表示変更
+
+- 対象:
+  - Source Generator が生成する nested object view の `ToString()`
+- 変更種別:
+  - generated API の public convenience display 変更
+- 影響:
+  - 従来は generated view class の型名表示だった
+  - T-089 以降は underlying `ParallelNode<T>.ToString()` に委譲し、元モデル型の `ToString()` 結果を model slot 別 value/state 形式で表示する
+  - `ToString()` の文字列を厳密に比較していた利用コードは期待値更新が必要になる可能性がある
+- 背景:
+  - `root.Root.Attribute["id"]` のような object view でも、元モデル型が `ToString()` を実装している場合はデバッグ時にその値を直接確認できるようにするため
+- 備考:
+  - 機械処理では indexer / `GetState(modelIndex)` / scalar member access / Diff entry の structured data を使う
+  - direct generated scalar member の `ToString()` は個別 formatter ではなく、対応する member `ParallelNode<TValue>.ToString()` に委譲する
+  - dynamic projection も materialized node がある path では同じ node `ToString()` に委譲する
+
 ### T-088 `ParallelNode<T>` / generated value `ToString()` の表示変更
 
 - 対象:

--- a/doc/design/detail/02-PublicApi.md
+++ b/doc/design/detail/02-PublicApi.md
@@ -151,6 +151,14 @@ public sealed class ParallelDiffValue
 - `HasDifferences()` は current node 自体、または配下 subtree のいずれかに差分があれば `true`
 - `GetDirectChildren()` は current node の直下 property を `ParallelChildSet` 単位で返す
 - `ParallelNode<T>.ToString()` と generated value の `ToString()` は model slot 別 value/state を Diff と同じ形式で返す
+- generated object view の `ToString()` は underlying `ParallelNode<T>.ToString()` に委譲する
+  - 元モデル型が `ToString()` を override している場合、その文字列表現を model slot 別に確認できる
+  - 例: `root.Root.Attribute["id"].ToString()` は `GeneratedXmlAttribute.ToString()` の結果を `[0]=...(State), [1]=...(State)` 形式で返す
+  - 生成型に comparable member `ToString` がある場合は名前衝突を避けるため、object view の override は生成しない
+- direct generated scalar member は対応する member `ParallelNode<TValue>` に indexer / `GetState()` / `ToString()` を委譲し、`ParallelNode<T>.ToString()` と表示実装を共有する
+  - `Select(...)` 由来の派生 generated value は materialized member node を持たないため、一時的な leaf `ParallelNode<TValue>` に変換して `ToString()` 表示を共有する
+- dynamic projection は materialized node がある path では `ToString()` を同じ node 表示へ委譲する
+  - runtime reflection だけで辿る materialized node のない派生 path は対象外
 
 ### 4.0 Direct Child Traversal Contract
 

--- a/reports/task-t-089-generated-object-tostring-20260625170134.md
+++ b/reports/task-t-089-generated-object-tostring-20260625170134.md
@@ -1,0 +1,56 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-089 generated object view の `ToString()` で元モデルの表示を model slot 別に返す
+- タスク種別: implementation
+
+## sub-agentを使う理由
+
+- 理由: 実装は generator への小変更と E2E 追加に限定されるため親 agent で実施。検証 evidence と review は sub-agent に委譲する。
+
+## 対象範囲
+
+- 対象: generated object view class の `ToString()` 生成、元モデル型 `ToString()` override を使う E2E、設計・tracking・breaking changes。
+
+## 対象外
+
+- 対象外: scalar generated value の表示規則変更、dynamic projection の `ToString()`、collection view の `ToString()` 再設計。
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`
+    - 実装前 failing proof: generated object view の `ToString()` が生成 view class の型名表示になり失敗。
+    - 実装後: Passed. Failed: 0, Passed: 1, Skipped: 0.
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString"`
+    - 追加実装後: Passed. Failed: 0, Passed: 2, Skipped: 0.
+    - 共通化後: Passed. Failed: 0, Passed: 2, Skipped: 0.
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"`
+    - dynamic 経路追加後: Passed. Failed: 0, Passed: 3, Skipped: 0.
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC/GeneratedProjectionRuntime.cs`
+  - `src/SSC.Generators/ParallelViewGenerator.cs`
+  - `src/SSC/ParallelDynamicAccessExtensions.cs`
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+  - `doc/design/detail/02-PublicApi.md`
+  - `Design/BreakingChanges.md`
+  - `tasks/tasks-status.md`
+  - `tasks/phases-status.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: review は別 report で実施する。
+
+## 結果
+
+- 結果: generated object view class に `override ToString() => _node.ToString()` を生成し、`root.Root.Attribute["id"].ToString()` で元モデル `GeneratedXmlAttribute.ToString()` の結果を model slot 別 value/state 形式で確認できるようにした。direct scalar generated member は対応する member `IParallelNode` を保持し、`ToString()` / `GetState()` を node に委譲して `ParallelGeneratedValue` 側の表示 formatter 重複を削除した。`Select(...)` 由来の派生値は一時的な leaf `ParallelNode<TValue>` に変換してから `ToString()` に委譲する。dynamic projection も materialized node がある path では同じ node `ToString()` に委譲する。comparable member `ToString` がある型では生成名衝突を避けるため override を出さない。さらに object 由来名の generated member には `new` を付け、意図的な hiding として生成する。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - collection view の `ToString()` と、materialized node を持たない runtime-derived dynamic path の `ToString()` は対象外。
+  - `ToString()` は人間確認用の便利表示であり、機械処理は structured API を使う前提。

--- a/reports/task-t-089-generated-object-tostring-review-20260625170550.md
+++ b/reports/task-t-089-generated-object-tostring-review-20260625170550.md
@@ -1,0 +1,166 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-089 generated object view `ToString()` follow-up のコードレビュー
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review は review-enforcer / codex-delegation-executor の固定 sub-agent 対象であり、ユーザー指定どおり gpt-5.5 high で独立レビューする。
+
+## 対象範囲
+
+- 対象: generated object view の `ToString()` 生成、E2E、設計・breaking changes・tracking・reports。Markdown lint は `package.json` に `lint:md` がないため unsupported として扱う。
+
+## 対象外
+
+- 対象外: dynamic projection の `ToString()`、collection view の `ToString()`、T-088 で完了済みの scalar generated value 表示規則。
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `git status --short --branch`: T-089 差分と未追跡 report を確認。
+  - `git diff HEAD --stat` / `git diff HEAD --name-only`: review 対象の変更ファイルを確認。
+  - `git diff HEAD -- src/SSC.Generators/ParallelViewGenerator.cs tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs Design/BreakingChanges.md doc/design/detail/02-PublicApi.md tasks/phases-status.md tasks/tasks-status.md`: T-089 patch を確認。
+  - `sed -n '1,260p' reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: 検証 report を確認。
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`: pass。Failed 0、Passed 1、Skipped 0、Total 1。
+  - `git diff --check`: pass。
+  - `npm run lint:md`: unsupported。`package.json` に `lint:md` script がなく `Missing script: "lint:md"`。
+  - 追加再レビュー `git diff HEAD --stat`: 追加変更後の T-089 差分を確認。
+  - 追加再レビュー `git diff HEAD -- src/SSC.Generators/ParallelViewGenerator.cs`: `public new` 生成対象名と実装位置を確認。
+  - 追加再レビュー `git diff HEAD -- tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: comparable member `ToString` の衝突回避 E2E を確認。
+  - 追加再レビュー `sed -n '1,280p' reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: 更新済み検証 report を確認。
+  - 追加再レビュー `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString"`: pass。Failed 0、Passed 2、Skipped 0、Total 2。
+  - 追加再レビュー `git diff --check`: pass。
+  - node 委譲再レビュー `git diff HEAD -- src/SSC/GeneratedProjectionRuntime.cs`: `ParallelGeneratedValue<TModel,TValue>` の `IParallelNode` 委譲と fallback を確認。
+  - node 委譲再レビュー `git diff HEAD -- src/SSC.Generators/ParallelViewGenerator.cs`: scalar member 生成時に `RequireMemberNode<TParent>(...)` を渡す変更を確認。
+  - node 委譲再レビュー `git diff HEAD -- src/SSC/ParallelDynamicAccessExtensions.cs`: 追加で現れている dynamic projection `ToString()` 委譲差分を確認。
+  - node 委譲再レビュー `sed -n '1,340p' reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: node 委譲変更後の検証 report を確認。
+  - node 委譲再レビュー `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString"`: pass。Failed 0、Passed 2、Skipped 0、Total 2。
+  - node 委譲再レビュー `git diff --check`: pass。
+  - node 委譲再レビュー `dotnet test SSC.sln --configuration Release`: pass。SSC.E2E.Tests Failed 0、Passed 74、Skipped 0、Total 74。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。
+  - blocker 対応後再レビュー `git diff HEAD -- src/SSC/GeneratedProjectionRuntime.cs`: `_valueNode` なしの `Select(...)` 派生 value が一時 leaf `ParallelNode<TValue>` を作って `ToString()` に委譲することを確認。
+  - blocker 対応後再レビュー `git diff HEAD -- src/SSC/ParallelDynamicAccessExtensions.cs`: dynamic materialized node path の `ToString()` 委譲を確認。
+  - blocker 対応後再レビュー `git diff HEAD -- tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: `Select(...)` 派生 value と dynamic projection の追加 E2E を確認。
+  - blocker 対応後再レビュー `sed -n '1,380p' reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: 最新 verification report を確認。
+  - blocker 対応後再レビュー `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"`: pass。Failed 0、Passed 3、Skipped 0、Total 3。
+  - blocker 対応後再レビュー `git diff --check`: pass。
+  - blocker 対応後再レビュー `dotnet test SSC.sln --configuration Release`: pass。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。SSC.E2E.Tests Failed 0、Passed 74、Skipped 0、Total 74。
+  - 最新 main ベース最終レビュー `git status --short --branch`: `fix/t-089-generated-object-tostring` branch 上で未コミット差分と未追跡 report を確認。
+  - 最新 main ベース最終レビュー `git diff HEAD --stat` / `git diff HEAD --name-only`: `origin/main...HEAD` ではなく現在の未コミット差分全体を確認。
+  - 最新 main ベース最終レビュー `git diff HEAD -- src/SSC/GeneratedProjectionRuntime.cs src/SSC/ParallelDynamicAccessExtensions.cs src/SSC.Generators/ParallelViewGenerator.cs`: runtime / dynamic / generator の最終差分を確認。
+  - 最新 main ベース最終レビュー `git diff HEAD -- tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: E2E 最終差分を確認。
+  - 最新 main ベース最終レビュー `sed -n '1,420p' reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: latest verification report を確認。
+  - 最新 main ベース最終レビュー `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"`: pass。Failed 0、Passed 3、Skipped 0、Total 3。
+  - 最新 main ベース最終レビュー `git diff --check`: pass。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `src/SSC.Generators/ParallelViewGenerator.cs`: generated object view class の `ToString()` 生成条件を確認。
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: 元モデル型 override `ToString()` と `root.Root.Attribute["id"].ToString()` の E2E assertion を確認。
+  - `src/SSC/ParallelNode.cs`: `_node.ToString()` が model slot 別 value/state 表示に委譲されることを確認。
+  - `src/SSC/ParallelDisplayFormatter.cs`: object value の `ToString()` 表示経路を確認。
+  - `src/SSC/GeneratedProjectionRuntime.cs`: T-088 の scalar generated value `ToString()` 実装が変更されていないことを確認。
+  - `doc/design/detail/02-PublicApi.md`: generated object view `ToString()` 契約と comparable member `ToString` 衝突回避の記載を確認。
+  - `Design/BreakingChanges.md`: public convenience display 変更として記録されていることを確認。
+  - `tasks/tasks-status.md` / `tasks/phases-status.md`: T-089 tracking が実装状態と整合していることを確認。
+  - `reports/task-t-089-generated-object-tostring-20260625170134.md`: implementation report を確認。
+  - `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: verification report を確認。
+  - `package.json`: Markdown lint script が未定義であることを確認。
+  - 追加再レビュー `src/SSC.Generators/ParallelViewGenerator.cs`: `GetGeneratedMemberVisibility` が `Equals` / `GetHashCode` / `GetType` / `ToString` に `public new` を返し、container/object/value accessor 生成直前で共通適用されることを確認。
+  - 追加再レビュー `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: `GeneratedToStringMemberChild.ToString` で object view override を生成しない経路と generated accessor `root.Child.ToString` が使えることを確認。
+  - 追加再レビュー `src/SSC/GeneratedProjectionRuntime.cs` / `src/SSC/ParallelNode.cs` / `src/SSC/ParallelDisplayFormatter.cs`: T-088 の scalar generated value 表示規則と `ParallelNode<T>.ToString()` runtime に追加差分がないことを確認。
+  - node 委譲再レビュー `src/SSC/GeneratedProjectionRuntime.cs`: direct scalar generated member の `_valueNode` 委譲、`Select(...)` fallback、`RequireMemberNode<TParent>` overload を確認。
+  - node 委譲再レビュー `src/SSC.Generators/ParallelViewGenerator.cs`: scalar member 生成時に `ParallelGeneratedValue<TModel,TValue>` へ `IParallelNode` を渡すことを確認。
+  - node 委譲再レビュー `src/SSC/ParallelDynamicAccessExtensions.cs`: dynamic node / materialized dynamic value path の `ToString()` 委譲差分を確認。
+  - node 委譲再レビュー `doc/design/detail/02-PublicApi.md`: generated value `ToString()` と direct generated scalar member の node 委譲契約を確認。
+  - node 委譲再レビュー `Design/BreakingChanges.md`: direct generated scalar member の `ToString()` 委譲が breaking changes に記録されていることを確認。
+  - node 委譲再レビュー `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: node 委譲変更後の full/focused 検証結果を確認。
+  - blocker 対応後再レビュー `src/SSC/GeneratedProjectionRuntime.cs`: `CreateDerivedLeaf()` による `Select(...)` 派生 value の node `ToString()` 共有を確認。
+  - blocker 対応後再レビュー `src/SSC/ParallelDynamicAccessExtensions.cs`: `DynamicParallelNodeView.ToString()` と `DynamicParallelValuePathView.ToString()` を確認。
+  - blocker 対応後再レビュー `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: `root.Root.Name.Select(...).ToString()` と dynamic materialized node display の E2E を確認。
+  - blocker 対応後再レビュー `doc/design/detail/02-PublicApi.md` / `Design/BreakingChanges.md` / `tasks/tasks-status.md` / `tasks/phases-status.md`: runtime-derived dynamic path 対象外化、node 表示共有、tracking の整合を確認。
+  - blocker 対応後再レビュー `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: 最新 full verification pass を確認。
+  - 最新 main ベース最終レビュー `src/SSC/GeneratedProjectionRuntime.cs`: direct scalar / `Select(...)` 派生 value の `ToString()` node 委譲を確認。
+  - 最新 main ベース最終レビュー `src/SSC.Generators/ParallelViewGenerator.cs`: object view `ToString()` 生成、object 由来名 `public new`、scalar member の `IParallelNode` 受け渡しを確認。
+  - 最新 main ベース最終レビュー `src/SSC/ParallelDynamicAccessExtensions.cs`: dynamic materialized path の `ToString()` node 委譲を確認。
+  - 最新 main ベース最終レビュー `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: object view / `Select(...)` / comparable member `ToString` / dynamic materialized path の E2E を確認。
+  - 最新 main ベース最終レビュー `doc/design/detail/02-PublicApi.md` / `Design/BreakingChanges.md`: latest main ベースの public behavior と breaking changes 記録を確認。
+  - 最新 main ベース最終レビュー `tasks/tasks-status.md` / `tasks/phases-status.md`: T-089 が Done に移動し、verification evidence と output が実装差分と整合することを確認。
+  - 最新 main ベース最終レビュー `reports/task-t-089-generated-object-tostring-20260625170134.md` / `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: implementation / verification report の最終内容を確認。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 通常経路を壊す blocker: 指摘なし。
+  - ユーザー確認が必要な能力ギャップ: 指摘なし。
+  - 非ブロッキング懸念:
+    - Low: comparable member `ToString` がある型で override を生成しない分岐は `src/SSC.Generators/ParallelViewGenerator.cs:163` で実装され、設計にも記載されているが、この分岐専用の E2E は追加されていない。現在の実装は `typeShape.Members` の comparable member 名で判定しており条件自体は妥当なため、通常経路の blocker ではない。
+    - Markdown lint は repo に `lint:md` script が存在しないため unsupported として扱う判断は妥当。Markdown lint evidence は未取得のまま残る。
+  - 追加再レビュー:
+    - 通常経路を壊す blocker: 指摘なし。
+    - ユーザー確認が必要な能力ギャップ: 指摘なし。
+    - 非ブロッキング懸念: 指摘なし。
+    - 初回レビューの Low 懸念は `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs:59` の E2E 追加により解消。`src/SSC.Generators/ParallelViewGenerator.cs:163` で comparable member `ToString` がある場合は object view override を生成せず、`src/SSC.Generators/ParallelViewGenerator.cs:221` で generated accessor 側に `public new` を付ける構成は妥当。
+  - node 委譲再レビュー:
+    - Medium: `src/SSC/GeneratedProjectionRuntime.cs:494` の `Select(...)` は `_valueNode` を渡さない派生 `ParallelGeneratedValue<TModel,TNext>` を返す一方、`src/SSC/GeneratedProjectionRuntime.cs:512` の `ToString()` fallback は `base.ToString()` になっている。このため `root.Groups[0].Items[0].Detail.Select(x => x.Label).ToString()` のような派生 generated value は T-088 で追加した model slot 別 value/state 表示ではなく型名表示へ戻る。`doc/design/detail/02-PublicApi.md:153` と `doc/design/detail/02-PublicApi.md:505` の generated value `ToString()` 契約と整合しないため、既存 API / T-088 表示規則の回帰として blocking。
+    - 通常経路を壊す blocker: あり。上記 `Select(...)` 派生 generated value の `ToString()` 回帰。
+    - ユーザー確認が必要な能力ギャップ: 指摘なし。
+    - 非ブロッキング懸念:
+      - value type member は generator が `ParallelGeneratedValue<TModel, int?>` の getter と untyped `IParallelNode` を渡すため、`ParallelNode<int>` との generic cast は発生しない。full solution test は pass しており、node type mismatch は確認されなかった。
+      - 依頼に明記されていなかった `src/SSC/ParallelDynamicAccessExtensions.cs` の dynamic `ToString()` 差分も確認した。materialized node がある path は node に委譲し、materialized node がない派生 path は設計上対象外と明記されているため、この差分自体は blocker ではない。
+  - blocker 対応後再レビュー:
+    - 通常経路を壊す blocker: 指摘なし。
+    - ユーザー確認が必要な能力ギャップ: 指摘なし。
+    - 非ブロッキング懸念: 指摘なし。
+    - 前回 blocker は解消済み。`src/SSC/GeneratedProjectionRuntime.cs:512` の `ToString()` は `_valueNode` があれば直接 node に委譲し、ない場合も `CreateDerivedLeaf()` で一時 leaf `ParallelNode<TValue>` を作って `ParallelNode<T>.ToString()` に委譲する。`tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs:44` で `root.Root.Name.Select(...).ToString()` の model slot 表示を検証している。
+    - dynamic materialized path は `src/SSC/ParallelDynamicAccessExtensions.cs:106` と `src/SSC/ParallelDynamicAccessExtensions.cs:323` で materialized node の `ToString()` に委譲し、`tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs:83` の E2E で検証されている。runtime reflection だけで辿る materialized node のない派生 path を対象外とする設計は、node 表示共有という今回の範囲と整合している。
+  - 最新 main ベース最終レビュー:
+    - 通常経路を壊す blocker: 指摘なし。
+    - ユーザー確認が必要な能力ギャップ: 指摘なし。
+    - 非ブロッキング懸念: 指摘なし。
+    - `git diff HEAD` で現在の未コミット差分全体を確認し、T-089 の実装・E2E・docs・tracking・reports は latest main ベースの最終状態と整合している。
+    - 前回 blocker の `Select(...)` 派生 generated value `ToString()` 型名表示回帰は再発していない。`CreateDerivedLeaf()` 経由で `ParallelNode<T>.ToString()` に集約され、focused E2E でも検証済み。
+    - latest verification report は focused E2E / full solution test / format / `git diff --check` pass と Markdown lint unsupported を記録しており、review 判断と矛盾しない。
+
+## 結果
+
+- 結果:
+  - review 完了。generated object view class は comparable member `ToString` がない場合に `public override string ToString() => _node.ToString();` を生成し、`ParallelNode<T>.ToString()` の model slot 別 value/state 表示へ委譲する。
+  - `GeneratedXmlAttribute.ToString()` を override した E2E で `root.Root.Attribute["id"].ToString()` が `[0]=id=left(Mismatched), [1]=id=right(Mismatched)` を返すことを確認した。
+  - T-088 の scalar generated value `ToString()` と existing generated API runtime には差分がなく、focused E2E と `git diff --check` は pass。
+  - 設計、breaking changes、tracking、implementation report、verification report は T-089 の実装内容と整合している。
+  - 追加再レビュー完了。`GetGeneratedMemberVisibility` は object 由来名 `Equals` / `GetHashCode` / `GetType` / `ToString` の generated accessor に限定して `public new` を返し、通常 member は従来どおり `public` のまま生成する。
+  - `ToString` member ありの型では object view `override ToString()` が生成されないため名前衝突を避けられ、E2E で generated accessor `root.Child.ToString[0]` / `[1]` と `GetState(0)` が使えることを確認した。
+  - 追加変更後も focused E2E と `git diff --check` は pass。T-088 表示 runtime と existing generated API runtime には追加差分なし。
+  - node 委譲再レビュー完了。direct scalar generated member は generator から `RequireMemberNode<TParent>(...)` の `IParallelNode` を受け取り、`GetState()` / `ToString()` を node に委譲するため、direct scalar 表示は `ParallelNode<T>.ToString()` と共有できている。
+  - `ParallelGeneratedValue.ToString()` 内の slot formatter 再実装は削除されているが、その結果 `_valueNode` を持たない派生 generated value の `ToString()` fallback が型名表示へ戻っている。これは T-088 の generated value 表示契約と不整合。
+  - node 委譲変更後の focused E2E、full solution test、`git diff --check` は pass。ただし `Select(...).ToString()` 経路を直接検証する E2E はなく、上記回帰はテストでは捕捉されていない。
+  - dynamic projection の `ToString()` 追加差分は、materialized node がある path を node 表示へ委譲する内容で、設計上の対象範囲と整合している。
+  - blocker 対応後再レビュー完了。direct scalar / `Select(...)` 派生 value / dynamic materialized path の `ToString()` はいずれも `ParallelNode<T>.ToString()` に集約されている。
+  - `Select(...)` 派生 value は一時 leaf `ParallelNode<TValue>` を作るため、前回の型名表示 fallback は解消されている。
+  - value type member は direct scalar では untyped `IParallelNode` 委譲により generic node type mismatch を避け、`Select(...)` 派生値では `ParallelNode<TValue>.CreateLeaf(values, states)` を使うため nullable / missing state を node 表示経路へ渡せている。
+  - blocker 対応後の focused E2E、full solution test、`git diff --check` は pass。full test output では前回見えていた nullable warning は出ていない。
+  - 設計、breaking changes、tracking、implementation report、verification report は最新実装と整合している。
+  - 最新 main ベース最終レビュー完了。`fix/t-089-generated-object-tostring` 上の未コミット差分全体を確認し、generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` は node 表示に集約されている。
+  - T-089 tracking は `tasks/tasks-status.md` で Done、`tasks/phases-status.md` で実装・検証 Done に反映され、implementation / verification / review report と整合している。
+  - 最新 main ベースの focused E2E 3件と `git diff --check` は pass。latest verification report の full verification pass と矛盾なし。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - comparable member `ToString` 衝突回避分岐は code review で確認済みだが、専用 E2E は未追加。通常経路を壊す blocker ではないため held risk として記録する。
+  - `npm run lint:md` は repo に script がなく unsupported。Markdown lint evidence は取得できないが、verification report と同じく unsupported として残す判断で問題ない。
+  - 追加再レビュー: 初回の comparable member `ToString` 専用 E2E 未追加リスクは解消済み。
+  - 追加再レビュー: `Equals` / `GetHashCode` / `GetType` の各 object 由来名そのものを使う個別 E2E はないが、同じ `GetGeneratedMemberVisibility` 分岐で `public new` を返す単純な name list であり、通常経路を壊す blocker ではない。
+  - 追加再レビュー: Markdown lint は引き続き repo に `lint:md` script がないため unsupported。
+  - node 委譲再レビュー: `Select(...)` 由来の派生 generated value `ToString()` が T-088 契約から外れるため、修正または仕様上の明示的な対象外化が必要。
+  - node 委譲再レビュー: `Select(...).ToString()` の回帰を検出する E2E がないため、修正時は direct scalar node 委譲経路とは別に派生 generated value fallback の検証が必要。
+  - node 委譲再レビュー: Markdown lint は引き続き repo に `lint:md` script がないため unsupported。
+  - blocker 対応後再レビュー: 前回の `Select(...)` 派生 generated value `ToString()` blocker と E2E 不足リスクは解消済み。
+  - blocker 対応後再レビュー: runtime-derived dynamic path は materialized node がないため node display 共有の対象外。設計に明記済みであり、通常経路を壊す blocker ではない。
+  - blocker 対応後再レビュー: Markdown lint は引き続き repo に `lint:md` script がないため unsupported。
+  - 最新 main ベース最終レビュー: 未解決 blocker なし。
+  - 最新 main ベース最終レビュー: Markdown lint は引き続き repo に `lint:md` script がないため unsupported。latest verification report と同じ扱い。

--- a/reports/task-t-089-generated-object-tostring-verification-20260625170333.md
+++ b/reports/task-t-089-generated-object-tostring-verification-20260625170333.md
@@ -1,0 +1,85 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-089 generated object view `ToString()` follow-up の検証 evidence を取得する
+- タスク種別: verification
+
+## sub-agentを使う理由
+
+- 理由: test/build execution used as verification evidence は codex-delegation-executor の固定 sub-agent 対象のため。
+
+## 対象範囲
+
+- 対象: PR #41 branch の T-089 差分に対する focused E2E、full solution test、format、diff whitespace check。
+
+## 対象外
+
+- 対象外: コード修正、設計変更、レビュー判断。
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers"`: pass。Failed 0、Passed 1、Skipped 0、Total 1。
+  - `dotnet test SSC.sln --configuration Release`: pass。SSC.E2E.Tests Failed 0、Passed 72、Skipped 0、Total 72。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。
+  - `dotnet format SSC.sln --verify-no-changes`: pass。
+  - `git diff --check`: pass。
+  - `npm run lint:md`: unsupported。`package.json` に `scripts.lint:md` が定義されていないため未実行。
+  - 追加変更後の再検証 `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString"`: pass。Failed 0、Passed 2、Skipped 0、Total 2。
+  - 追加変更後の再検証 `dotnet test SSC.sln --configuration Release`: pass。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。SSC.E2E.Tests Failed 0、Passed 73、Skipped 0、Total 73。
+  - 追加変更後の再検証 `dotnet format SSC.sln --verify-no-changes`: pass。
+  - 追加変更後の再検証 `git diff --check`: pass。
+  - node 委譲変更後の再検証 `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString"`: pass。Failed 0、Passed 2、Skipped 0、Total 2。
+  - node 委譲変更後の再検証 `dotnet test SSC.sln --configuration Release`: pass。SSC.E2E.Tests Failed 0、Passed 73、Skipped 0、Total 73。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。
+  - node 委譲変更後の再検証 `dotnet format SSC.sln --verify-no-changes`: pass。
+  - node 委譲変更後の再検証 `git diff --check`: pass。
+  - dynamic projection 委譲変更後の再検証 `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"`: pass。Failed 0、Passed 3、Skipped 0、Total 3。
+  - dynamic projection 委譲変更後の再検証 `dotnet test SSC.sln --configuration Release`: pass。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。SSC.E2E.Tests Failed 0、Passed 74、Skipped 0、Total 74。
+  - dynamic projection 委譲変更後の再検証 `dotnet format SSC.sln --verify-no-changes`: pass。
+  - dynamic projection 委譲変更後の再検証 `git diff --check`: pass。
+  - `Select(...)` generated value 修正後の再検証 `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"`: pass。Failed 0、Passed 3、Skipped 0、Total 3。
+  - `Select(...)` generated value 修正後の再検証 `dotnet test SSC.sln --configuration Release`: pass。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。SSC.E2E.Tests Failed 0、Passed 74、Skipped 0、Total 74。
+  - `Select(...)` generated value 修正後の再検証 `dotnet format SSC.sln --verify-no-changes`: pass。
+  - `Select(...)` generated value 修正後の再検証 `git diff --check`: pass。
+  - 最新 main ベース最終検証 `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"`: pass。Failed 0、Passed 3、Skipped 0、Total 3。`tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs(34,47)` で CS8603 nullable warning あり。
+  - 最新 main ベース最終検証 `dotnet test SSC.sln --configuration Release`: pass。SSC.E2E.Tests Failed 0、Passed 74、Skipped 0、Total 74。SSC.Unit.Tests Failed 0、Passed 31、Skipped 0、Total 31。
+  - 最新 main ベース最終検証 `dotnet format SSC.sln --verify-no-changes`: pass。
+  - 最新 main ベース最終検証 `git diff --check`: pass。
+  - 最新 main ベース最終検証 `npm run lint:md`: unsupported。`package.json` に `scripts.lint:md` が定義されていないため未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`: 検証 evidence を記録。
+  - `package.json`: `lint:md` script の有無を確認。
+  - `src/SSC.Generators/ParallelViewGenerator.cs`: 追加変更の検証対象。
+  - `src/SSC/GeneratedProjectionRuntime.cs`: node 委譲変更の検証対象。
+  - `src/SSC/ParallelDynamicAccessExtensions.cs`: dynamic projection 委譲変更の検証対象。
+  - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`: 追加 E2E の検証対象。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 指摘なし。
+
+## 結果
+
+- 結果:
+  - focused E2E により `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers` が pass し、`root.Root.Attribute["id"].ToString()` を含む generated object view `ToString()` follow-up の対象経路を検証した。
+  - full solution test、format verification、diff whitespace check はすべて pass。
+  - Markdown lint はこの repo で `lint:md` script が未定義のため unsupported として扱った。
+  - 追加変更後の focused E2E により `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers` と `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString` が pass し、object 由来名の generated member に対する `public new` 付与と ToString member 衝突回避経路を検証した。
+  - 追加変更後の full solution test、format verification、diff whitespace check はすべて pass。
+  - node 委譲変更後の focused E2E により `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers` と `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString` が pass し、`ParallelGeneratedValue<TModel,TValue>` の `GetState()` / `ToString()` が direct scalar member の `IParallelNode` に委譲される変更後も対象経路が維持されることを検証した。
+  - node 委譲変更後の full solution test、format verification、diff whitespace check はすべて pass。
+  - dynamic projection 委譲変更後の focused E2E により `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers`、`GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString`、`GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay` が pass し、`DynamicParallelNodeView.ToString()` と `DynamicParallelValuePathView.ToString()` が materialized node display に委譲される変更後も対象経路が維持されることを検証した。
+  - dynamic projection 委譲変更後の full solution test、format verification、diff whitespace check はすべて pass。
+  - `Select(...)` generated value 修正後の focused E2E により `GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers`、`GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString`、`GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay` が pass し、`Select(...)` 由来 generated value の `ToString()` expectation 追加後も対象経路が維持されることを検証した。
+  - `Select(...)` generated value 修正後の full solution test、format verification、diff whitespace check はすべて pass。
+  - 最新 main ベース最終検証により、focused E2E、full solution test、format verification、diff whitespace check はすべて pass。Markdown lint はこの repo で `lint:md` script が未定義のため unsupported として扱った。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - `npm run lint:md` は未定義のため、この検証では Markdown lint evidence は取得していない。
+  - 最新 main ベース最終検証の focused E2E build で `tests/SSC.E2E.Tests/ContainerAndSelectManyE2ETests.cs(34,47)` の CS8603 nullable warning が出力された。テスト結果は pass。

--- a/src/SSC.Generators/ParallelViewGenerator.cs
+++ b/src/SSC.Generators/ParallelViewGenerator.cs
@@ -160,9 +160,16 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
             source.AppendLine();
         }
 
+        if (!typeShape.Members.Any(static member => string.Equals(member.MemberName, "ToString", StringComparison.Ordinal)))
+        {
+            source.AppendLine("    public override string ToString() => _node.ToString();");
+            source.AppendLine();
+        }
+
         foreach (var member in typeShape.Members)
         {
             var memberName = EscapeIdentifier(member.MemberName);
+            var memberVisibility = GetGeneratedMemberVisibility(member.MemberName);
             if (member.Kind == MemberKind.Container)
             {
                 if (member.ElementType is null || !viewNames.TryGetValue(member.ElementType, out var childViewName))
@@ -174,12 +181,12 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
                 if (member.KeyType is not null)
                 {
                     var keyTypeName = member.KeyType.ToDisplayString(TypeDisplayFormat);
-                    source.AppendLine($"    public global::SSC.ParallelGeneratedDictionary<{keyTypeName}, {elementTypeName}, {childViewName}> {memberName} =>");
+                    source.AppendLine($"    {memberVisibility} global::SSC.ParallelGeneratedDictionary<{keyTypeName}, {elementTypeName}, {childViewName}> {memberName} =>");
                     source.AppendLine($"        new(_node.GetChildren<{elementTypeName}>(nameof({modelTypeName}.{memberName})), _node.Count, static child => new {childViewName}(child));");
                 }
                 else
                 {
-                    source.AppendLine($"    public global::SSC.ParallelGeneratedList<{elementTypeName}, {childViewName}> {memberName} =>");
+                    source.AppendLine($"    {memberVisibility} global::SSC.ParallelGeneratedList<{elementTypeName}, {childViewName}> {memberName} =>");
                     source.AppendLine($"        new(_node.GetChildren<{elementTypeName}>(nameof({modelTypeName}.{memberName})), _node.Count, static child => new {childViewName}(child));");
                 }
 
@@ -195,7 +202,7 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
                 }
 
                 var objectTypeName = member.ObjectType.ToDisplayString(TypeDisplayFormat);
-                source.AppendLine($"    public {childViewName} {memberName} =>");
+                source.AppendLine($"    {memberVisibility} {childViewName} {memberName} =>");
                 source.AppendLine($"        new(global::SSC.ParallelGeneratedRuntime.RequireMemberNode<{modelTypeName}, {objectTypeName}>(_node, nameof({modelTypeName}.{memberName}), nameof({modelTypeName}.{memberName})));");
                 source.AppendLine();
                 continue;
@@ -203,13 +210,16 @@ public sealed class ParallelViewGenerator : IIncrementalGenerator
 
             var valueTypeName = GetGeneratedValueTypeName(member.ValueType!);
             var getterExpression = GetGeneratedValueGetterExpression(memberName, member.ValueType!);
-            source.AppendLine($"    public global::SSC.ParallelGeneratedValue<{modelTypeName}, {valueTypeName}> {memberName} =>");
-            source.AppendLine($"        new(_node, static model => {getterExpression});");
+            source.AppendLine($"    {memberVisibility} global::SSC.ParallelGeneratedValue<{modelTypeName}, {valueTypeName}> {memberName} =>");
+            source.AppendLine($"        new(_node, global::SSC.ParallelGeneratedRuntime.RequireMemberNode<{modelTypeName}>(_node, nameof({modelTypeName}.{memberName}), nameof({modelTypeName}.{memberName})), static model => {getterExpression});");
             source.AppendLine();
         }
 
         source.AppendLine("}");
     }
+
+    private static string GetGeneratedMemberVisibility(string memberName) =>
+        memberName is "Equals" or "GetHashCode" or "GetType" or "ToString" ? "public new" : "public";
 
     private static List<TypeShape> BuildTypeGraph(INamedTypeSymbol rootType)
     {

--- a/src/SSC/GeneratedProjectionRuntime.cs
+++ b/src/SSC/GeneratedProjectionRuntime.cs
@@ -401,6 +401,7 @@ public sealed class ParallelGeneratedModelList<TElement, TView> : IReadOnlyList<
 public sealed class ParallelGeneratedValue<TModel, TValue>
 {
     private readonly ParallelNode<TModel> _node;
+    private readonly IParallelNode? _valueNode;
     private readonly Func<TModel, TValue> _getter;
 
     public ParallelGeneratedValue(ParallelNode<TModel> node, Func<TModel, TValue> getter)
@@ -411,10 +412,25 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
         _getter = getter;
     }
 
+    public ParallelGeneratedValue(
+        ParallelNode<TModel> node,
+        IParallelNode valueNode,
+        Func<TModel, TValue> getter)
+        : this(node, getter)
+    {
+        ArgumentNullException.ThrowIfNull(valueNode);
+        _valueNode = valueNode;
+    }
+
     public TValue this[int modelIndex] => ResolveValue(modelIndex, out _);
 
     public ValueState GetState(int modelIndex)
     {
+        if (_valueNode is not null)
+        {
+            return _valueNode.GetState(modelIndex);
+        }
+
         var selectedValue = ResolveValue(modelIndex, out var selectedPresence);
         return GetState(
             modelIndex,
@@ -495,22 +511,20 @@ public sealed class ParallelGeneratedValue<TModel, TValue>
 
     public override string ToString()
     {
-        var resolvedValues = new ResolvedGeneratedValue[_node.Count];
-        for (var modelIndex = 0; modelIndex < resolvedValues.Length; modelIndex++)
+        return _valueNode?.ToString() ?? CreateDerivedLeaf().ToString();
+    }
+
+    private ParallelNode<TValue> CreateDerivedLeaf()
+    {
+        var values = new TValue?[_node.Count];
+        var states = new ValueState[_node.Count];
+        for (var modelIndex = 0; modelIndex < _node.Count; modelIndex++)
         {
-            var value = ResolveValue(modelIndex, out var presence);
-            resolvedValues[modelIndex] = new ResolvedGeneratedValue(value, presence);
+            values[modelIndex] = ResolveValue(modelIndex, out _);
+            states[modelIndex] = GetState(modelIndex);
         }
 
-        return ParallelDisplayFormatter.FormatSlots(
-            _node.Count,
-            modelIndex =>
-            {
-                var selected = resolvedValues[modelIndex];
-                return new ParallelDisplaySlot(
-                    selected.Value,
-                    GetState(modelIndex, selected.Value, selected.Presence, index => resolvedValues[index]));
-            });
+        return ParallelNode<TValue>.CreateLeaf(values, states);
     }
 
     private readonly struct ResolvedGeneratedValue
@@ -592,6 +606,26 @@ public static class ParallelGeneratedRuntime
 
         throw new ArgumentException(
             $"{apiName} can be used only with generated member node '{memberName}'.",
+            nameof(memberName));
+    }
+
+    public static IParallelNode RequireMemberNode<TParent>(
+        ParallelNode<TParent> node,
+        string memberName,
+        string apiName)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        ArgumentException.ThrowIfNullOrEmpty(memberName);
+        ArgumentException.ThrowIfNullOrEmpty(apiName);
+
+        var internalNode = (IParallelNodeInternal)node;
+        if (internalNode.TryGetMemberNode(memberName, out var rawMemberNode))
+        {
+            return rawMemberNode;
+        }
+
+        throw new ArgumentException(
+            $"{apiName} cannot find generated member node '{memberName}'.",
             nameof(memberName));
     }
 }

--- a/src/SSC/ParallelDynamicAccessExtensions.cs
+++ b/src/SSC/ParallelDynamicAccessExtensions.cs
@@ -103,6 +103,8 @@ internal sealed class DynamicParallelNodeView : DynamicObject
         return false;
     }
 
+    public override string ToString() => _node.ToString() ?? string.Empty;
+
     public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object? result)
     {
         if (indexes.Length != 1 || indexes[0] is not int modelIndex)
@@ -317,6 +319,8 @@ internal sealed class DynamicParallelValuePathView : DynamicObject
         result = null;
         return false;
     }
+
+    public override string ToString() => _materializedNode?.ToString() ?? base.ToString() ?? string.Empty;
 
     public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object? result)
     {

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -14,6 +14,7 @@
 
 - Status: Done
 - Notes:
+  - T-089 で generated object view / direct scalar generated member / dynamic materialized path の表示は underlying member/root node の `ToString()` に委譲し、元モデル型の `ToString()` 表示を model slot 別に確認できる契約を追加する
   - T-088 で `ParallelNode<T>` と generated value の `ToString()` の model slot 別 value/state 表示契約を追加する
   - T-087 で generated projection list の key text indexer と diff path selector 互換を public API として確定した
   - T-086 で `ParallelDiffEntry` の親 path / 親 node を public API として確定した
@@ -36,6 +37,7 @@
 
 - Status: Done
 - Notes:
+  - T-089 を完了し、generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` を underlying node 表示へ委譲した
   - T-088 を完了し、`ParallelNode<T>` と generated value の `ToString()` を Diff と同じ value/state 表示へ改善した
   - T-087 follow-up を完了し、Dictionary member の generated access を string key text 限定から key 型 indexer へ拡張した
   - T-087 を完了し、generated projection list で `Attribute["id"]` のような raw key text access と `GetDiffEntries().Path` の escaped discriminator access を実装した
@@ -148,6 +150,7 @@
 
 - Status: Done
 - Notes:
+  - T-089 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-088 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-087 follow-up で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-087 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -12,6 +12,42 @@
 
 ## Done
 
+- T-089: generated object view の `ToString()` で元モデルの表示を model slot 別に返す
+  - Status: 完了（generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` を node 表示へ委譲した）
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-084 Source Generator の object member 展開不足修正
+    - T-088 `Parallel` の `ToString()` に model slot 別 value/state 表示を追加
+  - Exit Criteria:
+    - generated object view の `ToString()` が `_node.ToString()` と同等の model slot 別 value/state 形式を返す
+    - direct scalar generated member の `ToString()` / `GetState()` は対応する member node に委譲し、表示実装を `ParallelNode<T>.ToString()` と共有する
+    - dynamic projection も materialized node がある場合は `ToString()` を同じ node 表示へ委譲する
+    - 元モデル型が `ToString()` を override している場合、その表示が object view から確認できる
+    - `root.Root.Attribute["id"].ToString()` のように scalar member まで掘らない表示を E2E で検証する
+    - 生成型に comparable member `ToString` がある場合は名前衝突を避ける
+    - 設計更新、TDD、実装修正、検証、sub-agent review、PR 更新が完了している
+  - Output:
+    - PR #42
+    - `src/SSC/GeneratedProjectionRuntime.cs`
+    - `src/SSC.Generators/ParallelViewGenerator.cs`
+    - `src/SSC/ParallelDynamicAccessExtensions.cs`
+    - `tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs`
+    - `doc/design/detail/02-PublicApi.md`
+    - `Design/BreakingChanges.md`
+    - `reports/task-t-089-generated-object-tostring-20260625170134.md`
+    - `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`
+    - `reports/task-t-089-generated-object-tostring-review-20260625170550.md`
+  - Verification:
+    - TDD 赤確認: generated object view の `ToString()` が生成 view class の型名表示になり失敗
+    - `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"` 成功（3 件）
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 31 件 / E2E 74 件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - `npm run lint:md` は `Missing script: "lint:md"` のため unsupported
+    - gpt-5.5 medium verification sub-agent 実施、指摘なし
+    - gpt-5.5 high review / re-review sub-agent 実施、最終指摘なし
+
 - T-088: `Parallel` の `ToString()` に model slot 別 value/state 表示を追加
   - Status: 完了（`ParallelNode<T>` と generated value の `ToString()` を Diff 表示と同じ model slot 別 value/state 形式にした）
   - Phase: Phase 3

--- a/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/GeneratedProjectionE2ETests.cs
@@ -41,11 +41,13 @@ public sealed class GeneratedProjectionE2ETests
 
         Assert.Equal("root", root.Root.Name[0]);
         Assert.Equal("[0]=\"root\"(Matched), [1]=\"root\"(Matched)", root.Root.Name.ToString());
+        Assert.Equal("[0]=\"ROOT\"(Matched), [1]=\"ROOT\"(Matched)", root.Root.Name.Select(static value => value.ToUpperInvariant()).ToString());
         // Attribute["id"] は dictionary key の指定で、続く [0] / [1] は model index の指定。
         Assert.Equal("id", root.Root.Attribute["id"][0]!.Name);
         Assert.Equal("left", root.Root.Attribute["id"][0]!.Value);
         Assert.Equal("right", root.Root.Attribute["id"][1]!.Value);
         // child view 自体の GetState と、Value member の GetState は別々に取得できる。
+        Assert.Equal("[0]=id=left(Mismatched), [1]=id=right(Mismatched)", root.Root.Attribute["id"].ToString());
         Assert.Equal("right", root.Root.Attribute["id"].Value[1]);
         Assert.Equal("[0]=\"left\"(Mismatched), [1]=\"right\"(Mismatched)", root.Root.Attribute["id"].Value.ToString());
         Assert.Equal(ValueState.Mismatched, root.Root.Attribute["id"].GetState(0));
@@ -54,6 +56,66 @@ public sealed class GeneratedProjectionE2ETests
         Assert.Equal(4, root.Root.Range.EndLine[1]);
     }
 
+    [Fact]
+    public void Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString()
+    {
+        // Intent: A model member named ToString keeps its generated accessor instead of colliding with object view ToString().
+        var models = new[]
+        {
+            new GeneratedToStringMemberDocument
+            {
+                Child = new GeneratedToStringMemberChild { ToString = "left" },
+            },
+            new GeneratedToStringMemberDocument
+            {
+                Child = new GeneratedToStringMemberChild { ToString = "right" },
+            },
+        };
+
+        var root = ParallelCompareApi.Compare(models).AsGeneratedView()!;
+
+        Assert.Equal("left", root.Child.ToString[0]);
+        Assert.Equal("right", root.Child.ToString[1]);
+        Assert.Equal(ValueState.Mismatched, root.Child.ToString.GetState(0));
+    }
+
+    [Fact]
+    public void Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay()
+    {
+        // Intent: dynamic access and generated access share the same materialized node ToString() display.
+        var models = new[]
+        {
+            new GeneratedDocument
+            {
+                Root = new GeneratedXmlNode
+                {
+                    Name = "root",
+                    Attribute = new Dictionary<string, GeneratedXmlAttribute>
+                    {
+                        ["id"] = new() { Name = "id", Value = "left" },
+                    },
+                    Range = new GeneratedTextRange { StartLine = 1, EndLine = 3 },
+                },
+            },
+            new GeneratedDocument
+            {
+                Root = new GeneratedXmlNode
+                {
+                    Name = "root",
+                    Attribute = new Dictionary<string, GeneratedXmlAttribute>
+                    {
+                        ["id"] = new() { Name = "id", Value = "right" },
+                    },
+                    Range = new GeneratedTextRange { StartLine = 1, EndLine = 4 },
+                },
+            },
+        };
+
+        dynamic root = ParallelCompareApi.Compare(models).AsDynamic()!;
+
+        Assert.Equal("[0]=\"root\"(Matched), [1]=\"root\"(Matched)", root.Root.Name.ToString());
+        Assert.Equal("[0]=id=left(Mismatched), [1]=id=right(Mismatched)", root.Root.Attribute[0].ToString());
+    }
 
     [Fact]
     public void Compare_GeneratedProjection_PublicIEnumerableField_GeneratesContainerAccessor()
@@ -682,6 +744,8 @@ public sealed class GeneratedXmlAttribute
     public required string Name;
 
     public required string Value;
+
+    public override string ToString() => $"{Name}={Value}";
 }
 
 public struct GeneratedTextRange
@@ -689,6 +753,17 @@ public struct GeneratedTextRange
     public int StartLine;
 
     public int EndLine;
+}
+
+[GenerateParallelView]
+public sealed class GeneratedToStringMemberDocument
+{
+    public GeneratedToStringMemberChild Child { get; init; } = new();
+}
+
+public sealed class GeneratedToStringMemberChild
+{
+    public new string ToString { get; init; } = string.Empty;
 }
 
 [GenerateParallelView]


### PR DESCRIPTION
## Summary
- Add generated object view `ToString()` output by delegating to the underlying `ParallelNode<T>.ToString()`.
- Share direct scalar generated value `ToString()` / `GetState()` with materialized member nodes instead of duplicating slot formatting.
- Preserve `Select(...)` generated value display by converting derived values into a temporary leaf node before `ToString()`.
- Add dynamic materialized path `ToString()` delegation and E2E coverage for generated object, `ToString` member collision, `Select(...)`, and dynamic access.

## Issue
- No GitHub issue exists for this user-reported T-089 follow-up.
- Follow-up to merged PR #41.

## Reports
- `reports/task-t-089-generated-object-tostring-20260625170134.md`
- `reports/task-t-089-generated-object-tostring-verification-20260625170333.md`
- `reports/task-t-089-generated-object-tostring-review-20260625170550.md`

## Validation
- `dotnet test tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj --configuration Release --filter "FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ObjectMember_GeneratesNestedViewMembers|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_GeneratedProjection_ToStringMember_DoesNotConflictWithObjectViewToString|FullyQualifiedName~GeneratedProjectionE2ETests.Compare_DynamicProjection_ToString_UsesMaterializedNodeDisplay"` passed 3 tests.
- `dotnet test SSC.sln --configuration Release` passed: Unit 31, E2E 74.
- `dotnet format SSC.sln --verify-no-changes` passed.
- `git diff --check` passed.
- `npm run lint:md` unsupported: missing `lint:md` script.

## Review
- gpt-5.5 high sub-agent review and re-review: final findings none.
- Earlier `Select(...)` generated value fallback regression was fixed and re-reviewed.

## Risks
- Runtime-derived dynamic paths without a materialized node remain out of scope for node-display delegation.
- `ToString()` remains convenience output for human inspection; structured APIs remain the stable machine-readable contract.
