### PR TITLE
docs(t-091): polymorphic比較のXMLコメントを日本語化する

### DIFF
--- a/reports/task-t-091-japanese-xml-comments-implementation-20260711200933.md
+++ b/reports/task-t-091-japanese-xml-comments-implementation-20260711200933.md
@@ -1,0 +1,40 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: PR #43で追加したXML documentationを日本語化する
+- タスク種別: 実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザーが実装agentに`gpt-5.6-terra / medium`を指定したため
+
+## 対象範囲
+
+- 対象: `ParallelNode.cs`とpolymorphic E2E test 2ファイルのPR #43追加XML documentation
+
+## 対象外
+
+- 対象外: runtimeロジック、assertion、test data、設計文書、tracking、Git操作
+
+## 実行コマンド
+
+- 実行コマンド: `sed -n`、`rg -n -U`、`git diff --unified=80 origin/main -- <対象3ファイル>`、`git diff --cached --unified=3 -- <対象3ファイル>`、`git status --short`
+- 実行コマンド: 英語XML本文の対象語を `rg -n` で検出しないこと、XML documentation行を除去した各対象ファイルと `origin/main` の差分が0件であること、`git diff --check` が成功することを確認した。
+- 実行コマンド: 実spawnは `gpt-5.6-terra / medium / fork_turns none` で受理済み。実行中agentからlive profileを自己照会する手段は提供されていないため、受理済みのdispatch指定と区別した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelNode.cs`、`tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`、本レポート
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。XML tag、`paramref`、`see`、`langword`、型名・member名・識別子を維持して、PR #43由来の英語XML documentation本文のみを日本語化した。
+
+## 結果
+
+- 結果: 3対象ファイルのXML documentationを自然で簡潔な日本語へ翻訳した。runtimeロジック、assertion、test data、using、および無関係なwhitespaceは変更していない。テスト実行は別verification agentの担当。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: 翻訳は実装担当で確認済みだが、最終的な差分・形式確認およびテスト検証は親workflowと別verification/review agentが担当する。

--- a/reports/task-t-091-japanese-xml-comments-review-20260711200934.md
+++ b/reports/task-t-091-japanese-xml-comments-review-20260711200934.md
@@ -1,0 +1,44 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-091の日本語XML documentation修正を独立レビューする
+- タスク種別: レビュー
+
+## sub-agentを使う理由
+
+- 理由: review-enforcerが独立reviewerによるreviewとreport保存を必須としているため
+
+## 対象範囲
+
+- 対象: T-091全差分、日本語の自然さ、契約・テスト意図の保持、tracking/report整合性
+
+## 対象外
+
+- 対象外: ファイル修正、commit、push、PR操作
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short`、`git branch --show-current`、`git rev-parse origin/main`、`git diff --stat origin/main --`、`git diff --name-status origin/main --`、`git diff --unified=80 origin/main -- <T-091対象>`、`git diff --check origin/main --`
+- 実行コマンド: `sed -n`、`nl -ba`、`rg -n`で対象3ファイルのXML documentation、7件の`[Fact]`、tracking、implementation/verification reportを確認した。
+- 実行コマンド: 対象3ファイルごとにXML documentation行を除外したcurrentと`origin/main`を`cmp -s`で比較し、すべて一致した。XML tag行の比較と参照要素数の照合で、`param name`、`paramref name`、`see`、`langword`、`returns`が保持されていることを確認した。
+- 実行コマンド: XML documentationを`xmllint --noout -`で検査し、対象3ファイルすべてで整形式を確認した。タグ除外後の本文を`rg -n -o '[A-Za-z][A-Za-z0-9_-]*'`で検査し、残存ASCII語は言語キーワード`null`のみで、英語本文が残っていないことを確認した。
+- 実行コマンド: `dotnet test SSC.sln --configuration Release`（成功: Unit 31件、E2E 81件、計112件、失敗0件）、`dotnet format SSC.sln --verify-no-changes`（成功）、`git diff --check`（成功）
+- 実行コマンド: `package.json`、lock file、`Makefile`、`.github`にMarkdown lint配線がないことを確認し、`unsupported`と判定した。
+- 実行コマンド: 実spawnは親指定の`gpt-5.6-sol / high / fork_turns none`で受理済み。実行中agentからlive profileを自己照会する手段は提供されていないため、受理済みdispatch指定と区別した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelNode.cs`、`tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`、`tasks/tasks-status.md`、`tasks/phases-status.md`、`reports/task-t-091-japanese-xml-comments-implementation-20260711200933.md`、`reports/task-t-091-japanese-xml-comments-verification-20260711200934.md`、本レポート
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。blocking、ユーザー確認必要、non-blockingのいずれにも該当するcode/documentation findingはない。日本語は自然かつ明確で、「実行時型」「位置合わせ」「ノード」「メンバー」等の用語も対象内で一貫している。`summary` / `param` / `returns`と7件の`Fact`は元英語のcontractとテスト意図を正確に保持している。XML tag、`param`名、`paramref`、`see`、`langword`、識別子も保持されている。
+
+## 結果
+
+- 結果: 合格。英語XML本文の残存はなく、XML documentationを除外した対象3ファイルは`origin/main`と一致したため、non-comment code、assertion、test dataに差分はない。XML整形式、Release 112テスト、format、diff checkはすべて成功した。T-091はreview完了前の`In Progress`として対象、exit criteria、3reportをtrackingに整合しており、親workflowがこのreview結果を受けて完了同期する状態である。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lintはrepository wiring不在のため`unsupported`。自動的なMarkdown用語検査ができない残存リスクはあるが、本タスクの通常経路は対象XML documentationの独立目視review、英語本文検索、contract/tag照合、XML整形式検査で満たされるため、本reviewでは非blockingのheld dispositionとする。後続のcode/documentation修正は不要。

--- a/reports/task-t-091-japanese-xml-comments-verification-20260711200934.md
+++ b/reports/task-t-091-japanese-xml-comments-verification-20260711200934.md
@@ -1,0 +1,44 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-091の日本語XML documentation修正を独立検証する
+- タスク種別: 検証
+
+## sub-agentを使う理由
+
+- 理由: codex-delegation-executorがverification evidenceを独立sub-agentの固定担当としているため
+
+## 対象範囲
+
+- 対象: 日本語化差分、全テスト、format、diff check、非コメント差分の有無
+
+## 対象外
+
+- 対象外: ファイル修正、commit、push、PR操作、review
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short`、`git diff --name-only origin/main --`、`git diff -- <対象3ファイル>`、`rg -n "Polymorphic" tests --glob '*.cs'`
+- 実行コマンド: 対象3ファイルごとに、`sed '/^[[:space:]]*\/\/\//d'`でXML documentation行を除去したcurrentと`git show origin/main:<file>`を`cmp -s`で比較し、すべて一致した。
+- 実行コマンド: 対象3ファイルごとにXML documentationから抽出したタグ列をcurrentと`origin/main`で`cmp -s`比較し、`param` name、`paramref`、`see`、`langword`を含めてすべて一致した。`xmllint --noout -`によるXML整形式検証もすべて成功した。
+- 実行コマンド: XML tagを除去したXML documentation本文を`rg -n -o "[A-Za-z][A-Za-z0-9_-]*"`で検査し、残存ASCII語が言語キーワード`null`のみで、英語本文が残っていないことを確認した。
+- 実行コマンド: `dotnet test SSC.sln --configuration Release`（成功: Unit 31件、E2E 81件、失敗0件）、`dotnet format SSC.sln --verify-no-changes`（成功）、`git diff --check`（成功）
+- 実行コマンド: Markdown lint wiringを`package.json`、lock file、`.github`、`Makefile`から検索したが存在しないためunsupportedと判定した。
+- 実行コマンド: 実spawnは`gpt-5.6-sol / high / fork_turns none`で受理済み。実行中agentからlive profileを自己照会する手段は提供されていないため、受理済みdispatch指定と区別した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelNode.cs`、`tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`、`tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`、`tasks/tasks-status.md`、`tasks/phases-status.md`、`reports/task-t-091-japanese-xml-comments-implementation-20260711200933.md`、`reports/task-t-091-japanese-xml-comments-review-20260711200934.md`、本レポート
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。対象3ファイルの変更はXML documentation本文の日本語化だけで、英語本文の残存、XML構造・参照の変化、runtimeロジック、assertion、test data、using、無関係なwhitespaceの差分はない。trackingはT-091をIn Progressとして対象・exit criteria・reportを整合して記録している。
+
+## 結果
+
+- 結果: 合格。静的検証、Release全112テスト、format、diff checkがすべて成功した。Markdown lintはrepository wiring不在のためunsupported。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: 検証上の未解決リスクなし。独立reviewレポートは別review agentの担当であり、本検証時点では未記入。

--- a/src/SSC/ParallelNode.cs
+++ b/src/SSC/ParallelNode.cs
@@ -12,15 +12,15 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     private readonly List<string> _directChildOrder = [];
 
     /// <summary>
-    /// Initializes a comparison node from aligned model values and presence states, optionally treating differing non-null runtime types as a mismatch.
+    /// 位置合わせ済みのモデル値と存在状態から比較ノードを初期化し、必要に応じてnull以外の実行時型の違いを不一致として扱います。
     /// </summary>
-    /// <param name="values">Values aligned by model index.</param>
-    /// <param name="states">Presence states aligned with <paramref name="values"/>.</param>
-    /// <param name="keyText">Display text for the key that identifies this node, when one exists.</param>
-    /// <param name="keyValue">Raw key value used to align keyed collection elements, when one exists.</param>
-    /// <param name="keyComparer">Comparer used for <paramref name="keyValue"/>, when keyed alignment requires one.</param>
-    /// <param name="isScalarNode"><see langword="true"/> when this node compares values directly rather than child members.</param>
-    /// <param name="detectRuntimeTypeMismatch"><see langword="true"/> to mark aligned present values with different runtime types as mismatched.</param>
+    /// <param name="values">モデルインデックスで位置合わせした値。</param>
+    /// <param name="states"><paramref name="values"/>と位置合わせした存在状態。</param>
+    /// <param name="keyText">存在する場合にこのノードを識別するキーの表示テキスト。</param>
+    /// <param name="keyValue">存在する場合にキー付きコレクション要素の位置合わせに使用する生のキー値。</param>
+    /// <param name="keyComparer">キーによる位置合わせで必要な場合に<paramref name="keyValue"/>に使用する比較子。</param>
+    /// <param name="isScalarNode">このノードが子メンバーではなく値を直接比較する場合は<see langword="true"/>。</param>
+    /// <param name="detectRuntimeTypeMismatch">実行時型が異なる位置合わせ済みの存在値を不一致として記録する場合は<see langword="true"/>。</param>
     internal ParallelNode(
         T?[] values,
         NodePresenceState[] states,
@@ -46,7 +46,7 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     internal IEqualityComparer<object>? KeyComparer { get; }
 
     /// <summary>
-    /// Gets whether aligned present values have differing runtime types and must be reported as a node-level mismatch without descending into members.
+    /// 位置合わせ済みの存在値に異なる実行時型があり、メンバーへ下降せずノードレベルの不一致として報告する必要があるかを取得します。
     /// </summary>
     internal bool HasRuntimeTypeMismatch => _hasRuntimeTypeMismatch;
 
@@ -333,11 +333,11 @@ public sealed class ParallelNode<T> : Parallel<T>, IParallelNode, IParallelNodeI
     }
 
     /// <summary>
-    /// Determines whether the aligned present values contain more than one non-null runtime type.
+    /// 位置合わせ済みの存在値に複数のnull以外の実行時型が含まれるかを判定します。
     /// </summary>
-    /// <param name="values">Values aligned by model index.</param>
-    /// <param name="states">Presence states aligned with <paramref name="values"/>.</param>
-    /// <returns><see langword="true"/> when at least two present non-null values have different runtime types; otherwise, <see langword="false"/>.</returns>
+    /// <param name="values">モデルインデックスで位置合わせした値。</param>
+    /// <param name="states"><paramref name="values"/>と位置合わせした存在状態。</param>
+    /// <returns>存在するnull以外の値のうち少なくとも2つの実行時型が異なる場合は<see langword="true"/>。それ以外の場合は<see langword="false"/>。</returns>
     private static bool DetectRuntimeTypeMismatch(
         IReadOnlyList<T?> values,
         IReadOnlyList<NodePresenceState> states)

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -37,6 +37,7 @@
 
 - Status: Done
 - Notes:
+  - T-091でT-090追加分のXML documentationを日本語化した
   - T-090 の polymorphic sequence runtime 型比較とレビュー指摘の XML documentation 修正を完了した
   - T-089 を完了し、generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` を underlying node 表示へ委譲した
   - T-088 を完了し、`ParallelNode<T>` と generated value の `ToString()` を Diff と同じ value/state 表示へ改善した
