### PR TITLE
fix(compare): polymorphic sequence の runtime 型を比較する

### DIFF
--- a/Design/BreakingChanges.md
+++ b/Design/BreakingChanges.md
@@ -1,5 +1,26 @@
 # Breaking Changes
 
+## 2026-07-11
+
+### T-090 polymorphic sequence の runtime 型比較
+
+- 対象:
+  - 基底型で宣言された sequence member
+  - 例: `IEnumerable<Item>` に `Node` / `Content` が格納されるモデル
+- 変更種別:
+  - public runtime behavior の変更
+- 影響:
+  - 従来は sequence の宣言要素型だけで比較対象メンバーを探索していたため、基底型に比較可能なメンバーが無い場合、派生型固有メンバーの差分が `GetDiffEntries()` に現れなかった
+  - T-090 以降は aligned slot の runtime 型が同一なら、そのruntime型のpublic property / fieldを再帰比較する
+  - aligned slot のruntime型が異なる場合は、派生メンバーへ展開せず要素node自身を `Mismatched` として返す
+  - 従来0件だった差分が新たに返るため、diff entry件数やpathを厳密に固定している利用コードは期待値更新が必要になる可能性がある
+- 背景:
+  - YXmlの `Node.Children : IEnumerable<Item>` では実値が `Node` / `Content` であり、`Content.Text` や `Node.Attribute` の差分が比較木構築時に欠落していたため
+- 互換性:
+  - public API shapeは変更しない
+  - child nodeのgeneric型は引き続き宣言要素型を維持し、`GetChildren<Item>(...)` の既存アクセスを保持する
+  - sequence alignment、`CompareKey`、null、Missingの既存規則は変更しない
+
 ## 2026-06-25
 
 ### T-089 generated object view `ToString()` の表示変更

--- a/doc/design/detail/03-ContainerRules.md
+++ b/doc/design/detail/03-ContainerRules.md
@@ -51,6 +51,44 @@ E2=[null,(3,30)]
 - 実行時型が未対応コンテナの場合 `UnsupportedContainerType`
 - trace 有効時は declared type と runtime type、materialize 件数、再判定結果を記録する
 
+### 4.1 Polymorphic Sequence Element Rules
+
+`IEnumerable<Base>` の aligned element に `DerivedA` / `DerivedB` が入る場合、公開 node の generic 型と、比較対象メンバーを探索する型を分離する。
+
+- 公開 node の generic 型は宣言要素型を維持する
+  - 例: `ParallelNode<Base>`
+  - `GetChildren<Base>(...)` の既存型付きアクセスを維持する
+- `PresentValue` の runtime 型が全 model で同一の場合、その runtime 型の comparable member を再帰比較する
+  - `DerivedA` vs `DerivedA`: `DerivedA` の public property / field を比較する
+  - `DerivedA` vs `Missing`: `DerivedA` の型情報を使用し、既存の presence 差分を優先する
+  - `DerivedA` vs `null`: `DerivedA` の型情報を使用し、既存の value/null 差分を優先する
+- `PresentValue` に複数の runtime 型が混在する場合、要素 node 自身を `Mismatched` とする
+  - 例: `DerivedA` vs `DerivedB`
+  - 派生型固有メンバーへは再帰しない
+  - `GetDiffEntries()` は aligned element path に node entry を生成する
+  - 型違いは通常差分であり、`CompareIssue` や `HasError` の対象にしない
+- 派生型固有メンバーの union を作って大量の `Missing` 差分へ展開しない
+- runtime 派生型にだけ存在する `CompareKey` は探索しない。alignment 規則は宣言要素型に基づく既存契約を維持する
+
+例:
+
+```text
+declared element type = Item
+
+Node    vs Node       -> Node の member を再帰比較
+Content vs Content    -> Content の member を再帰比較
+Node    vs Content    -> element 自身の runtime 型差分
+Node    vs null       -> value/null 差分
+Node    vs Missing    -> presence 差分
+```
+
+trace では、公開 node 型と member 探索型を区別できるようにする。
+
+```text
+phase=node path=Document.Root.Children nodeType=Item comparisonType=Content nodeKind=Object keyText=0
+phase=node path=Document.Root.Children nodeType=Item comparisonType=Item nodeKind=RuntimeTypeMismatch runtimeTypes=Content,Node keyText=0
+```
+
 ## 5. Unsupported Containers
 
 - `IAsyncEnumerable<T>`

--- a/reports/task-t-090-polymorphic-sequence-runtime-type-design-20260711.md
+++ b/reports/task-t-090-polymorphic-sequence-runtime-type-design-20260711.md
@@ -1,0 +1,157 @@
+# T-090 polymorphic sequence runtime 型比較 設計メモ
+
+## 背景
+
+`IEnumerable<Item>` のように基底型で宣言された sequence に、実行時には `Node` や `Content` などの派生型が格納されるモデルを比較すると、派生型固有メンバーの差分が `GetDiffEntries()` に現れない。
+
+確認した最小構造は次のとおり。
+
+```csharp
+public class Item
+{
+}
+
+public sealed class Node : Item
+{
+    public string Name { get; init; } = string.Empty;
+
+    public IEnumerable<Item> Children { get; init; } = [];
+}
+
+public sealed class Content : Item
+{
+    public string Text { get; init; } = string.Empty;
+}
+```
+
+この構造で左右の同じ ordinal に `Content` があり、`Text` だけが異なっていても、従来実装では差分 entry が 0 件になる。
+
+## 問題が起きる理由
+
+sequence 構築処理は、メンバー宣言から得た要素型 `Item` をそのまま `BuildNode` に渡している。
+
+```text
+declaredType = IEnumerable<Item>
+elementType  = Item
+nodeType     = Item
+```
+
+`BuildNodeGeneric<TNode>` は `typeof(TNode)` に対して比較対象メンバーを列挙する。そのため `TNode == Item` で、`Item` に public property / field が無い場合、子 node は比較対象メンバーを一つも持たない。
+
+実際の slot 値が `Node` または `Content` でも、次のメンバーは比較木に登録されない。
+
+- `Node.Name`
+- `Node.Children`
+- `Content.Text`
+- その他の派生型固有メンバー
+
+これは parser、`CompareKey`、`GetDiffEntries()` の表示フィルターによる欠落ではなく、比較木を構築する段階で派生型情報を参照していないことが原因である。
+
+## 修正方針
+
+### 1. 公開 node 型とメンバー探索型を分離する
+
+公開される node の generic 型は、従来どおり sequence の宣言要素型を維持する。
+
+```text
+ParallelNode<Item>
+```
+
+一方、比較対象メンバーの探索には、aligned slot 内の runtime 型を使用できるようにする。
+
+```text
+nodeType       = Item
+comparisonType = Content
+```
+
+これにより `GetChildren<Item>(...)` など既存の型付きアクセスを壊さず、`Content.Text` や `Node.Name` を比較木へ登録できる。
+
+### 2. aligned slot の runtime 型が一種類の場合
+
+`PresentValue` の slot から runtime 型を収集し、全て同一型で、かつ宣言要素型へ代入可能な場合、その型を `comparisonType` とする。
+
+```text
+Node    vs Node    -> comparisonType = Node
+Content vs Content -> comparisonType = Content
+Node    vs Missing -> comparisonType = Node
+Node    vs null    -> comparisonType = Node
+```
+
+`Missing` と `PresentNull` は runtime 型解決の候補から除外し、既存の presence/null 判定を維持する。
+
+### 3. aligned slot に複数の runtime 型が混在する場合
+
+次のような比較では、どちらか一方の派生型へ強制キャストしない。
+
+```text
+Node vs Content
+```
+
+この場合は以下の契約とする。
+
+1. 要素 node 自身を `Mismatched` とする。
+2. `HasDifferences()` は `true` を返す。
+3. `GetDiffEntries()` は、その要素 path に node entry を1件生成する。
+4. 派生型固有メンバーの再帰比較は打ち切る。
+5. `CompareIssue` は追加せず、`HasError` も立てない。
+
+型違いは入力エラーではなく、通常の構造差分として扱う。
+
+派生型ごとの全メンバーを union して `Missing` 差分へ展開する方式は採用しない。型変更1件が大量の派生メンバー差分へ膨らみ、差分の主因が不明瞭になるためである。
+
+### 4. null / Missing の既存契約
+
+| 左 | 右 | 結果 |
+|---|---|---|
+| `Node` | `Node` | `Node` のメンバーを再帰比較 |
+| `Content` | `Content` | `Content` のメンバーを再帰比較 |
+| `Node` | `Content` | 要素 node の runtime 型差分 |
+| `Node` | `null` | 既存の value/null presence 差分 |
+| `Node` | `Missing` | 既存の presence 差分 |
+| `null` | `null` | 一致 |
+| `Missing` | `Missing` | 比較対象なし |
+
+## 実装対象
+
+### `ParallelCompareApi`
+
+- `BuildNode` に、generic node 型とは別の `comparisonType` を渡せる内部経路を追加する。
+- `BuildNodeGeneric<TNode>` は scalar 判定と comparable member 探索に `comparisonType` を使用する。
+- keyed sequence と ordinal-aligned sequence の child slot 構築後に runtime 型を解決する。
+- public node の generic 型には宣言要素型を使用し続ける。
+- trace に `nodeType`、`comparisonType`、runtime 型不一致を識別できる情報を追加する。
+
+### `ParallelNode<T>`
+
+- `PresentValue` slot の runtime 型不一致を検出する。
+- runtime 型不一致時は各 present slot の `GetState()` を `Mismatched` とする。
+- runtime 型不一致時は `HasDifferences()` を `true` とする。
+- runtime 型不一致 node は派生メンバーへ再帰せず、要素自身を leaf 相当の差分として公開する。
+
+## 変更しない範囲
+
+- sequence の alignment 規則は変更しない。
+  - `[CompareKey]` がある場合は key union。
+  - `[CompareKey]` がない場合は ordinal index。
+- `MissingCompareKeyListPolicy` の意味は変更しない。
+- runtime 派生型にだけ存在する `[CompareKey]` を新たに探索する仕様は本タスクに含めない。
+- public enum や public interface へのメンバー追加は行わない。
+
+## 必須テスト
+
+1. 空の基底型で宣言された sequence に、左右とも同じ派生型が入り、派生型scalar memberだけが異なる場合に差分が出る。
+2. `Node.Children : IEnumerable<Item>` のような再帰構造で、孫の `Content.Text` 差分まで検出できる。
+3. 同じ ordinal で `Node` と `Content` が対向した場合、要素 path に1件の runtime 型差分が出て再帰しない。
+4. `Node` 対 `null` が既存の null 差分になる。
+5. `Node` 対 `Missing` が既存の presence 差分になる。
+6. child node が引き続き `ParallelNode<Item>` として取得できる。
+7. keyed sequence の key union と keyless sequence の ordinal alignment に回帰がない。
+8. dynamic container materialization でも同じ規則が適用される。
+
+## 受け入れ条件
+
+- `IEnumerable<Item>` 配下の同一派生型メンバー差分が `GetDiffEntries()` に現れる。
+- runtime 型が異なる aligned element は例外や Error issueではなく通常差分になる。
+- 型不一致 entry は要素 path に集約され、派生型固有メンバー差分へ展開されない。
+- `GetChildren<Item>()` 等の既存型付きアクセスが維持される。
+- 既存の sequence alignment、null、Missing、duplicate key、strict mode のテストが通る。

--- a/reports/task-t-090-review-fix-implementation-20260711192823.md
+++ b/reports/task-t-090-review-fix-implementation-20260711192823.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: PR #43 のレビューで指摘された XML documentation 不足を修正する
+- タスク種別: 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザーが実装を `5.6 terra medium` sub-agentへ委譲するよう指定したため
+
+## 対象範囲
+
+- 対象: `src/SSC/ParallelNode.cs` の変更 internal contract、および新規 polymorphic E2E test 2ファイルの XML documentation
+
+## 対象外
+
+- 対象外: runtime比較ロジック、テスト内容、設計文書、公開API、Git commit/push、PR操作
+
+## 実行コマンド
+
+- 実行コマンド: `sed`、`rg` による対象コード・XML documentation 方針の確認、`git diff --check`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelNode.cs`、`tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`、`reports/task-t-090-review-fix-implementation-20260711192823.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 新規7件の Fact、2つのテストクラス、共有 public nested test type/property、および変更済み internal 契約に XML documentation が不足していた。
+
+## 結果
+
+- 結果: `gpt-5.6-terra / medium` 指定で実装し、runtime比較ロジック、テスト assertion・データ、設計 Markdown、tracking、Git/PR 操作を変更せず、指定された XML documentation のみを追加した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: テスト実行は別 verification agent の担当であり、本タスクでは未実行。`git diff --check` のみ実施する。