@@ -151,6 +152,7 @@
 
 - Status: Done
 - Notes:
+  - T-091はRelease 112テスト、format、diff check、XML整形式、非コメント差分照合、独立reviewに成功した
   - T-090 は Release 112テスト、format、diff check、standards validation、`gpt-5.6-sol / high` 再レビューに成功した
   - T-089 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）
   - T-088 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -12,6 +12,35 @@
 
 ## Done
 
+- T-091: T-090で追加したXML documentationを日本語化する
+  - Status: 完了（PR #43由来のXML documentationを日本語化し、非コメント差分なしを検証した）
+  - Phase: Phase 3
+  - Estimate: S
+  - Depends on:
+    - T-090 polymorphic sequence の runtime 型比較
+  - Exit Criteria:
+    - PR #43で追加したproduction/testのXML documentationが自然な日本語になっている
+    - XML tag、`paramref`、`see`、識別子、runtime契約、テスト意図を変更しない
+    - runtimeロジック、assertion、test dataに差分がない
+    - 全テスト、format、diff check、独立reviewが成功する
+  - Output:
+    - `src/SSC/ParallelNode.cs`
+    - `tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs`
+    - `tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs`
+    - `reports/task-t-091-japanese-xml-comments-implementation-20260711200933.md`
+    - `reports/task-t-091-japanese-xml-comments-verification-20260711200934.md`
+    - `reports/task-t-091-japanese-xml-comments-review-20260711200934.md`
+  - Verification:
+    - 対象3ファイルに英語XML本文の残存なし
+    - XML documentationを除外すると`origin/main`と同一
+    - XML整形式確認成功
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 31件 / E2E 81件）
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - Markdown lintはrepository wiring不在のためunsupported
+    - `gpt-5.6-terra / medium` implementation agentで実装
+    - parentと同じ`gpt-5.6-sol / high` reviewerで指摘なし
+
 - T-090: polymorphic sequence の runtime 型比較
   - Status: 完了（runtime派生型比較を実装し、レビュー指摘のXML documentation不足を修正して再検証・再レビューした）
   - Phase: Phase 3