--- a/reports/task-t-090-review-fix-rereview-20260711193527.md
+++ b/reports/task-t-090-review-fix-rereview-20260711193527.md
@@ -1,0 +1,45 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: PR #43 の XML documentation 修正後の再レビュー
+- タスク種別: 再レビュー
+
+## sub-agentを使う理由
+
+- 理由: review-enforcer が独立 reviewer による再レビューとレポート保存を必須としているため
+- reviewer: `gpt-5.6-sol / high`
+- reviewer再利用判断: 前回 reviewer の spawn は hidden model override を指定しておらず、ユーザー指定の `gpt-5.6-sol / high` を確実に適用するため fresh spawn とし、元 reviewer は再利用しなかった
+
+## 対象範囲
+
+- 対象: `origin/main` から現在worktreeまでのPR全差分、特に前回blocking指摘の解消、機能・設計・テスト・追跡・レポート整合性
+
+## 対象外
+
+- 対象外: ファイル修正、commit、push、PR操作
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short`、`git rev-parse origin/main`、`git rev-parse HEAD`、`git diff --stat origin/main...HEAD`、`git diff --name-status origin/main...HEAD`、`git diff --stat HEAD`、`git diff --name-status HEAD`、`git diff --unified=80 origin/main -- ...` によるPR全差分確認、`git diff --unified=5 HEAD -- ...` による修正後差分確認、`rg`・`nl` による7件の Fact・2テストクラス・共有 public nested type/property・変更 internal contract の XML documentation 確認、`sed '/^[[:space:]]*\/\/\//d'` と `diff -u` による documentation 除外後の修正前後比較、`git diff --check`（成功）。verification evidenceとして `dotnet test SSC.sln --configuration Release`（Unit 31件 + E2E 81件 = 112件成功）、`dotnet format SSC.sln --verify-no-changes`（成功）を確認。Markdown lint は `package.json` と `tools/lint` が存在せず repo wiring 不在のため unsupported。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `Design/BreakingChanges.md`、`doc/design/detail/03-ContainerRules.md`、`reports/task-t-090-polymorphic-sequence-runtime-type-design-20260711.md`、`src/SSC/ParallelCompareApi.cs`、`src/SSC/ParallelNode.cs`、`tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`、`tasks/tasks-status.md`、`tasks/phases-status.md`、`reports/task-t-090-review-fix-implementation-20260711192823.md`、`reports/task-t-090-review-fix-verification-20260711193158.md`。本再レビューで変更したのは当レポートの空欄のみ。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。
+  - blocking normal-path finding: なし。
+  - ユーザー確認が必要な capability gap: なし。
+  - non-blocking hold: Markdown lint は repo wiring 不在のため unsupported。通常利用経路、runtime 実装、テスト契約を妨げないため held とする。
+  - 前回 blocking の解消確認: 新規7件の Fact はすべて `[Fact]` 直前に挙動契約を述べる XML summary があり、2テストクラスと共有 public nested type/property にも XML summary がある。`src/SSC/ParallelNode.cs:14` の変更 internal constructor は summary と全7 parameter documentation、`src/SSC/ParallelNode.cs:48` の `HasRuntimeTypeMismatch` は node-level mismatch と子memberへ下降しない契約を説明している。
+  - 修正差分の不変性確認: 修正前 HEAD と現在worktreeの対象3ファイルから XML documentation 行を除去した比較は差分0件。実装後の追加は XML documentation、tracking、report のみで、runtimeロジック、assertion、test data は不変。
+
+## 結果
+
+- 結果: 合格。`origin/main` から現在worktreeまでのPR全差分を built-in code review behavior で再レビューし、blocking finding、ユーザー確認が必要な gap、保持すべきコード上の non-blocking finding はいずれもなかった。Release 112 tests、format、`git diff --check` の成功 evidence と合わせ、PR #43 の XML documentation 修正後 review gate は通過可能。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lint は repo wiring 不在のため機械的な pass evidence を取得できず unsupported のまま。ただし対象 Markdown と tracking/report を目視確認し、通常利用経路への影響はないため non-blocking hold とする。既存差分外の `ContainerAndSelectManyE2ETests.cs(34,47)` に CS8603 warning が1件あるが、Release 112 tests は失敗0・skip 0で、本PRの blocking finding ではない。

--- a/reports/task-t-090-review-fix-verification-20260711193158.md
+++ b/reports/task-t-090-review-fix-verification-20260711193158.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: PR #43 の XML documentation 修正を独立検証する
+- タスク種別: 検証・standards validation
+
+## sub-agentを使う理由
+
+- 理由: codex-delegation-executor と feedback-coding-standards-enforcer が検証・standards validationを独立 sub-agentの固定担当としているため
+
+## 対象範囲
+
+- 対象: PR #43 headからの修正差分、XML documentation網羅性、全テスト、format、diff check
+
+## 対象外
+
+- 対象外: ファイル修正、commit、push、PR操作、再レビュー
+
+## 実行コマンド
+
+- 実行コマンド: `git diff --unified=80 origin/pr/43 -- src/SSC/ParallelNode.cs tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`rg`・`nl`・`awk` による XML documentation 網羅性と非 documentation 差分の確認、`dotnet test SSC.sln --configuration Release`（成功、Unit 31件 + E2E 81件 = 計112件）、`dotnet format SSC.sln --verify-no-changes`（失敗、MSBuild workspace の restore operation failed）、`dotnet format SSC.sln --verify-no-changes --verbosity diagnostic`（同失敗）、`dotnet format SSC.sln --verify-no-changes --no-restore`（失敗、sandbox が build-host named pipe 接続を Permission denied）、`git diff --check`（成功）。Markdown lint は `package.json`・`tools/lint` が存在せず repo wiring がないため unsupported と判定し、未実行。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelNode.cs`、`tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`、`AGENTS.md`、`src/SSC/SSC.csproj`、`tests/SSC.E2E.Tests/SSC.E2E.Tests.csproj`、`reports/task-t-090-review-fix-implementation-20260711192823.md`、`reports/task-t-090-review-fix-verification-20260711193158.md`。本検証で変更したのは当レポートの空欄のみ。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: standards 指摘なし。新規7件の Fact は全て属性直前に挙動契約を述べる XML summary があり、2テストクラスと共有 public nested test type/property も全て XML summary を持つ。`ParallelNode<T>` の変更 internal constructor は summary と全7 parameter docs、`HasRuntimeTypeMismatch` は node-level mismatch と非下降契約を説明しており、source documentation policy を満たす。対象3ファイルの `origin/pr/43` 差分は追加112行が全て `///` documentation で、非 documentation の追加・削除は0行のため、runtimeロジック、assertion、test data の変更はない。
+
+## 結果
+
+- 結果: XML documentation standards validation は合格。Release 全112テストは失敗0・skip 0で合格し、`git diff --check` も合格。`dotnet format SSC.sln --verify-no-changes` は sandbox 内の MSBuild build-host IPC 制約により完了できず、format pass は未確認。Markdown lint は repo wiring 不在のため unsupported。独立再検証として 2026-07-11 に `/tmp/ssc-pr43-fix` で同コマンドを実行した結果、終了コード0で成功し、format gate の合格を確認した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: sandbox 外で `dotnet format SSC.sln --verify-no-changes` を再実行し、format gate を確定する必要がある。テスト中に既存の `ContainerAndSelectManyE2ETests.cs(34,47)` の CS8603 warning が1件出たが、対象差分外でテスト失敗には至っていない。Markdown lint は repo に配線されるまで機械的な pass evidence を取得できない。なお、format gate は上記の独立再検証成功により確定済みであり、この点の後続対応は不要となった。

--- a/src/SSC/ParallelCompareApi.cs
+++ b/src/SSC/ParallelCompareApi.cs
@@ -81,12 +81,15 @@ public static class ParallelCompareApi
         CompareContext context,
         string? keyText,
         object? keyValue,
-        IEqualityComparer<object>? keyComparer)
+        IEqualityComparer<object>? keyComparer,
+        Type? comparisonType = null)
     {
         var generic = BuildNodeMethod.MakeGenericMethod(nodeType);
         try
         {
-            return (IParallelNode)generic.Invoke(null, [slots, path, context, keyText, keyValue, keyComparer])!;
+            return (IParallelNode)generic.Invoke(
+                null,
+                [slots, path, context, keyText, keyValue, keyComparer, comparisonType ?? nodeType])!;
         }
         catch (TargetInvocationException ex) when (ex.InnerException is CompareInputException)
         {
@@ -104,7 +107,8 @@ public static class ParallelCompareApi
         CompareContext context,
         string? keyText,
         object? keyValue,
-        IEqualityComparer<object>? keyComparer)
+        IEqualityComparer<object>? keyComparer,
+        Type comparisonType)
     {
         var typedValues = new TNode?[slots.Length];
         var states = new NodePresenceState[slots.Length];
@@ -117,23 +121,53 @@ public static class ParallelCompareApi
                 : default;
         }
 
-        var isScalarNode = IsScalarType(typeof(TNode));
+        var isScalarNode = IsScalarType(comparisonType);
         var node = new ParallelNode<TNode>(typedValues, states, keyText, keyValue, keyComparer, isScalarNode);
+        if (node.HasRuntimeTypeMismatch)
+        {
+            if (context.IsTraceEnabled)
+            {
+                context.Trace(
+                    "node",
+                    path,
+                    ("nodeType", typeof(TNode)),
+                    ("comparisonType", comparisonType),
+                    ("nodeKind", "RuntimeTypeMismatch"),
+                    ("runtimeTypes", FormatRuntimeTypes(slots)),
+                    ("keyText", keyText));
+            }
+
+            return node;
+        }
+
         if (isScalarNode)
         {
             if (context.IsTraceEnabled)
             {
-                context.Trace("node", path, ("nodeType", typeof(TNode)), ("nodeKind", "Scalar"), ("keyText", keyText));
+                context.Trace(
+                    "node",
+                    path,
+                    ("nodeType", typeof(TNode)),
+                    ("comparisonType", comparisonType),
+                    ("nodeKind", "Scalar"),
+                    ("keyText", keyText));
             }
+
             return node;
         }
 
         if (context.IsTraceEnabled)
         {
-            context.Trace("node", path, ("nodeType", typeof(TNode)), ("nodeKind", "Object"), ("keyText", keyText));
+            context.Trace(
+                "node",
+                path,
+                ("nodeType", typeof(TNode)),
+                ("comparisonType", comparisonType),
+                ("nodeKind", "Object"),
+                ("keyText", keyText));
         }
 
-        foreach (var property in TypeMetadataResolver.GetComparableMembers(typeof(TNode)))
+        foreach (var property in TypeMetadataResolver.GetComparableMembers(comparisonType))
         {
             var propertyPath = $"{path}.{property.Name}";
             if (context.IsTraceEnabled)
@@ -503,7 +537,8 @@ public static class ParallelCompareApi
                 context,
                 keyText: keyTexts.TryGetValue(key, out var keyText) ? keyText : KeyToText(key),
                 keyValue: key,
-                keyComparer: comparer);
+                keyComparer: comparer,
+                comparisonType: ResolveRuntimeComparisonType(elementType, slots));
             children.Add(childNode);
         }
 
@@ -587,10 +622,55 @@ public static class ParallelCompareApi
                 context,
                 keyText: itemIndex.ToString(CultureInfo.InvariantCulture),
                 keyValue: null,
-                keyComparer: null));
+                keyComparer: null,
+                comparisonType: ResolveRuntimeComparisonType(elementType, slots)));
         }
 
         return children;
+    }
+
+    private static Type ResolveRuntimeComparisonType(Type declaredType, IReadOnlyList<NodeSlot> slots)
+    {
+        Type? runtimeType = null;
+        for (var index = 0; index < slots.Count; index++)
+        {
+            var slot = slots[index];
+            if (slot.State != NodePresenceState.PresentValue || slot.Value is null)
+            {
+                continue;
+            }
+
+            var currentType = slot.Value.GetType();
+            if (!declaredType.IsAssignableFrom(currentType))
+            {
+                return declaredType;
+            }
+
+            if (runtimeType is null)
+            {
+                runtimeType = currentType;
+                continue;
+            }
+
+            if (runtimeType != currentType)
+            {
+                return declaredType;
+            }
+        }
+
+        return runtimeType ?? declaredType;
+    }
+
+    private static string FormatRuntimeTypes(IReadOnlyList<NodeSlot> slots)
+    {
+        var runtimeTypes = slots
+            .Where(slot => slot.State == NodePresenceState.PresentValue && slot.Value is not null)
+            .Select(slot => slot.Value!.GetType().ToString())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(typeName => typeName, StringComparer.Ordinal)
+            .ToArray();
+
+        return runtimeTypes.Length == 0 ? "<none>" : string.Join(",", runtimeTypes);
     }
 
     private static IEnumerable<(object? Key, object? Value)> EnumerateDictionary(object rawContainer)

--- a/src/SSC/ParallelCompareApi.cs
+++ b/src/SSC/ParallelCompareApi.cs
@@ -89,7 +89,16 @@ public static class ParallelCompareApi
         {
             return (IParallelNode)generic.Invoke(
                 null,
-                [slots, path, context, keyText, keyValue, keyComparer, comparisonType ?? nodeType])!;
+                [
+                    slots,
+                    path,
+                    context,
+                    keyText,
+                    keyValue,
+                    keyComparer,
+                    comparisonType ?? nodeType,
+                    comparisonType is not null,
+                ])!;
         }
         catch (TargetInvocationException ex) when (ex.InnerException is CompareInputException)
         {
@@ -108,7 +117,8 @@ public static class ParallelCompareApi
         string? keyText,
         object? keyValue,
         IEqualityComparer<object>? keyComparer,
-        Type comparisonType)
+        Type comparisonType,
+        bool detectRuntimeTypeMismatch)
     {
         var typedValues = new TNode?[slots.Length];
         var states = new NodePresenceState[slots.Length];
@@ -122,7 +132,14 @@ public static class ParallelCompareApi
         }
 
         var isScalarNode = IsScalarType(comparisonType);
-        var node = new ParallelNode<TNode>(typedValues, states, keyText, keyValue, keyComparer, isScalarNode);
+        var node = new ParallelNode<TNode>(
+            typedValues,
+            states,
+            keyText,
+            keyValue,
+            keyComparer,
+            isScalarNode,
+            detectRuntimeTypeMismatch);
         if (node.HasRuntimeTypeMismatch)
         {
             if (context.IsTraceEnabled)

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -17,12 +17,13 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         string? keyText,
         object? keyValue = null,
         IEqualityComparer<object>? keyComparer = null,
-        bool isScalarNode = false)
+        bool isScalarNode = false,
+        bool detectRuntimeTypeMismatch = false)
     {
         _values = values;
         _states = states;
         _isScalarNode = isScalarNode;
-        _hasRuntimeTypeMismatch = DetectRuntimeTypeMismatch(values, states);
+        _hasRuntimeTypeMismatch = detectRuntimeTypeMismatch && DetectRuntimeTypeMismatch(values, states);
         KeyText = keyText;
         KeyValue = keyValue;
         KeyComparer = keyComparer;

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -5,6 +5,7 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     private readonly T?[] _values;
     private readonly NodePresenceState[] _states;
     private readonly bool _isScalarNode;
+    private readonly bool _hasRuntimeTypeMismatch;
     private readonly Dictionary<string, IReadOnlyList<IParallelNode>> _children = new(StringComparer.Ordinal);
     private readonly Dictionary<string, NodePresenceState[]> _containerPresenceStates = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IParallelNode> _memberNodes = new(StringComparer.Ordinal);
@@ -21,6 +22,7 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         _values = values;
         _states = states;
         _isScalarNode = isScalarNode;
+        _hasRuntimeTypeMismatch = DetectRuntimeTypeMismatch(values, states);
         KeyText = keyText;
         KeyValue = keyValue;
         KeyComparer = keyComparer;
@@ -31,6 +33,8 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     internal object? KeyValue { get; }
 
     internal IEqualityComparer<object>? KeyComparer { get; }
+
+    internal bool HasRuntimeTypeMismatch => _hasRuntimeTypeMismatch;
 
     public int Count => _values.Length;
 
@@ -83,6 +87,11 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         if (_states.Length <= 1)
         {
             return ValueState.Missing;
+        }
+
+        if (_hasRuntimeTypeMismatch)
+        {
+            return ValueState.Mismatched;
         }
 
         if (!_isScalarNode)
@@ -164,6 +173,11 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
             return false;
         }
 