--- a/tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs
+++ b/tests/SSC.E2E.Tests/PolymorphicDynamicSequenceE2ETests.cs
@@ -3,12 +3,12 @@ using SSC;
 namespace SSC.E2E.Tests;
 
 /// <summary>
-/// Verifies dynamic projections for sequences whose declared element type differs from their runtime types.
+/// 宣言された要素型と実行時型が異なるシーケンスの動的プロジェクションを検証します。
 /// </summary>
 public sealed class PolymorphicDynamicSequenceE2ETests
 {
     /// <summary>
-    /// Verifies that a dynamic projection exposes runtime members for a polymorphic sequence and preserves their mismatch states.
+    /// 動的プロジェクションがポリモーフィックなシーケンスの実行時メンバーを公開し、その不一致状態を保持することを検証します。
     /// </summary>
     [Fact]
     public void Compare_DynamicProjection_RuntimeDerivedPolymorphicSequence_UsesRuntimeMembers()
@@ -48,44 +48,44 @@ public sealed class PolymorphicDynamicSequenceE2ETests
     }
 
     /// <summary>
-    /// Represents a test root that exposes a polymorphic detail object.
+    /// ポリモーフィックな詳細オブジェクトを公開するテストルートを表します。
     /// </summary>
     public sealed class DynamicRoot
     {
         /// <summary>
-        /// Gets the polymorphic detail object projected dynamically by the test.
+        /// テストが動的プロジェクションで公開するポリモーフィックな詳細オブジェクトを取得します。
         /// </summary>
         public DynamicBase Detail { get; init; } = null!;
     }
 
     /// <summary>