+        if (_hasRuntimeTypeMismatch)
+        {
+            return true;
+        }
+
         if (_isScalarNode)
         {
             for (var modelIndex = 0; modelIndex < _states.Length; modelIndex++)
@@ -214,7 +228,7 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
 
     public IReadOnlyList<ParallelChildSet> GetDirectChildren()
     {
-        if (_directChildOrder.Count == 0)
+        if (_hasRuntimeTypeMismatch || _directChildOrder.Count == 0)
         {
             return Array.Empty<ParallelChildSet>();
         }
@@ -302,6 +316,34 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         {
             _directChildOrder.Add(memberName);
         }
+    }
+
+    private static bool DetectRuntimeTypeMismatch(
+        IReadOnlyList<T?> values,
+        IReadOnlyList<NodePresenceState> states)
+    {
+        Type? runtimeType = null;
+        for (var index = 0; index < states.Count; index++)
+        {
+            if (states[index] != NodePresenceState.PresentValue || values[index] is null)
+            {
+                continue;
+            }
+
+            var currentType = values[index]!.GetType();
+            if (runtimeType is null)
+            {
+                runtimeType = currentType;
+                continue;
+            }
+
+            if (runtimeType != currentType)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool HasPresenceMismatch(IReadOnlyList<NodePresenceState> states)

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -11,6 +11,16 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     private readonly Dictionary<string, IParallelNode> _memberNodes = new(StringComparer.Ordinal);
     private readonly List<string> _directChildOrder = [];
 
+    /// <summary>
+    /// Initializes a comparison node from aligned model values and presence states, optionally treating differing non-null runtime types as a mismatch.
+    /// </summary>
+    /// <param name="values">Values aligned by model index.</param>
+    /// <param name="states">Presence states aligned with <paramref name="values"/>.</param>
+    /// <param name="keyText">Display text for the key that identifies this node, when one exists.</param>
+    /// <param name="keyValue">Raw key value used to align keyed collection elements, when one exists.</param>
+    /// <param name="keyComparer">Comparer used for <paramref name="keyValue"/>, when keyed alignment requires one.</param>
+    /// <param name="isScalarNode"><see langword="true"/> when this node compares values directly rather than child members.</param>
+    /// <param name="detectRuntimeTypeMismatch"><see langword="true"/> to mark aligned present values with different runtime types as mismatched.</param>
     internal ParallelNode(
         T?[] values,
         NodePresenceState[] states,
@@ -35,6 +45,9 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
 
     internal IEqualityComparer<object>? KeyComparer { get; }
 
+    /// <summary>
+    /// Gets whether aligned present values have differing runtime types and must be reported as a node-level mismatch without descending into members.
+    /// </summary>
     internal bool HasRuntimeTypeMismatch => _hasRuntimeTypeMismatch;
 
     public int Count => _values.Length;
@@ -319,6 +332,12 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
         }
     }
 
+    /// <summary>
+    /// Determines whether the aligned present values contain more than one non-null runtime type.
+    /// </summary>
+    /// <param name="values">Values aligned by model index.</param>
+    /// <param name="states">Presence states aligned with <paramref name="values"/>.</param>
+    /// <returns><see langword="true"/> when at least two present non-null values have different runtime types; otherwise, <see langword="false"/>.</returns>
     private static bool DetectRuntimeTypeMismatch(
         IReadOnlyList<T?> values,
         IReadOnlyList<NodePresenceState> states)

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -1,6 +1,6 @@
 # Phases Status
 
-- Updated: 2026-06-25
+- Updated: 2026-07-11
 
 ## Phase 1: 要件・外部仕様確定
 
@@ -37,6 +37,7 @@
 
 - Status: Done
 - Notes:
+  - T-090 の polymorphic sequence runtime 型比較とレビュー指摘の XML documentation 修正を完了した
   - T-089 を完了し、generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` を underlying node 表示へ委譲した
   - T-088 を完了し、`ParallelNode<T>` と generated value の `ToString()` を Diff と同じ value/state 表示へ改善した
   - T-087 follow-up を完了し、Dictionary member の generated access を string key text 限定から key 型 indexer へ拡張した
@@ -150,6 +151,7 @@
 
 - Status: Done
 - Notes:
+  - T-090 は Release 112テスト、format、diff check、standards validation、`gpt-5.6-sol / high` 再レビューに成功した
   - T-089 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-088 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-087 follow-up で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -1,6 +1,6 @@
 # Tasks Status
 
-- Updated: 2026-06-25
+- Updated: 2026-07-11
 
 ## In Progress
 
@@ -11,6 +11,39 @@
 なし
 
 ## Done
+
+- T-090: polymorphic sequence の runtime 型比較
+  - Status: 完了（runtime派生型比較を実装し、レビュー指摘のXML documentation不足を修正して再検証・再レビューした）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-085 gist `XmlCustom` 同等 E2E 比較の修正
+  - Exit Criteria:
+    - 基底型 sequence の同一 runtime 派生型メンバー差分を再帰検出できる
+    - 異なる runtime 型は要素 node 自身の通常差分として扱い、派生メンバーへ再帰しない
+    - null / Missing、key alignment、dynamic projection の既存契約を維持する
+    - 新規・変更 internal API と新規 E2E テストに必要な XML documentation がある
+    - 全テスト、format、diff check、sub-agent 再レビューが成功する
+  - Output:
+    - PR #43
+    - `src/SSC/ParallelCompareApi.cs`
+    - `src/SSC/ParallelNode.cs`
+    - `tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`
+    - `tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`
+    - `doc/design/detail/03-ContainerRules.md`
+    - `Design/BreakingChanges.md`
+    - `reports/task-t-090-polymorphic-sequence-runtime-type-design-20260711.md`
+    - `reports/task-t-090-review-fix-implementation-20260711192823.md`
+    - `reports/task-t-090-review-fix-verification-20260711193158.md`
+    - `reports/task-t-090-review-fix-rereview-20260711193527.md`
+  - Verification:
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 31件 / E2E 81件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - XML documentation standards validation 成功
+    - Markdown lint は repository wiring 不在のため unsupported
+    - `gpt-5.6-terra / medium` implementation agent でレビュー指摘を修正
+    - `gpt-5.6-sol / high` reviewer の再レビューで指摘なし
 
 - T-089: generated object view の `ToString()` で元モデルの表示を model slot 別に返す
   - Status: 完了（generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` を node 表示へ委譲した）

--- a/tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs
+++ b/tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs
@@ -2,8 +2,14 @@ using SSC;
 
 namespace SSC.E2E.Tests;
 
+/// <summary>
+/// Verifies dynamic projections for sequences whose declared element type differs from their runtime types.
+/// </summary>
 public sealed class PolymorphicDynamicSequenceE2ETests
 {
+    /// <summary>
+    /// Verifies that a dynamic projection exposes runtime members for a polymorphic sequence and preserves their mismatch states.
+    /// </summary>
     [Fact]
     public void Compare_DynamicProjection_RuntimeDerivedPolymorphicSequence_UsesRuntimeMembers()
     {
@@ -41,22 +47,46 @@ public sealed class PolymorphicDynamicSequenceE2ETests
         Assert.Equal(ValueState.Mismatched, (ValueState)item.GetState(1));
     }
 
+    /// <summary>
+    /// Represents a test root that exposes a polymorphic detail object.
+    /// </summary>
     public sealed class DynamicRoot
     {
+        /// <summary>
+        /// Gets the polymorphic detail object projected dynamically by the test.
+        /// </summary>
         public DynamicBase Detail { get; init; } = null!;
     }
 
+    /// <summary>
+    /// Defines the declared base type for the dynamic detail object.
+    /// </summary>
     public abstract class DynamicBase;
 
+    /// <summary>
+    /// Represents the dynamic detail type that contains polymorphic items.
+    /// </summary>
     public sealed class DynamicDetail : DynamicBase
     {
+        /// <summary>
+        /// Gets the polymorphic items exposed through the dynamic projection.
+        /// </summary>
         public List<DynamicItem> Items { get; init; } = [];
     }
 
+    /// <summary>
+    /// Defines the declared base type for dynamic polymorphic items.
+    /// </summary>
     public abstract class DynamicItem;
 
+    /// <summary>
+    /// Represents a dynamic polymorphic item with text content.
+    /// </summary>
     public sealed class DynamicContent : DynamicItem
     {
+        /// <summary>
+        /// Gets the text exposed through the dynamic projection.
+        /// </summary>
         public string Text { get; init; } = string.Empty;
     }
 }

--- a/tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs
+++ b/tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs
@@ -1,0 +1,62 @@
+using SSC;
+
+namespace SSC.E2E.Tests;
+
+public sealed class PolymorphicDynamicSequenceE2ETests
+{
+    [Fact]
+    public void Compare_DynamicProjection_RuntimeDerivedPolymorphicSequence_UsesRuntimeMembers()
+    {
+        var models = new[]
+        {
+            new DynamicRoot
+            {
+                Detail = new DynamicDetail
+                {
+                    Items =
+                    [
+                        new DynamicContent { Text = "left" },
+                    ],
+                },
+            },
+            new DynamicRoot
+            {
+                Detail = new DynamicDetail
+                {
+                    Items =
+                    [
+                        new DynamicContent { Text = "right" },
+                    ],
+                },
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+        dynamic root = result.AsDynamic()!;
+        dynamic item = root.Detail.Items[0];
+
+        Assert.Equal("left", (string?)item.Text[0]);
+        Assert.Equal("right", (string?)item.Text[1]);
+        Assert.Equal(ValueState.Mismatched, (ValueState)item.GetState(0));
+        Assert.Equal(ValueState.Mismatched, (ValueState)item.GetState(1));
+    }
+
+    public sealed class DynamicRoot
+    {
+        public DynamicBase Detail { get; init; } = null!;
+    }
+
+    public abstract class DynamicBase;
+
+    public sealed class DynamicDetail : DynamicBase
+    {
+        public List<DynamicItem> Items { get; init; } = [];
+    }
+
+    public abstract class DynamicItem;
+
+    public sealed class DynamicContent : DynamicItem
+    {
+        public string Text { get; init; } = string.Empty;
+    }
+}

--- a/tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs
+++ b/tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs
@@ -2,8 +2,14 @@ using SSC;
 
 namespace SSC.E2E.Tests;
 
+/// <summary>
+/// Verifies comparison behavior for sequences whose declared element type differs from their runtime types.
+/// </summary>
 public sealed class PolymorphicSequenceE2ETests
 {
+    /// <summary>
+    /// Verifies that aligned elements with the same derived type compare their runtime members while retaining the declared node type.
+    /// </summary>
     [Fact]
     public void Compare_WhenAlignedElementsShareDerivedType_UsesRuntimeMembersAndPreservesDeclaredNodeType()
     {
@@ -39,6 +45,9 @@ public sealed class PolymorphicSequenceE2ETests
         Assert.Equal("Items[0].Name", entry.Path);
     }
 
+    /// <summary>
+    /// Verifies that nested elements with matching derived types compare runtime members recursively.
+    /// </summary>
     [Fact]
     public void Compare_WhenNestedElementsShareDerivedTypes_UsesRuntimeMembersRecursively()
     {
@@ -80,6 +89,9 @@ public sealed class PolymorphicSequenceE2ETests
         Assert.Equal("Items[0].Children[0].Text", entry.Path);
     }
 
+    /// <summary>
+    /// Verifies that aligned elements with different runtime types report an element mismatch without comparing child members.
+    /// </summary>
     [Fact]
     public void Compare_WhenAlignedElementsHaveDifferentRuntimeTypes_ReportsElementDifferenceWithoutDescending()
     {
@@ -117,6 +129,9 @@ public sealed class PolymorphicSequenceE2ETests
         Assert.All(entry.Values, value => Assert.Equal(ValueState.Mismatched, value.State));
     }
 
+    /// <summary>
+    /// Verifies that null and missing polymorphic elements retain their established presence-state behavior.
+    /// </summary>
     [Fact]
     public void Compare_WhenPolymorphicElementIsNullOrMissing_PreservesExistingPresenceStates()
     {
@@ -161,6 +176,9 @@ public sealed class PolymorphicSequenceE2ETests
         Assert.Equal(ValueState.Missing, missingEntry.Values[1].State);
     }
 
+    /// <summary>
+    /// Verifies that keyed elements with matching derived types retain key alignment while comparing runtime members.
+    /// </summary>
     [Fact]
     public void Compare_WhenKeyedElementsShareDerivedType_PreservesKeyAlignmentAndUsesRuntimeMembers()
     {
@@ -192,6 +210,9 @@ public sealed class PolymorphicSequenceE2ETests
         Assert.Equal("Items[1].Value", entry.Path);
     }
 
+    /// <summary>
+    /// Verifies that trace output identifies both the declared node type and the runtime comparison type.
+    /// </summary>
     [Fact]
     public void Compare_WhenTraceEnabled_ReportsDeclaredNodeAndRuntimeComparisonTypes()
     {
@@ -222,40 +243,82 @@ public sealed class PolymorphicSequenceE2ETests
             && line.Contains("comparisonType=SSC.E2E.Tests.PolymorphicSequenceE2ETests+PolymorphicNode", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// Represents a test root that exposes polymorphic sequence items.
+    /// </summary>
     public sealed class PolymorphicRoot
     {
+        /// <summary>
+        /// Gets the polymorphic items compared by the sequence tests.
+        /// </summary>
         public List<PolymorphicItem?> Items { get; init; } = [];
     }
 
+    /// <summary>
+    /// Defines the declared base type for polymorphic sequence items.
+    /// </summary>
     public abstract class PolymorphicItem
     {
     }
 
+    /// <summary>
+    /// Represents a polymorphic item with a name and nested polymorphic children.
+    /// </summary>
     public sealed class PolymorphicNode : PolymorphicItem
     {
+        /// <summary>
+        /// Gets the name compared for this polymorphic node.
+        /// </summary>
         public string Name { get; init; } = string.Empty;
 
+        /// <summary>
+        /// Gets the nested polymorphic items compared recursively.
+        /// </summary>
         public List<PolymorphicItem?> Children { get; init; } = [];
     }
 
+    /// <summary>
+    /// Represents a polymorphic item with text content.
+    /// </summary>
     public sealed class PolymorphicContent : PolymorphicItem
     {
+        /// <summary>
+        /// Gets the text compared for this polymorphic content item.
+        /// </summary>
         public string Text { get; init; } = string.Empty;
     }
 
+    /// <summary>
+    /// Represents a test root that exposes keyed polymorphic sequence items.
+    /// </summary>
     public sealed class KeyedPolymorphicRoot
     {
+        /// <summary>
+        /// Gets the keyed polymorphic items compared by the sequence tests.
+        /// </summary>
         public List<KeyedPolymorphicItem> Items { get; init; } = [];
     }
 
+    /// <summary>
+    /// Defines the declared base type for keyed polymorphic sequence items.
+    /// </summary>
     public abstract class KeyedPolymorphicItem
     {
+        /// <summary>
+        /// Gets the key used to align polymorphic items between compared models.
+        /// </summary>
         [CompareKey]
         public int Id { get; init; }
     }
 
+    /// <summary>
+    /// Represents a keyed polymorphic item with a value compared after key alignment.
+    /// </summary>
     public sealed class KeyedPolymorphicValue : KeyedPolymorphicItem
     {
+        /// <summary>
+        /// Gets the value compared for the keyed polymorphic item.
+        /// </summary>
         public int Value { get; init; }
     }
 }

--- a/tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs
+++ b/tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs
@@ -1,0 +1,261 @@
+using SSC;
+
+namespace SSC.E2E.Tests;
+
+public sealed class PolymorphicSequenceE2ETests
+{
+    [Fact]
+    public void Compare_WhenAlignedElementsShareDerivedType_UsesRuntimeMembersAndPreservesDeclaredNodeType()
+    {
+        var models = new[]
+        {
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "left" },
+                ],
+            },
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "right" },
+                ],
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+
+        Assert.False(result.HasError);
+        var root = Assert.IsType<ParallelNode<PolymorphicRoot>>(result.Root);
+        var item = Assert.Single(root.GetChildren<PolymorphicItem>(nameof(PolymorphicRoot.Items)));
+        Assert.IsType<PolymorphicNode>(item[0]);
+        Assert.IsType<PolymorphicNode>(item[1]);
+        Assert.Equal(ValueState.Mismatched, item.GetState(0));
+        Assert.Equal(ValueState.Mismatched, item.GetState(1));
+
+        var entry = Assert.Single(result.GetDiffEntries());
+        Assert.Equal("Items[0].Name", entry.Path);
+    }
+
+    [Fact]
+    public void Compare_WhenNestedElementsShareDerivedTypes_UsesRuntimeMembersRecursively()
+    {
+        var models = new[]
+        {
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode
+                    {
+                        Name = "node",
+                        Children =
+                        [
+                            new PolymorphicContent { Text = "left" },
+                        ],
+                    },
+                ],
+            },
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode
+                    {
+                        Name = "node",
+                        Children =
+                        [
+                            new PolymorphicContent { Text = "right" },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+
+        var entry = Assert.Single(result.GetDiffEntries());
+        Assert.Equal("Items[0].Children[0].Text", entry.Path);
+    }
+
+    [Fact]
+    public void Compare_WhenAlignedElementsHaveDifferentRuntimeTypes_ReportsElementDifferenceWithoutDescending()
+    {
+        var models = new[]
+        {
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "same" },
+                ],
+            },
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicContent { Text = "same" },
+                ],
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+
+        Assert.False(result.HasError);
+        var root = Assert.IsType<ParallelNode<PolymorphicRoot>>(result.Root);
+        var item = Assert.Single(root.GetChildren<PolymorphicItem>(nameof(PolymorphicRoot.Items)));
+        Assert.Empty(item.GetDirectChildren());
+        Assert.Equal(ValueState.Mismatched, item.GetState(0));
+        Assert.Equal(ValueState.Mismatched, item.GetState(1));
+
+        var entry = Assert.Single(result.GetDiffEntries());
+        Assert.Equal("Items[0]", entry.Path);
+        Assert.IsType<PolymorphicNode>(entry.Values[0].Value);
+        Assert.IsType<PolymorphicContent>(entry.Values[1].Value);
+        Assert.All(entry.Values, value => Assert.Equal(ValueState.Mismatched, value.State));
+    }
+
+    [Fact]
+    public void Compare_WhenPolymorphicElementIsNullOrMissing_PreservesExistingPresenceStates()
+    {
+        var valueAndNull = ParallelCompareApi.Compare(
+        [
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "node" },
+                ],
+            },
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    null,
+                ],
+            },
+        ]);
+
+        var nullEntry = Assert.Single(valueAndNull.GetDiffEntries());
+        Assert.Equal("Items[0]", nullEntry.Path);
+        Assert.Equal(ValueState.Mismatched, nullEntry.Values[0].State);
+        Assert.Equal(ValueState.Mismatched, nullEntry.Values[1].State);
+
+        var valueAndMissing = ParallelCompareApi.Compare(
+        [
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "node" },
+                ],
+            },
+            new PolymorphicRoot(),
+        ]);
+
+        var missingEntry = Assert.Single(valueAndMissing.GetDiffEntries());
+        Assert.Equal("Items[0]", missingEntry.Path);
+        Assert.Equal(ValueState.Mismatched, missingEntry.Values[0].State);
+        Assert.Equal(ValueState.Missing, missingEntry.Values[1].State);
+    }
+
+    [Fact]
+    public void Compare_WhenKeyedElementsShareDerivedType_PreservesKeyAlignmentAndUsesRuntimeMembers()
+    {
+        var models = new[]
+        {
+            new KeyedPolymorphicRoot
+            {
+                Items =
+                [
+                    new KeyedPolymorphicValue { Id = 1, Value = 10 },
+                ],
+            },
+            new KeyedPolymorphicRoot
+            {
+                Items =
+                [
+                    new KeyedPolymorphicValue { Id = 1, Value = 20 },
+                ],
+            },
+        };
+
+        var result = ParallelCompareApi.Compare(models);
+
+        var root = Assert.IsType<ParallelNode<KeyedPolymorphicRoot>>(result.Root);
+        var item = Assert.Single(root.GetChildren<KeyedPolymorphicItem>(nameof(KeyedPolymorphicRoot.Items)));
+        Assert.Equal("1", item.KeyText);
+
+        var entry = Assert.Single(result.GetDiffEntries());
+        Assert.Equal("Items[1].Value", entry.Path);
+    }
+
+    [Fact]
+    public void Compare_WhenTraceEnabled_ReportsDeclaredNodeAndRuntimeComparisonTypes()
+    {
+        var logs = new List<string>();
+        var configuration = new CompareConfiguration { TraceLog = logs.Add };
+        var models = new[]
+        {
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "left" },
+                ],
+            },
+            new PolymorphicRoot
+            {
+                Items =
+                [
+                    new PolymorphicNode { Name = "right" },
+                ],
+            },
+        };
+
+        _ = ParallelCompareApi.Compare(models, configuration);
+
+        Assert.Contains(logs, line =>
+            line.Contains("nodeType=SSC.E2E.Tests.PolymorphicSequenceE2ETests+PolymorphicItem", StringComparison.Ordinal)
+            && line.Contains("comparisonType=SSC.E2E.Tests.PolymorphicSequenceE2ETests+PolymorphicNode", StringComparison.Ordinal));
+    }
+
+    public sealed class PolymorphicRoot
+    {
+        public List<PolymorphicItem?> Items { get; init; } = [];
+    }
+
+    public abstract class PolymorphicItem
+    {
+    }
+
+    public sealed class PolymorphicNode : PolymorphicItem
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public List<PolymorphicItem?> Children { get; init; } = [];
+    }
+
+    public sealed class PolymorphicContent : PolymorphicItem
+    {
+        public string Text { get; init; } = string.Empty;
+    }
+
+    public sealed class KeyedPolymorphicRoot
+    {
+        public List<KeyedPolymorphicItem> Items { get; init; } = [];
+    }
+
+    public abstract class KeyedPolymorphicItem
+    {
+        [CompareKey]
+        public int Id { get; init; }
+    }
+
+    public sealed class KeyedPolymorphicValue : KeyedPolymorphicItem
+    {
+        public int Value { get; init; }
+    }
+}


### PR DESCRIPTION
## 概要

`IEnumerable<Item>` のように基底型で宣言された sequence に、実行時には `Node` / `Content` などの派生型が入る場合、派生型固有メンバーの差分を比較木へ取り込めるようにします。

あわせて、同じ aligned position に異なる派生型が入った場合の挙動を定義します。

- 同一 runtime 型: その型のメンバーを再帰比較
- 異なる runtime 型: 要素自身を `Mismatched` とし、派生メンバーへは再帰しない
- `null` / `Missing`: 既存の presence 規則を維持

## 背景

YXmlモデルでは、概ね次の形で子要素を保持しています。

```csharp
public class Item
{
}

public sealed class Node : Item
{
    public string Name { get; init; } = string.Empty;
    public IEnumerable<Item> Children { get; init; } = [];
}

public sealed class Content : Item
{
    public string Text { get; init; } = string.Empty;
}
```

`Children`の宣言要素型は`Item`ですが、実際の値は`Node`または`Content`です。

この状態で、左右とも同じ位置に`Content`があり、`Text`だけが異なる場合でも、従来は`GetDiffEntries()`が0件になりました。

実データの調査でも、パース後モデルには意味上の差分が残っている一方、直接の`Document`比較は0件となり、具体型を保持する診断用projectionでは差分が検出されました。parserや表示フィルターではなく、比較木構築時の型解決が原因です。