-    /// Defines the declared base type for the dynamic detail object.
+    /// 動的な詳細オブジェクトの宣言上の基底型を定義します。
     /// </summary>
     public abstract class DynamicBase;
 
     /// <summary>
-    /// Represents the dynamic detail type that contains polymorphic items.
+    /// ポリモーフィックな要素を含む動的な詳細型を表します。
     /// </summary>
     public sealed class DynamicDetail : DynamicBase
     {
         /// <summary>
-        /// Gets the polymorphic items exposed through the dynamic projection.
+        /// 動的プロジェクションを通じて公開するポリモーフィックな要素を取得します。
         /// </summary>
         public List<DynamicItem> Items { get; init; } = [];
     }
 
     /// <summary>
-    /// Defines the declared base type for dynamic polymorphic items.
+    /// 動的なポリモーフィック要素の宣言上の基底型を定義します。
     /// </summary>
     public abstract class DynamicItem;
 
     /// <summary>
-    /// Represents a dynamic polymorphic item with text content.
+    /// テキスト内容を持つ動的なポリモーフィック要素を表します。
     /// </summary>
     public sealed class DynamicContent : DynamicItem
     {
         /// <summary>
-        /// Gets the text exposed through the dynamic projection.
+        /// 動的プロジェクションを通じて公開するテキストを取得します。
         /// </summary>
         public string Text { get; init; } = string.Empty;
     }