## 問題がなぜ起きているのか

従来のsequence構築処理は、メンバー宣言から取得した要素型をそのまま`BuildNode`へ渡します。

```text
declaredType = IEnumerable<Item>
elementType  = Item
nodeType     = Item
```

続いて`BuildNodeGeneric<TNode>`は、`typeof(TNode)`のpublic property / fieldを比較対象として列挙します。

このケースでは`TNode == Item`です。しかし`Item`には比較可能なメンバーがありません。そのため、実際のslot値が`Node`や`Content`でも、次のメンバーは比較木に登録されません。

- `Node.Name`
- `Node.Children`
- `Content.Text`
- その他の派生型固有メンバー

結果として、派生型内部にだけ存在する差分は`HasDifferences()`まで伝播せず、`GetDiffEntries()`も0件になります。

## 修正方針

### 公開node型とメンバー探索型を分離する

公開されるnodeのgeneric型は、既存契約どおり宣言要素型を維持します。

```text
ParallelNode<Item>
```

一方、比較対象メンバーの探索には、aligned slot内で一意に決まるruntime型を使用します。

```text
nodeType       = Item
comparisonType = Content
```

`ParallelNode<Content>`へ型を差し替えないのは、既存の次のアクセスを壊さないためです。

```csharp
root.GetChildren<Item>(nameof(Root.Items))
```

runtime型解決とruntime型不一致判定は、sequence childを構築する経路だけで有効にします。通常のroot/object member比較には適用せず、本修正の影響範囲をpolymorphic sequenceへ限定します。

### runtime型が一種類の場合

`PresentValue`のslotからruntime型を収集し、全て同一型で、宣言要素型へ代入可能なら、その型を`comparisonType`として使用します。

```text
Node    vs Node    -> Nodeのメンバーを比較
Content vs Content -> Contentのメンバーを比較
Node    vs Missing -> Nodeを探索型にし、presence差分を優先
Node    vs null    -> Nodeを探索型にし、value/null差分を優先
```

### runtime型が複数ある場合

```text
Node vs Content
```

この場合、どちらか一方の派生型へ強制キャストしません。次の規則とします。

1. aligned element node自身を`Mismatched`にする
2. `HasDifferences()`は`true`を返す
3. `GetDiffEntries()`は要素pathにnode entryを1件生成する
4. 派生型固有メンバーへの再帰を打ち切る
5. `CompareIssue`は追加せず、`HasError`も立てない

型違いは入力エラーではなく通常の構造差分です。

派生型ごとの全メンバーをunionして多数の`Missing`差分へ展開する方式は採用しません。型変更1件が大量のmember差分へ膨らみ、差分の主因が不明瞭になるためです。

## 挙動表

| 左 | 右 | 結果 |
|---|---|---|
| `Node` | `Node` | `Node`のメンバーを再帰比較 |
| `Content` | `Content` | `Content`のメンバーを再帰比較 |
| `Node` | `Content` | 要素nodeのruntime型差分 |
| `Node` | `null` | 既存のvalue/null差分 |
| `Node` | `Missing` | 既存のpresence差分 |
| `null` | `null` | 一致 |
| `Missing` | `Missing` | 比較対象なし |

## 変更内容

### `ParallelCompareApi`

- `BuildNode`に、generic node型とは別の`comparisonType`を渡す内部経路を追加
- scalar判定とcomparable member探索を`comparisonType`基準へ変更
- keyed sequenceとordinal-aligned sequenceのslot構築後にruntime型を解決
- nodeのgeneric型は宣言要素型のまま維持
- runtime型不一致判定をsequence構築時だけ明示的に有効化
- traceへ`nodeType`、`comparisonType`、runtime型不一致情報を追加

### `ParallelNode<T>`

- sequenceから明示された場合に限り、`PresentValue` slot間のruntime型不一致を検出
- runtime型不一致時の`GetState()`を`Mismatched`化
- runtime型不一致時の`HasDifferences()`を`true`化
- runtime型不一致nodeでは派生memberへ再帰せず、要素自身をleaf相当の差分として公開

### 設計・互換性文書

- `doc/design/detail/03-ContainerRules.md`へpolymorphic sequence規則を追加
- 詳細な理由、非対象、受け入れ条件をT-090設計メモへ記録
- 従来0件だった差分が新たに返るruntime behavior変更を`Design/BreakingChanges.md`へ記録

## テスト

以下のE2Eを追加しています。

- 同じ派生型のscalar member差分を検出する
- `Node.Children : IEnumerable<Item>`配下の孫`Content.Text`差分を再帰検出する
- `Node`対`Content`を要素pathの1件の差分として扱う
- `Node`対`null`の既存stateを維持する
- `Node`対`Missing`の既存stateを維持する
- keyed sequenceのkey alignmentを維持しつつ派生memberを比較する
- dynamic projectionのruntime-derived containerでも派生memberを比較する
- traceで宣言node型とruntime comparison型を区別できる
- child nodeを引き続き`ParallelNode<Item>`として取得できる

## 変更しない範囲

- `[CompareKey]`があるsequenceのkey union規則
- `[CompareKey]`がないsequenceのordinal alignment規則
- `MissingCompareKeyListPolicy`の意味
- runtime派生型にだけ存在する`CompareKey`の探索
- dictionary valueのpolymorphic比較規則
- 通常のroot/object memberに対するruntime型比較
- public enum / public interfaceの追加

## 互換性と影響

public API shapeは変更しません。

従来0件だったpolymorphic sequence内の差分が、新たに通常差分として返るようになります。diff entry件数やpathを厳密に固定している利用コードは期待値更新が必要になる可能性があります。

## 検証状況

- GitHub Actions `PR .NET Tests` run #83: 成功
  - source generatorのrestore/build: 成功
  - test projectのrestore/test: 成功
- 追加したdirect、keyed、null/Missing、異種派生型、trace、dynamic projectionのE2Eを含めて成功
- GitHub connectorのみでbranch作成、commit、PR作成を実施
- ローカル環境には`dotnet`が無いため、ローカル実行は未実施