--- a/tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs
+++ b/tests/SSC.E2E.Tests/PolymorphicSequenceE2ETests.cs
@@ -3,12 +3,12 @@ using SSC;
 namespace SSC.E2E.Tests;
 
 /// <summary>
-/// Verifies comparison behavior for sequences whose declared element type differs from their runtime types.
+/// 宣言された要素型と実行時型が異なるシーケンスの比較動作を検証します。
 /// </summary>
 public sealed class PolymorphicSequenceE2ETests
 {
     /// <summary>
-    /// Verifies that aligned elements with the same derived type compare their runtime members while retaining the declared node type.
+    /// 同じ派生型を持つ位置合わせ済み要素が、宣言されたノード型を保持しながら実行時メンバーを比較することを検証します。
     /// </summary>
     [Fact]
     public void Compare_WhenAlignedElementsShareDerivedType_UsesRuntimeMembersAndPreservesDeclaredNodeType()
@@ -46,7 +46,7 @@ public sealed class PolymorphicSequenceE2ETests
     }
 
     /// <summary>
-    /// Verifies that nested elements with matching derived types compare runtime members recursively.
+    /// 一致する派生型を持つ入れ子要素が実行時メンバーを再帰的に比較することを検証します。
     /// </summary>
     [Fact]
     public void Compare_WhenNestedElementsShareDerivedTypes_UsesRuntimeMembersRecursively()
@@ -90,7 +90,7 @@ public sealed class PolymorphicSequenceE2ETests
     }
 
     /// <summary>
-    /// Verifies that aligned elements with different runtime types report an element mismatch without comparing child members.
+    /// 実行時型が異なる位置合わせ済み要素が、子メンバーを比較せず要素の不一致を報告することを検証します。
     /// </summary>
     [Fact]
     public void Compare_WhenAlignedElementsHaveDifferentRuntimeTypes_ReportsElementDifferenceWithoutDescending()
@@ -130,7 +130,7 @@ public sealed class PolymorphicSequenceE2ETests
     }
 
     /// <summary>
-    /// Verifies that null and missing polymorphic elements retain their established presence-state behavior.
+    /// nullおよび欠損のポリモーフィック要素が既存の存在状態の動作を維持することを検証します。
     /// </summary>
     [Fact]
     public void Compare_WhenPolymorphicElementIsNullOrMissing_PreservesExistingPresenceStates()
@@ -177,7 +177,7 @@ public sealed class PolymorphicSequenceE2ETests
     }
 
     /// <summary>
-    /// Verifies that keyed elements with matching derived types retain key alignment while comparing runtime members.
+    /// 一致する派生型を持つキー付き要素が、キーによる位置合わせを維持しながら実行時メンバーを比較することを検証します。
     /// </summary>
     [Fact]
     public void Compare_WhenKeyedElementsShareDerivedType_PreservesKeyAlignmentAndUsesRuntimeMembers()
@@ -211,7 +211,7 @@ public sealed class PolymorphicSequenceE2ETests
     }
 
     /// <summary>
-    /// Verifies that trace output identifies both the declared node type and the runtime comparison type.
+    /// トレース出力が宣言されたノード型と実行時の比較型の両方を識別することを検証します。
     /// </summary>
     [Fact]
     public void Compare_WhenTraceEnabled_ReportsDeclaredNodeAndRuntimeComparisonTypes()
@@ -244,80 +244,80 @@ public sealed class PolymorphicSequenceE2ETests
     }
 
     /// <summary>
-    /// Represents a test root that exposes polymorphic sequence items.
+    /// ポリモーフィックなシーケンス要素を公開するテストルートを表します。
     /// </summary>
     public sealed class PolymorphicRoot
     {
         /// <summary>
-        /// Gets the polymorphic items compared by the sequence tests.
+        /// シーケンステストで比較するポリモーフィックな要素を取得します。
         /// </summary>
         public List<PolymorphicItem?> Items { get; init; } = [];
     }
 
     /// <summary>
-    /// Defines the declared base type for polymorphic sequence items.
+    /// ポリモーフィックなシーケンス要素の宣言上の基底型を定義します。
     /// </summary>
     public abstract class PolymorphicItem
     {
     }
 
     /// <summary>
-    /// Represents a polymorphic item with a name and nested polymorphic children.
+    /// 名前と入れ子のポリモーフィックな子要素を持つ要素を表します。
     /// </summary>
     public sealed class PolymorphicNode : PolymorphicItem
     {
         /// <summary>
-        /// Gets the name compared for this polymorphic node.
+        /// このポリモーフィックノードで比較する名前を取得します。
         /// </summary>
         public string Name { get; init; } = string.Empty;
 
         /// <summary>
-        /// Gets the nested polymorphic items compared recursively.
+        /// 再帰的に比較する入れ子のポリモーフィックな要素を取得します。
         /// </summary>
         public List<PolymorphicItem?> Children { get; init; } = [];
     }
 
     /// <summary>
-    /// Represents a polymorphic item with text content.
+    /// テキスト内容を持つポリモーフィックな要素を表します。
     /// </summary>
     public sealed class PolymorphicContent : PolymorphicItem
     {
         /// <summary>
-        /// Gets the text compared for this polymorphic content item.
+        /// このポリモーフィックな内容要素で比較するテキストを取得します。
         /// </summary>
         public string Text { get; init; } = string.Empty;
     }
 
     /// <summary>
-    /// Represents a test root that exposes keyed polymorphic sequence items.
+    /// キー付きポリモーフィックなシーケンス要素を公開するテストルートを表します。
     /// </summary>
     public sealed class KeyedPolymorphicRoot
     {
         /// <summary>
-        /// Gets the keyed polymorphic items compared by the sequence tests.
+        /// シーケンステストで比較するキー付きポリモーフィックな要素を取得します。
         /// </summary>
         public List<KeyedPolymorphicItem> Items { get; init; } = [];
     }
 
     /// <summary>
-    /// Defines the declared base type for keyed polymorphic sequence items.
+    /// キー付きポリモーフィックなシーケンス要素の宣言上の基底型を定義します。
     /// </summary>
     public abstract class KeyedPolymorphicItem
     {
         /// <summary>
-        /// Gets the key used to align polymorphic items between compared models.
+        /// 比較するモデル間でポリモーフィックな要素を位置合わせするキーを取得します。
         /// </summary>
         [CompareKey]
         public int Id { get; init; }
     }
 
     /// <summary>
-    /// Represents a keyed polymorphic item with a value compared after key alignment.
+    /// キーによる位置合わせ後に値を比較するキー付きポリモーフィックな要素を表します。
     /// </summary>
     public sealed class KeyedPolymorphicValue : KeyedPolymorphicItem
     {
         /// <summary>
-        /// Gets the value compared for the keyed polymorphic item.
+        /// キー付きポリモーフィックな要素で比較する値を取得します。
         /// </summary>
         public int Value { get; init; }
     }


### PR DESCRIPTION
## 概要

PR #43で追加されたpolymorphic sequence比較関連のXML documentationを日本語化します。

## 変更内容

- `ParallelNode<T>`の実行時型不一致に関する`summary` / `param` / `returns`を日本語化
- polymorphic sequence E2Eの7テスト、テストクラス、共有モデル型・propertyの説明を日本語化
- T-091のtrackingと実装・検証・review reportを追加

## 変更しない範囲

- runtimeロジック
- assertionとtest data
- XML tag、`param`名、`paramref`、`see`、`langword`、識別子

## 検証

- `dotnet test SSC.sln --configuration Release`: Unit 31件 / E2E 81件成功
- `dotnet format SSC.sln --verify-no-changes`: 成功
- XML documentation除外後の対象3ファイルが`origin/main`と一致
- XML整形式: 成功
- `git diff --check`: 成功
- `gpt-5.6-sol / high`独立review: 指摘なし
- Markdown lint: repository wiring不在のため`unsupported`

## レポート

- `reports/task-t-091-japanese-xml-comments-implementation-20260711200933.md`
- `reports/task-t-091-japanese-xml-comments-verification-20260711200934.md`
- `reports/task-t-091-japanese-xml-comments-review-20260711200934.md`

## 関連

- Follow-up to #43
- 専用issueはなく、マージ済みPR #43のdocumentation follow-upとして扱います。
