### PR TITLE
差分パスのLINQフィルターを追加

### DIFF
--- a/doc/design/README.md
+++ b/doc/design/README.md
@@ -16,6 +16,7 @@
 - `detail/07-NonFunctional.md`
 - `detail/08-ImplementationChecklist.md`
 - `detail/09-ValueStateBehavior.md`
+- `detail/10-DiffEntryPathFilter.md`
 
 ## Notes
 

--- a/doc/design/detail/09-DiffEntryPathFilter.md
+++ b/doc/design/detail/09-DiffEntryPathFilter.md
@@ -1,0 +1,187 @@
+# Diff Entry Path Filter
+
+## 1. 目的
+
+`CompareResult<T>.GetDiffEntries()` が返す差分一覧に対し、XPath-like path の構造を使って利用側で任意の差分を絞り込めるようにする。
+
+想定例:
+
+```text
+Boards[任意].Files[任意].Document.Root.Children[任意].Children[任意].Attribute[LastEditingTime].Value
+```
+
+基板名、ファイル識別子、子要素のキーまたは ordinal が入力ごとに変化しても、構造上同じ位置にある差分を一致させる。
+
+## 2. 非目的
+
+- `[CompareIgnore]` の動作変更
+- 比較対象メンバーの変更
+- `ParallelCompareApi.Compare()` の比較結果変更
+- `CompareConfiguration` への ignore path 設定追加
+- `GetDiffEntries()` が返す差分一覧の変更
+- `CompareResult<T>.Root`、`Issues`、`ValueState`、`HasDifferences()` の変更
+- 正規表現による path 判定
+- XPath の axis、predicate、再帰検索の実装
+
+## 3. `CompareIgnore` との境界
+
+`CompareIgnoreAttribute` はメタデータ解決時に対象メンバーを比較対象から除外する。除外されたメンバーは node 構築、container 正規化、差分生成の対象にならない。
+
+本機能は比較完了後に生成済みの `ParallelDiffEntry` を選別するだけであり、`CompareIgnoreAttribute`、`TypeMetadataResolver`、比較パイプラインには接続しない。
+
+```text
+models
+  -> CompareIgnore を含む既存メタデータ解決
+  -> 既存比較ツリー構築
+  -> 既存 GetDiffEntries()
+  -> 利用側の LINQ Where + path pattern
+```
+
+## 4. 利用例
+
+```csharp
+ParallelDiffPathPattern ignoreLastEditingTime = ParallelDiffPathPattern.Parse(
+    "Boards[*].Files[*].Document.Root.Children[*].Children[*].Attribute[LastEditingTime].Value");
+
+ParallelDiffEntry[] effectiveDiffs = result
+    .GetDiffEntries()
+    .Where(entry => !entry.PathMatches(ignoreLastEditingTime))
+    .ToArray();
+```
+
+元の一覧を残したまま分類する場合:
+
+```csharp
+var classified = result
+    .GetDiffEntries()
+    .Select(entry => new
+    {
+        Entry = entry,
+        IsFiltered = entry.PathMatches(ignoreLastEditingTime),
+    })
+    .ToArray();
+```
+
+## 5. 公開 API
+
+```csharp
+public sealed class ParallelDiffPathPattern
+{
+    public static ParallelDiffPathPattern Parse(string pattern);
+
+    public static bool TryParse(
+        string pattern,
+        out ParallelDiffPathPattern? parsedPattern);
+
+    public bool IsMatch(string path);
+}
+
+public static class ParallelDiffEntryPathExtensions
+{
+    public static bool PathMatches(
+        this ParallelDiffEntry entry,
+        ParallelDiffPathPattern pattern);
+}
+```
+
+### 5.1 例外と失敗
+
+- `Parse(null)` は `ArgumentNullException`
+- `Parse(不正な構文)` は `FormatException`
+- `TryParse(null または不正な構文)` は `false`
+- `IsMatch(null)` は `ArgumentNullException`
+- `PathMatches(null entry, ...)` は `ArgumentNullException`
+- `PathMatches(..., null pattern)` は `ArgumentNullException`
+- 判定対象 path が既存 XPath-like path として不正な場合、`IsMatch` は `false`
+
+## 6. パターン構文
+
+既存 XPath-like path の root-relative grammar を基礎とし、selector に `[*]` を追加する。
+
+```text
+pattern          = segment *( "." segment )
+segment          = member-name [ selector-pattern ]
+selector-pattern = exact-selector / any-selector
+any-selector     = "[*]"
+```
+
+`[*]` は、その segment に selector が存在する任意の child に一致する。
+
+一致対象:
+
+- key selector: `Boards[MainBoard]`
+- numeric key selector: `Children[0]`
+- ordinal selector: `Children[#0]`
+
+一致しない対象:
+
+- selector を持たない scalar/object member: `Document`
+- member 名が異なる segment
+
+初期実装では member 名の wildcard、任意深度 wildcard、prefix/subtree match は提供しない。path 全体の segment 数と各 segment が一致する exact match のみとする。
+
+## 7. 一致規則
+
+候補 path と pattern を segment 単位で比較する。
+
+1. segment 数が異なる場合は不一致
+2. member 名は `StringComparison.Ordinal` 相当で完全一致
+3. pattern に selector がない場合、候補にも selectorがない場合だけ一致
+4. pattern selector が `[*]` の場合、候補に key または ordinal selector があれば一致
+5. exact key selector は key text と完全一致
+6. exact ordinal selector は ordinal 値と一致
+7. key selector と ordinal selector は相互に一致しない
+
+例:
+
+```text
+Pattern: Boards[*].Files[*].Document.Root.Children[*].Attribute[LastEditingTime].Value
+
+Match:
+Boards[A].Files[No1/ygx].Document.Root.Children[0].Attribute[LastEditingTime].Value
+Boards[B].Files[No2/ygx].Document.Root.Children[#3].Attribute[LastEditingTime].Value
+
+No match:
+Boards[A].Files[No1/ygx].Document.Root.Attribute[LastEditingTime].Value
+Boards[A].Files[No1/ygx].Document.Root.Children[0].Attribute[CreatedAt].Value
+```
+
+## 8. 実装方針
+
+- 候補 path の解析には既存 `XPathLikePathParser` を再利用する
+- pattern parser は既存 grammar と escape 規則を維持しつつ `[*]` だけを追加解釈する
+- 文字列の `StartsWith`、`Contains`、正規表現変換では判定しない
+- `ParallelDiffEntry` 本体には `IsIgnored` 等の状態を追加しない
+- `IEnumerable<ParallelDiffEntry>` を書き換える拡張は追加せず、標準 LINQ の `Where` と `PathMatches` を組み合わせる
+- pattern は `Parse` 時に一度構造化し、各 `IsMatch` 呼び出しでは pattern の再解析を行わない
+
+## 9. テスト方針
+
+### 9.1 pattern parser
+
+- exact member/key path を解析できる
+- `[*]` を解析できる
+- ordinal selector `[#0]` を exact selector として解析できる
+- bracket 内の dot と既存 escape を維持する
+- 空文字、未閉じ bracket、空 selector、二重 selector、不正 escape を拒否する
+
+### 9.2 match
+
+- 任意 board key に一致する
+- 任意 file key に一致する
+- `[*]` が key selector と ordinal selectorの両方に一致する
+- exact key と exact ordinal を区別する
+- member 名違い、segment 数違い、selector 有無違いを拒否する
+- 不正な候補 path に対して `false` を返す
+
+### 9.3 LINQ 利用
+
+- `.Where(entry => !entry.PathMatches(pattern))` で対象差分だけ除外できる
+- 元の `IReadOnlyList<ParallelDiffEntry>` の件数と内容は変化しない
+- `CompareResult<T>.Issues` と `Root.HasDifferences()` は変化しない
+
+### 9.4 `CompareIgnore` 回帰
+
+- 既存 `CompareIgnore` テストを変更せず通す
+- `[CompareIgnore]` 付き sequence が CompareKey 検証対象にならない既存契約を維持する
+- 本機能の production code から `CompareIgnoreAttribute`、`TypeMetadataResolver`、`CompareConfiguration` を参照しない

--- a/doc/design/detail/10-DiffEntryPathFilter.md
+++ b/doc/design/detail/10-DiffEntryPathFilter.md
@@ -70,7 +70,7 @@ public sealed class ParallelDiffPathPattern
     public static ParallelDiffPathPattern Parse(string pattern);
 
     public static bool TryParse(
-        string pattern,
+        string? pattern,
         out ParallelDiffPathPattern? parsedPattern);
 
     public bool IsMatch(string path);
@@ -96,16 +96,19 @@ public static class ParallelDiffEntryPathExtensions
 
 ## 6. パターン構文
 
-既存 XPath-like path の root-relative grammar を基礎とし、selector に `[*]` を追加する。
+既存 XPath-like path の root-relative grammar を基礎とし、selector に `[*]` と `*` の escape を追加する。
 
 ```text
 pattern          = segment *( "." segment )
 segment          = member-name [ selector-pattern ]
-selector-pattern = exact-selector / any-selector
+selector-pattern = exact-selector / any-selector / escaped-asterisk-selector
 any-selector     = "[*]"
+escaped-asterisk-selector = "[\\*]"
 ```
 
 `[*]` は、その segment に selector が存在する任意の child に一致する。
+
+`[\*]` は `*` をエスケープして通常文字の key として扱う。`[*]` の wildcard と区別される。既存の `\]`、`\\`、`\#` の escape 規則も維持する。
 
 一致対象:
 
@@ -149,7 +152,7 @@ Boards[A].Files[No1/ygx].Document.Root.Children[0].Attribute[CreatedAt].Value
 ## 8. 実装方針
 
 - 候補 path の解析には既存 `XPathLikePathParser` を再利用する
-- pattern parser は既存 grammar と escape 規則を維持しつつ `[*]` だけを追加解釈する
+- pattern parser は既存 grammar と escape 規則を維持しつつ `[*]` と `[\*]` を追加解釈する
 - 文字列の `StartsWith`、`Contains`、正規表現変換では判定しない
 - `ParallelDiffEntry` 本体には `IsIgnored` 等の状態を追加しない
 - `IEnumerable<ParallelDiffEntry>` を書き換える拡張は追加せず、標準 LINQ の `Where` と `PathMatches` を組み合わせる
@@ -161,15 +164,18 @@ Boards[A].Files[No1/ygx].Document.Root.Children[0].Attribute[CreatedAt].Value
 
 - exact member/key path を解析できる
 - `[*]` を解析できる
+- `[\*]` が `*` をエスケープして通常文字の key として扱う
 - ordinal selector `[#0]` を exact selector として解析できる
-- bracket 内の dot と既存 escape を維持する
+- bracket 内の dot と既存の `\]`、`\\`、`\#` escape を維持する
 - 空文字、未閉じ bracket、空 selector、二重 selector、不正 escape を拒否する
+- `TryParse(null)` は `false` とし、`Parse(null)` と `IsMatch(null)` は `ArgumentNullException` とする
 
 ### 9.2 match
 
 - 任意 board key に一致する
 - 任意 file key に一致する
 - `[*]` が key selector と ordinal selectorの両方に一致する
+- `[\*]` が `*` をエスケープして通常文字の key として扱い、他の key には一致しない
 - exact key と exact ordinal を区別する
 - member 名違い、segment 数違い、selector 有無違いを拒否する
 - 不正な候補 path に対して `false` を返す
@@ -179,6 +185,7 @@ Boards[A].Files[No1/ygx].Document.Root.Children[0].Attribute[CreatedAt].Value
 - `.Where(entry => !entry.PathMatches(pattern))` で対象差分だけ除外できる
 - 元の `IReadOnlyList<ParallelDiffEntry>` の件数と内容は変化しない
 - `CompareResult<T>.Issues` と `Root.HasDifferences()` は変化しない
+- `PathMatches(null entry, ...)` と `PathMatches(..., null pattern)` は `ArgumentNullException` とする
 
 ### 9.4 `CompareIgnore` 回帰
 

--- a/reports/task-t-092-initial-review-20260711221140.md
+++ b/reports/task-t-092-initial-review-20260711221140.md
@@ -1,0 +1,44 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: PR #45 の差分パスLINQフィルターを初回コードレビューする
+- タスク種別: コードレビュー
+
+## sub-agentを使う理由
+
+- 理由: `review-enforcer` により独立したsub-agentレビューが必須であり、ユーザーが `gpt-5.6-sol / high` を指定したため
+
+## 対象範囲
+
+- 対象: `origin/main...HEAD` のproduction code、unit test、設計書、および周辺実装との整合
+- レビュー基準: public API契約、path pattern grammar、matching semantics、例外契約、性能上の明白な問題、設計書との一致、日本語XML documentation、テストの十分性
+
+## 対象外
+
+- 対象外: レビュー中の実装修正、PR #45 と無関係な既存コードの改善、report構造の変更
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short --branch`、`git log --oneline --decorate -8`、`git diff --stat origin/main...HEAD`、`git diff --name-status origin/main...HEAD`、`git diff --unified=80 origin/main...HEAD -- <3変更ファイル>`、`nl -ba`、`sed -n`、`rg -n`で差分と周辺実装・XML documentation・設計配置を確認した。`dotnet script eval` で literal `*` key の照合を再現し、`literal-star=True; other-key=True; escaped-star-parse=False` を確認した。`dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` は16件成功、`dotnet test SSC.sln --configuration Release` はUnit 47件・E2E 81件の全128件成功、`dotnet format SSC.sln --verify-no-changes` と `git diff --check origin/main...HEAD` は成功した。`npm run lint:md` は `Missing script: "lint:md"` で失敗し、`tools/lint/`、`cspell.config.jsonc`、textlint/prh/whitelist設定も存在しないため、focused/full Markdown lintはともに `unsupported` と判定した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`doc/design/detail/09-DiffEntryPathFilter.md`、`src/SSC/Internal/XPathLikePathParser.cs`、`src/SSC/ParallelPathAccessExtensions.cs`、`src/SSC/ParallelDiffContracts.cs`、`tests/SSC.Unit.Tests/XPathLikePathParserUnitTests.cs`、`tests/SSC.Unit.Tests/XPathLikeDiffEntriesUnitTests.cs`、`doc/design/README.md`、`doc/design/detail/09-ValueStateBehavior.md`、`src/SSC/SSC.csproj`、`tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj`、`package.json`、`tasks/tasks-status.md`、`tasks/phases-status.md`。変更したのは本レポートのみ。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - [P1][ユーザー確認必須のcapability gap] `src/SSC/ParallelDiffPathPattern.cs:122-134` は `[*]` を必ずwildcardとして解釈する一方、既存のpath生成は `src/SSC/ParallelPathAccessExtensions.cs:282-291` で `*` をescapeしない。そのため有効なliteral `*` keyのpath `Items[*].Value` をexact指定できず、同じpatternが `Items[other].Value` にも一致する。`Items[\*].Value` も既存escape grammarでは解析できない。LINQで差分を除外する主用途で無関係な差分を隠し得るため、literal wildcardのescape構文を追加するか、literal `*` keyを非サポートとして公開契約に明記するかをユーザに確認する必要がある。
+  - [P2][blocking] `tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs:5-128` の新規test classと全10個の `[Fact]` / `[Theory]` にXML summaryがなく、method内の `// Intent:` はテスト契約のXML documentationを代替できない。また、grammar/matchingの境界を担う新規private関数 `src/SSC/ParallelDiffPathPattern.cs:94-153,156-228,242-255,272-298` にもタスク基準が要求する契約説明がない。さらにpublic `PathMatches` は `src/SSC/ParallelDiffPathPattern.cs:313-320` でentry/patternのnull時に `ArgumentNullException` を投げるが、XML documentationに両方の `<exception>` 契約がない。`source-documentation-policy` とT-092 exit criteriaに反するためreview gateをblockする。
+  - [P2][blocking] `doc/design/detail/09-DiffEntryPathFilter.md:72-74` は `TryParse(string pattern, ...)` と非nullの公開signatureを記載するが、実装は `src/SSC/ParallelDiffPathPattern.cs:42` で `string?` を受け取り、同設計書の91行もnullを正式な `false` 経路と定義している。nullable契約を設計と実装で一致させる必要がある。加えて `doc/design/README.md:7-18` のFinal Design Indexに新規設計書が追加されず、既存 `09-ValueStateBehavior.md` と番号が衝突しているため、設計ソースの配置と索引を整合させる必要がある。
+  - [P2][blocking] `tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs:67-98,127-136` は不正非null pattern、不正candidate path、extensionのnullだけを検証し、設計書の例外契約である `Parse(null)`、`TryParse(null)`、`IsMatch(null)` を検証していない。既存escape grammar維持についてもdotと `\]` のみで、`\\` と `\#` のexact key照合が未検証である。また `doc/design/detail/09-DiffEntryPathFilter.md:177-186` が明記する `Issues` / `Root.HasDifferences()` 不変と `CompareIgnore` 回帰は新規テストから直接確認できない。現行実装は差分一覧に状態を持たず全回帰テストも成功しているが、明文化したpublic boundaryと設計上のテスト方針を回帰テストに固定するまでreview gateをblockする。
+  - [P3][non-blocking held] 候補pathは各 `IsMatch` で再解析されるが、patternは一度だけ構造化され、正規表現や明白な非線形処理もない。現スコープで明白な性能・安全性の追加指摘はなく、benchmark/cache追加は実害が出るまでholdとする。
+
+## 結果
+
+- 結果: 初回レビューは不合格。Release全128テスト、focused 16テスト、format、diff checkは成功したが、literal `*` keyとwildcardの契約衝突はユーザ確認が必要であり、XML documentation、設計書契約／配置、public boundaryのテストにblocking findingがある。修正後に同一レビュアーでの再レビューが必要。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: literal `*` keyの公開grammar方針をユーザに確認し、決定に従って設計・実装・テストを一致させる必要がある。その他のblocking findingを修正してfocused/full validationと再レビューを実施する必要がある。Markdown lintはrepository wiring不在によりfocused/fullとも `unsupported` で、用語検査が自動実行できない残存リスクがあるが、設計本文の目視照合、backtick/quote回避の不在確認、実装・テストとの契約照合を行ったため、本初回レビューでは追加のnon-blocking held riskとする。

--- a/reports/task-t-092-review-fix-implementation-20260711222105.md
+++ b/reports/task-t-092-review-fix-implementation-20260711222105.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: PR #45の初回レビュー指摘4件をTDDで修正する
+- タスク種別: テスト・production code・設計書の実装
+
+## sub-agentを使う理由
+
+- 理由: ユーザーが実装に `gpt-5.6-terra / medium` を指定し、コード・テスト・設計書をまたぐ境界明確な修正であるため
+
+## 対象範囲
+
+- 対象: `*` のエスケープ構文、境界テスト、日本語XML documentation、nullable契約、設計書番号・索引、状態不変性とCompareIgnore回帰
+
+## 対象外
+
+- 対象外: wildcard以外の新grammar、比較パイプライン変更、PR #45と無関係な既存コード改善、Git操作
+
+## 実行コマンド
+
+- 実行コマンド: production 修正前に `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` を実行し、21件中20件成功・1件失敗を確認した。失敗した `IsMatch_WithEscapedAsteriskSelector_TreatsAsteriskAsRegularKeyCharacter` は `ParallelDiffPathPattern.Parse("Items[\\*].Value")` が `FormatException` を送出し、`[\\*]` が未対応である赤テストを示した。最小実装後に同じコマンドを再実行し、21件すべて成功した。`npm run lint:md` は `Missing script: "lint:md"` で終了した。`tools/lint/`、cspell、textlint、prh、whitelistのrepo wiringも存在しないため、変更した `doc/design/README.md`、`doc/design/detail/10-DiffEntryPathFilter.md`、本レポートに対するfocused/full Markdown lintはともに `unsupported` と判定した。`git diff --check` は成功した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`doc/design/detail/09-DiffEntryPathFilter.md`（`10-DiffEntryPathFilter.md` へ改名）、`doc/design/README.md`、本レポートを変更した。`Design/BreakingChanges.md`、比較パイプライン、task tracking、Git操作は変更していない。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 初回レビューのblocking指摘を修正した。`[*]` は任意selectorのwildcardとして維持し、`[\\*]` は `*` をエスケープして通常文字のkeyとして扱う。Parse/TryParse/IsMatch/PathMatchesのnull契約、既存 `\\]`・`\\\\`・`\\#` escape、LINQ絞り込みでの `Issues` と `Root.HasDifferences()` の不変、CompareIgnore回帰をfocused testで固定した。productionのpublic APIとgrammar/matching境界、test classと全Fact/Theoryに自然な日本語XML documentationを追加し、`// Intent:` は削除した。設計書の番号衝突、nullable TryParse契約、索引を整合させた。
+
+## 結果
+
+- 結果: TDDの赤→緑を完了した。赤は `Items[\\*].Value` の `FormatException`、緑はfocused unit test 21件成功で確認した。`Design/BreakingChanges.md` はadditive public APIと未merge PR内の契約修正であり、破壊的変更ではないため未変更とした。Markdown lintはrepo wiring不在のためfocused/fullとも `unsupported` として記録した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lintのrepository wiringが存在しないため、変更したdesign Markdownと本レポートの自動用語検査は実行できない。focused test以外のsolution全体test、format、最終standards validationと再レビューは、指定どおり後続verification sub-agentの担当である。

--- a/reports/task-t-092-review-fix-implementation-r2-20260711222941.md
+++ b/reports/task-t-092-review-fix-implementation-r2-20260711222941.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: 独立検証で不足が判明した `PatternSelector.Exact` の日本語XML documentationを追加する
+- タスク種別: review findingの限定修正
+
+## sub-agentを使う理由
+
+- 理由: T-092の実装担当を再利用し、ユーザー指定の `gpt-5.6-terra / medium` で限定修正するため
+
+## 対象範囲
+
+- 対象: `PatternSelector.Exact` の日本語XML documentationとfocused確認
+
+## 対象外
+
+- 対象外: 振る舞い変更、テスト変更、他のコメント変更、Git操作
+
+## 実行コマンド
+
+- 実行コマンド: `dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` は21件すべて成功した。`git diff --check` は成功した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelDiffPathPattern.cs` と本レポートを変更した。tests、他コメント、振る舞い、Git操作は変更していない。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: `PatternSelector.Exact(XPathLikePathSelector selector)` に、exact selector patternを生成して引数selectorを保持するfactoryであることを説明する日本語XML summary、param、returnsを追加した。
+
+## 結果
+
+- 結果: P2のdocumentation欠落を限定修正し、focused testと差分検査で確認した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: 本修正はdocumentation-onlyであり、振る舞い変更はない。独立検証で指摘された未コミット／未pushのP1、全体検証、format、再レビューは対象外として残る。

--- a/reports/task-t-092-review-fix-implementation-r3-20260711223708.md
+++ b/reports/task-t-092-review-fix-implementation-r3-20260711223708.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: 再レビューで指摘された設計grammarの選択肢接続漏れを修正する
+- タスク種別: design review findingの限定修正
+
+## sub-agentを使う理由
+
+- 理由: T-092の実装担当を再利用し、ユーザー指定の `gpt-5.6-terra / medium` で修正するため
+
+## 対象範囲
+
+- 対象: `10-DiffEntryPathFilter.md` のgrammar定義1か所
+
+## 対象外
+
+- 対象外: production code、テスト、他の設計文、tracking、Git操作
+
+## 実行コマンド
+
+- 実行コマンド: `npm run lint:md` は `Missing script: "lint:md"` で終了した。`tools/lint/`、cspell、textlint、prh、whitelist、focused lint wiringが存在しないため、変更した `doc/design/detail/10-DiffEntryPathFilter.md` と本レポートのfocused/full Markdown lintはともに `unsupported` と判定した。`git diff --check` は成功した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `doc/design/detail/10-DiffEntryPathFilter.md` と本レポートを変更した。production code、tests、他design、tracking、Git操作は変更していない。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: `selector-pattern` の選択肢へ `escaped-asterisk-selector` を追加し、exact selector、任意selector wildcard、`*` をエスケープして通常文字として扱うselectorのgrammar関係を閉じた。
+
+## 結果
+
+- 結果: P2の形式grammar接続漏れを1行の限定修正で解消し、差分検査は成功した。Markdown lintはrepository wiring不在のためfocused/fullとも `unsupported` と記録した。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lintのrepository wiringが存在しないため、自動用語検査は実行できない。focused/full lintの `unsupported`、全体検証、format、限定再レビュー、未commit・未pushは後続担当として残る。

--- a/reports/task-t-092-review-fix-rereview-20260711223300.md
+++ b/reports/task-t-092-review-fix-rereview-20260711223300.md
@@ -1,0 +1,44 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-092の初回レビュー指摘修正を同一レビュアーで再レビューする
+- タスク種別: コード再レビュー
+
+## sub-agentを使う理由
+
+- 理由: `review-enforcer` により独立sub-agent再レビューが必須であり、初回の `gpt-5.6-sol / high` レビュアーを再利用するため
+
+## 対象範囲
+
+- 対象: PR #45とT-092のcommit予定差分、初回4指摘の解消、検証結果、設計・XML documentation整合
+
+## 対象外
+
+- 対象外: 実装修正、Git操作、PR #45と無関係な改善、report構造変更
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short --branch`、`git log --oneline --decorate -6`、`git diff --name-status origin/main...HEAD`、`git diff --name-status HEAD`、`git ls-files --others --exclude-standard`、`git diff --stat HEAD`、`git diff --unified=50 HEAD -- <T-092修正ファイル>`、`rg --files`、`rg -n`、`nl -ba`、`sed -n`でcommit予定のworking tree・未追跡を含む全差分、初回4指摘、XML documentation、設計配置、周辺のpath grammarを照合した。`dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` は21件成功、`dotnet test SSC.sln --configuration Release` はUnit 52件・E2E 81件の全133件成功、`dotnet format SSC.sln --verify-no-changes` と `git diff --check` は成功した。`npm run lint:md` は `Missing script: "lint:md"` で失敗し、`tools/lint/`、cspell、textlint、prh、whitelist、focused lint wiringも不在のため、変更Markdownのfocused/full lintはともに `unsupported` と再判定した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`doc/design/detail/10-DiffEntryPathFilter.md`、削除予定の `doc/design/detail/09-DiffEntryPathFilter.md`、`doc/design/README.md`、`src/SSC/Internal/XPathLikePathParser.cs`、`src/SSC/ParallelPathAccessExtensions.cs`、`tests/SSC.E2E.Tests/CompareApiE2ETests.cs`、`tasks/tasks-status.md`、`tasks/phases-status.md`、`package.json`、`Design/BreakingChanges.md`、T-092のimplementation・verification・review report一式を確認した。変更したのは本レポートの空欄のみ。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - [P2][blocking] `doc/design/detail/10-DiffEntryPathFilter.md:102-107` は `escaped-asterisk-selector = "[\\*]"` を定義するが、`selector-pattern = exact-selector / any-selector` の選択肢に `escaped-asterisk-selector` を含めていない。この形式grammarのままでは `[*]` はwildcardとして生成可能な一方、`[\*]` は定義されてもpatternから到達できない。同ファイル99行・111行・155行・167行・178行の契約文、`src/SSC/ParallelDiffPathPattern.cs:128-161` の実装、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs:81-94` のテストは `*` をエスケープして通常文字として扱う意図で一致しているため、ユーザー判断は不要であり、`selector-pattern` に当該productionを接続する設計書修正が必要である。
+  - 初回指摘1のruntime capability gapは解消済み。`[*]` はwildcard、`[\*]` は `*` をエスケープして通常文字のkeyとして扱う実装とfocused testがあり、後者は `Items[*].Value` に一致し `Items[other].Value` に一致しない。ただし上記P2の形式grammar修正が残る。
+  - 初回指摘2は解消済み。productionのpublic APIとgrammar/matching境界関数、`PatternSelector.Exact`、test class、全15個の `[Fact]` / `[Theory]` attributeに自然な日本語XML documentationがあり、`PathMatches` はentry/patternの両null例外を明記している。
+  - 初回指摘3は解消済み。設計と実装の `TryParse(string? ...)` が一致し、設計書は `10-DiffEntryPathFilter.md` へrenameされ、Final Design Indexの10番と実ファイルが整合している。
+  - 初回指摘4は解消済み。null例外・TryParse null false、`\]` / `\\` / `\#` / `\*` escape、state不変、CompareIgnore回帰はfocused 21件と既存solution回帰で確認できる。
+  - ユーザー確認が必要な新規capability gapとnon-blockingでholdすべき新規code findingはない。初回のperformance懸念は実害の根拠がなく、引き続non-blocking heldとする。
+
+## 結果
+
+- 結果: 再レビューは不合格。working tree・未追跡を含むcommit予定差分で、Release全133件、focused 21件、format、diff checkの成功を再確認した。初回指摘のruntime、XML documentation、nullable契約・rename/index、境界・回帰テストは解消したが、設計書の形式grammarにP2 blocking findingが1件残る。これを修正後、同一レビュアーで限定再レビューが必要。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: `selector-pattern` に `escaped-asterisk-selector` を接続し、形式grammarと実装・説明文・テストを一致させる必要がある。Markdown lintはrepository wiring不在によりfocused/fullとも集約状態 `unsupported` である。これはpassではないが、対象Markdownの目視契約照合、backtick/quote回避の不在確認、Release/focused test、format、diff checkが成功し、repoに必須Markdown gateも存在しないため、自動用語検査不在のリスクをnon-blocking heldとするdispositionは妥当である。未commit・未pushは指定どおり後続Git workflowのみのリスクで、code findingにはしない。

--- a/reports/task-t-092-review-fix-rereview-r2-20260711223811.md
+++ b/reports/task-t-092-review-fix-rereview-r2-20260711223811.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: 設計grammar接続漏れの修正を同一レビュアーで限定再レビューする
+- タスク種別: design findingの限定再レビュー
+
+## sub-agentを使う理由
+
+- 理由: 初回から同じ `gpt-5.6-sol / high` レビュアーでreview gateを完了するため
+
+## 対象範囲
+
+- 対象: `10-DiffEntryPathFilter.md` のgrammar修正と実装・テスト契約との一致
+
+## 対象外
+
+- 対象外: 実装修正、Git操作、既に合格済みの無関係な範囲
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short --branch`、`nl -ba doc/design/detail/10-DiffEntryPathFilter.md`、`nl -ba src/SSC/ParallelDiffPathPattern.cs`、`nl -ba tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`rg -n "selector-pattern|escaped-asterisk-selector|any-selector" doc/design/detail/10-DiffEntryPathFilter.md` で形式grammarと最小限の実装・テストを照合した。`dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` は21件すべて成功し、`git diff --check` も成功した。Markdown lintはimplementation reportの `npm run lint:md` が `Missing script: "lint:md"` で、repo内wiringも不在のためfocused/fullとも `unsupported` とする既存dispositionを確認した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `doc/design/detail/10-DiffEntryPathFilter.md`、`src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`reports/task-t-092-review-fix-rereview-20260711223300.md`、`reports/task-t-092-review-fix-implementation-r3-20260711223708.md`。変更したのは本レポートの空欄のみ。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。前回P2は解消済み。`doc/design/detail/10-DiffEntryPathFilter.md:102-106` で `segment` から `selector-pattern` へ達し、`selector-pattern` は `exact-selector`、`any-selector`、`escaped-asterisk-selector` の全3選択肢に接続され、定義したproductionが形式grammar上で到達可能になっている。`src/SSC/ParallelDiffPathPattern.cs:128-161` は `[*]` をwildcardとし、`[\*]` は `*` をエスケープして通常文字のkeyとして扱う。`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs:81-94` も同契約を検証し、focused 21件が成功した。新規blocking finding、ユーザー確認必須gap、non-blocking held findingはない。
+
+## 結果
+
+- 結果: pass。前回P2のgrammar接続漏れは限定修正で解消し、設計grammar、実装、テストの `[*]` wildcardと `[\*]` escape契約は一致している。focused 21件とdiff checkの成功を確認し、T-092のreview gateは通過可能。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: コード・設計上の未解決指摘なし。Markdown lintはrepository wiring不在によりfocused/fullとも `unsupported` であり、自動用語検査不在のnon-blocking held riskは残る。未commit・未pushは後続Git workflowのみのリスクであり、本review gateをblockしない。

--- a/reports/task-t-092-review-fix-verification-20260711222629.md
+++ b/reports/task-t-092-review-fix-verification-20260711222629.md
@@ -1,0 +1,41 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: T-092のレビュー指摘修正を独立検証する
+- タスク種別: build・test・coding standards・設計整合の検証
+
+## sub-agentを使う理由
+
+- 理由: build、test、環境・standards validationは独立sub-agentによる検証が必須であるため
+
+## 対象範囲
+
+- 対象: PR #45の全差分とT-092修正、Release全テスト、format、diff check、日本語XML documentation、設計書、Markdown lint分類
+
+## 対象外
+
+- 対象外: 実装修正、Git操作、PR #45と無関係な改善
+
+## 実行コマンド
+
+- 実行コマンド: `dotnet test SSC.sln --configuration Release` は成功（Unit 52件、E2E 81件、計133件）。`dotnet format SSC.sln --verify-no-changes` と `git diff --check` はともに成功。`dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` は21件すべて成功した。`git status --short --branch`、`git diff --name-status origin/main...HEAD`、`git diff --name-status`、`git ls-files --others --exclude-standard`、`git diff --check`、`git diff origin/main...HEAD` とworking tree差分を確認した。Markdown明示対象について `npm run lint:md` を実行したが `Missing script: "lint:md"` で失敗し、`tools/lint/`、cspell、textlint、prh、whitelist、focused lint用wiringも存在しないため、focused/fullとも `unsupported` と判定した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`doc/design/README.md`、`doc/design/detail/09-DiffEntryPathFilter.md`、`doc/design/detail/10-DiffEntryPathFilter.md`、`Design/BreakingChanges.md`、`tasks/tasks-status.md`、`tasks/phases-status.md`、`package.json`、3つのT-092 report。`origin/main...HEAD` は旧 `09-DiffEntryPathFilter.md`、production code、unit testの3ファイルだけを追加しており、T-092修正はworking treeの変更・削除と未追跡ファイルに存在する。未追跡は `10-DiffEntryPathFilter.md` と3つのT-092 reportである。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - [P1][blocking] 現在のPR #45本体である `origin/main...HEAD` にはT-092修正が含まれていない。`src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、design index・設計書rename・trackingはworking treeのみで、`10-DiffEntryPathFilter.md` と3レポートは未追跡である。したがってpush済みPRだけを評価すると、初回レビューのliteral `*`、XML documentation、nullable設計、設計書番号衝突の指摘は未解消である。修正・tracking・reportsを意図したcommitに含めてpushするまで受け入れ不可。
+  - [P2][blocking] T-092 Exit Criteriaの「新規・変更する関数」のXML documentationを厳密に適用すると、`src/SSC/ParallelDiffPathPattern.cs:290-293` の新規private factory `PatternSelector.Exact` にXML summaryがない。公開API、grammar/matching境界の主要関数、test class、全21個の `[Fact]` / `[Theory]`、および `PathMatches` の両null例外契約は自然な日本語XML documentationで確認できたが、この1関数は基準未達である。
+  - [確認済み] working treeの実装・テスト・設計は `[*]` をselector wildcard、`[\\*]` を `*` をエスケープして通常文字のkeyとして扱う契約で一致する。star keyを「完全一致」と主表現にせず、設計書10の111行とテストXML summaryで同じ説明をしている。`TryParse(string? ...)` とnull時false、設計書10へのrenameとdesign index、`Issues`／`Root.HasDifferences()`不変、`CompareIgnore`回帰、既存 `\\]`・`\\\\`・`\\#` escapeは21件のfocused testとソース照合で確認した。`Design/BreakingChanges.md` を未変更とする判断は、additive APIと未merge PR内の契約修正で既存動作を変更しないため妥当である。明示Markdownは目視で確認し、通常の文章をbacktick/quoteでlint回避した箇所は見つからなかった。
+
+## 結果
+
+- 結果: Release全133テスト、focused 21テスト、format、working treeのdiff checkは成功した。working tree上の機能・設計・テスト整合は概ね確認できたが、P1の未コミット／未pushとP2の新規private factoryのXML documentation欠落があるため、独立検証は不合格（blocking）とする。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lintはrepository wiring不在によりfocused/fullとも `unsupported` であり、自動用語検査は未実施である。P1を解消後はcommit対象とPR差分を再照合し、P2を解消後は同じRelease/focused/format/diff checkと独立再レビューを再実行する必要がある。

--- a/reports/task-t-092-review-fix-verification-r2-20260711223108.md
+++ b/reports/task-t-092-review-fix-verification-r2-20260711223108.md
@@ -1,0 +1,41 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: `PatternSelector.Exact` の日本語XML documentation追加後にT-092を独立再検証する
+- タスク種別: build・test・coding standards再検証
+
+## sub-agentを使う理由
+
+- 理由: 初回検証担当を再利用し、finding解消と全validation gateを独立確認するため
+
+## 対象範囲
+
+- 対象: XML documentation finding、Release全テスト、focused test、format、diff check、PR差分に含める予定のworking tree全体
+
+## 対象外
+
+- 対象外: 実装修正、Git操作、PR #45と無関係な改善
+
+## 実行コマンド
+
+- 実行コマンド: `nl -ba src/SSC/ParallelDiffPathPattern.cs` と `nl -ba tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs` でXML documentationを行番号付き確認した。`dotnet test SSC.sln --configuration Release` はUnit 52件・E2E 81件の計133件すべて成功。`dotnet test tests/SSC.Unit.Tests/SSC.Unit.Tests.csproj --configuration Release --filter FullyQualifiedName~ParallelDiffPathPatternUnitTests` は21件すべて成功。`dotnet format SSC.sln --verify-no-changes` と `git diff --check` は成功。`git status --short --branch`、`git diff --name-status`、`git ls-files --others --exclude-standard`、`git diff -- src/SSC/ParallelDiffPathPattern.cs` でcommit予定のworking treeと未追跡ファイルを確認した。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `src/SSC/ParallelDiffPathPattern.cs`、`tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`、`doc/design/README.md`、`doc/design/detail/09-DiffEntryPathFilter.md`、`doc/design/detail/10-DiffEntryPathFilter.md`、`tasks/tasks-status.md`、`tasks/phases-status.md`、初回・r1・r2のT-092 report。working tree変更はdesign index、09から10へのrename、production/test、trackingであり、未追跡は設計書10とT-092 report 5件である。これらはPR #45に次回commitする予定のT-092一式として揃っている。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - 前回P2は解消した。`src/SSC/ParallelDiffPathPattern.cs:290-295` の `PatternSelector.Exact(XPathLikePathSelector selector)` には、exact selector patternを生成する契約を述べる日本語の `<summary>`、`selector` の意味を示す `<param>`、保持結果を示す `<returns>` が追加されている。
+  - documentation基準は満たす。public APIは `ParallelDiffPathPattern`（5-8行）、`Parse`（17-24行）、nullable `TryParse`（36-42行）、`IsMatch`（66-72行）、`ParallelDiffEntryPathExtensions`（328-331行）、両null例外を明記する `PathMatches`（333-342行）に日本語XML documentationがある。新規・変更したgrammar/matching境界のprivate関数 `TryParsePatternSegment`（94-100行）、`TrySplitSegments`（165-171行）、`PatternSegment.IsMatch`（257-260行）、`PatternSelector.Exact`（290-295行）、`PatternSelector.IsMatch`（300-303行）にも契約説明がある。test class（5-8行）と全21個の `[Fact]` / `[Theory]` は各attributeの直上に自然な日本語XML summaryがあり、通常コメントで代替した箇所はない。
+  - findingなし。`[*]` wildcardと `[\\*]` のエスケープ、nullable `TryParse`、state不変性、`CompareIgnore`回帰を含むfocused 21件とsolution全133件が成功し、format/diff checkも成功した。前回P1の未commit／未pushは、今回の指示どおりGit workflow前の期待状態として後続Git作業に分類し、実装またはverification gateのfailureにはしない。
+
+## 結果
+
+- 結果: pass。前回P2のXML documentation findingは解消済みで、documentation基準、Release全テスト、focused test、format、diff check、commit予定ファイル集合を独立確認した。T-092修正・rename・tracking・reportはworking treeおよび未追跡集合に揃っている。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lintはrepository wiring不在の既知riskであり、focused/fullとも `unsupported` のままである。T-092一式は未commit／未pushのため、後続Git workflowで意図したファイルをcommit・pushし、PR #45の実際の差分に反映されたことを確認する必要がある。

--- a/src/SSC/ParallelDiffPathPattern.cs
+++ b/src/SSC/ParallelDiffPathPattern.cs
@@ -1,0 +1,322 @@
+using SSC.Internal;
+
+namespace SSC;
+
+/// <summary>
+/// <see cref="ParallelDiffEntry.Path"/> と照合する XPath-like path pattern を表します。
+/// </summary>
+public sealed class ParallelDiffPathPattern
+{
+    private readonly IReadOnlyList<PatternSegment> _segments;
+
+    private ParallelDiffPathPattern(IReadOnlyList<PatternSegment> segments)
+    {
+        _segments = segments;
+    }
+
+    /// <summary>
+    /// 指定した文字列を差分 path pattern として解析します。
+    /// </summary>
+    /// <param name="pattern">解析する root-relative path pattern。</param>
+    /// <returns>解析済み pattern。</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pattern"/> が <see langword="null"/> の場合。</exception>
+    /// <exception cref="FormatException"><paramref name="pattern"/> が pattern grammar に適合しない場合。</exception>
+    public static ParallelDiffPathPattern Parse(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        if (!TryParse(pattern, out var parsedPattern) || parsedPattern is null)
+        {
+            throw new FormatException($"Diff path pattern '{pattern}' is invalid.");
+        }
+
+        return parsedPattern;
+    }
+
+    /// <summary>
+    /// 指定した文字列を差分 path pattern として解析します。
+    /// </summary>
+    /// <param name="pattern">解析する root-relative path pattern。</param>
+    /// <param name="parsedPattern">解析に成功した場合の pattern。</param>
+    /// <returns>解析に成功した場合は <see langword="true"/>、それ以外は <see langword="false"/>。</returns>
+    public static bool TryParse(string? pattern, out ParallelDiffPathPattern? parsedPattern)
+    {
+        parsedPattern = null;
+        if (string.IsNullOrEmpty(pattern)
+            || !TrySplitSegments(pattern, out var rawSegments))
+        {
+            return false;
+        }
+
+        var segments = new List<PatternSegment>(rawSegments.Count);
+        foreach (var rawSegment in rawSegments)
+        {
+            if (!TryParsePatternSegment(rawSegment, out var segment))
+            {
+                return false;
+            }
+
+            segments.Add(segment);
+        }
+
+        parsedPattern = new ParallelDiffPathPattern(segments);
+        return true;
+    }
+
+    /// <summary>
+    /// 指定した XPath-like path がこの pattern に一致するか判定します。
+    /// </summary>
+    /// <param name="path">照合する <see cref="ParallelDiffEntry.Path"/>。</param>
+    /// <returns>path 全体が一致する場合は <see langword="true"/>。</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> が <see langword="null"/> の場合。</exception>
+    public bool IsMatch(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (!XPathLikePathParser.TryParse(path, out var parsedPath)
+            || parsedPath is null
+            || parsedPath.Segments.Count != _segments.Count)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < _segments.Count; index++)
+        {
+            if (!_segments[index].IsMatch(parsedPath.Segments[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParsePatternSegment(string rawSegment, out PatternSegment segment)
+    {
+        segment = null!;
+        var selectorStart = rawSegment.IndexOf('[', StringComparison.Ordinal);
+        if (selectorStart < 0)
+        {
+            if (!XPathLikePathParser.TryParse(rawSegment, out var parsedPath)
+                || parsedPath is null
+                || parsedPath.Segments.Count != 1)
+            {
+                return false;
+            }
+
+            var parsedSegment = parsedPath.Segments[0];
+            if (parsedSegment.Selector is not null)
+            {
+                return false;
+            }
+
+            segment = new PatternSegment(parsedSegment.MemberName, selector: null);
+            return true;
+        }
+
+        if (selectorStart == 0 || !rawSegment.EndsWith(']'))
+        {
+            return false;
+        }
+
+        var selectorText = rawSegment[(selectorStart + 1)..^1];
+        if (selectorText == "*")
+        {
+            var memberName = rawSegment[..selectorStart];
+            if (memberName.Length == 0
+                || memberName.Contains('[', StringComparison.Ordinal)
+                || memberName.Contains(']', StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            segment = new PatternSegment(memberName, PatternSelector.Any);
+            return true;
+        }
+
+        if (!XPathLikePathParser.TryParse(rawSegment, out var exactPath)
+            || exactPath is null
+            || exactPath.Segments.Count != 1)
+        {
+            return false;
+        }
+
+        var exactSegment = exactPath.Segments[0];
+        if (exactSegment.Selector is null)
+        {
+            return false;
+        }
+
+        segment = new PatternSegment(
+            exactSegment.MemberName,
+            PatternSelector.Exact(exactSegment.Selector));
+        return true;
+    }
+
+    private static bool TrySplitSegments(string pattern, out List<string> segments)
+    {
+        segments = [];
+        var segmentStart = 0;
+        var inSelector = false;
+        var escaping = false;
+        var selectorClosedInSegment = false;
+
+        for (var index = 0; index < pattern.Length; index++)
+        {
+            var current = pattern[index];
+            if (inSelector)
+            {
+                if (escaping)
+                {
+                    escaping = false;
+                    continue;
+                }
+
+                if (current == '\\')
+                {
+                    escaping = true;
+                    continue;
+                }
+
+                if (current == ']')
+                {
+                    inSelector = false;
+                    selectorClosedInSegment = true;
+                }
+
+                continue;
+            }
+
+            if (current == '[')
+            {
+                if (selectorClosedInSegment)
+                {
+                    return false;
+                }
+
+                inSelector = true;
+                continue;
+            }
+
+            if (current == ']')
+            {
+                return false;
+            }
+
+            if (current != '.')
+            {
+                continue;
+            }
+
+            if (index == segmentStart)
+            {
+                return false;
+            }
+
+            segments.Add(pattern[segmentStart..index]);
+            segmentStart = index + 1;
+            selectorClosedInSegment = false;
+        }
+
+        if (inSelector || escaping || segmentStart == pattern.Length)
+        {
+            return false;
+        }
+
+        segments.Add(pattern[segmentStart..]);
+        return true;
+    }
+
+    private sealed class PatternSegment
+    {
+        public PatternSegment(string memberName, PatternSelector? selector)
+        {
+            MemberName = memberName;
+            Selector = selector;
+        }
+
+        public string MemberName { get; }
+
+        public PatternSelector? Selector { get; }
+
+        public bool IsMatch(XPathLikePathSegment candidate)
+        {
+            if (!string.Equals(MemberName, candidate.MemberName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (Selector is null)
+            {
+                return candidate.Selector is null;
+            }
+
+            return candidate.Selector is not null && Selector.IsMatch(candidate.Selector);
+        }
+    }
+
+    private sealed class PatternSelector
+    {
+        private PatternSelector(bool matchesAny, XPathLikePathSelector? exactSelector)
+        {
+            MatchesAny = matchesAny;
+            ExactSelector = exactSelector;
+        }
+
+        public static PatternSelector Any { get; } = new(matchesAny: true, exactSelector: null);
+
+        public bool MatchesAny { get; }
+
+        public XPathLikePathSelector? ExactSelector { get; }
+
+        public static PatternSelector Exact(XPathLikePathSelector selector)
+        {
+            return new PatternSelector(matchesAny: false, selector);
+        }
+
+        public bool IsMatch(XPathLikePathSelector candidate)
+        {
+            if (MatchesAny)
+            {
+                return true;
+            }
+
+            if (ExactSelector is null || ExactSelector.Kind != candidate.Kind)
+            {
+                return false;
+            }
+
+            return ExactSelector.Kind switch
+            {
+                XPathLikePathSelectorKind.Key => string.Equals(
+                    ExactSelector.KeyText,
+                    candidate.KeyText,
+                    StringComparison.Ordinal),
+                XPathLikePathSelectorKind.Ordinal => ExactSelector.Ordinal == candidate.Ordinal,
+                _ => false,
+            };
+        }
+    }
+}
+
+/// <summary>
+/// <see cref="ParallelDiffEntry"/> の path pattern 判定を提供します。
+/// </summary>
+public static class ParallelDiffEntryPathExtensions
+{
+    /// <summary>
+    /// 差分 entry の path が指定 pattern に一致するか判定します。
+    /// </summary>
+    /// <param name="entry">判定する差分 entry。</param>
+    /// <param name="pattern">照合する path pattern。</param>
+    /// <returns>一致する場合は <see langword="true"/>。</returns>
+    public static bool PathMatches(
+        this ParallelDiffEntry entry,
+        ParallelDiffPathPattern pattern)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        return pattern.IsMatch(entry.Path);
+    }
+}

--- a/src/SSC/ParallelDiffPathPattern.cs
+++ b/src/SSC/ParallelDiffPathPattern.cs
@@ -17,7 +17,7 @@ public sealed class ParallelDiffPathPattern
     /// <summary>
     /// 指定した文字列を差分 path pattern として解析します。
     /// </summary>
-    /// <param name="pattern">解析する root-relative path pattern。</param>
+    /// <param name="pattern">解析する root-relative path pattern。<see langword="null"/> の場合は解析に失敗します。</param>
     /// <returns>解析済み pattern。</returns>
     /// <exception cref="ArgumentNullException"><paramref name="pattern"/> が <see langword="null"/> の場合。</exception>
     /// <exception cref="FormatException"><paramref name="pattern"/> が pattern grammar に適合しない場合。</exception>
@@ -91,6 +91,12 @@ public sealed class ParallelDiffPathPattern
         return true;
     }
 
+    /// <summary>
+    /// 一つの pattern segment を既存 path grammar または selector wildcard grammar として解析します。
+    /// </summary>
+    /// <remarks>
+    /// <c>[*]</c> は任意 selector を表し、<c>[\*]</c> は <c>*</c> をエスケープして通常文字の key として扱います。
+    /// </remarks>
     private static bool TryParsePatternSegment(string rawSegment, out PatternSegment segment)
     {
         segment = null!;
@@ -134,7 +140,10 @@ public sealed class ParallelDiffPathPattern
             return true;
         }
 
-        if (!XPathLikePathParser.TryParse(rawSegment, out var exactPath)
+        var exactSegmentText = selectorText == "\\*"
+            ? string.Concat(rawSegment.AsSpan(0, selectorStart + 1), "*]")
+            : rawSegment;
+        if (!XPathLikePathParser.TryParse(exactSegmentText, out var exactPath)
             || exactPath is null
             || exactPath.Segments.Count != 1)
         {
@@ -153,6 +162,12 @@ public sealed class ParallelDiffPathPattern
         return true;
     }
 
+    /// <summary>
+    /// selector 内の escape を考慮して root-relative pattern を segment 文字列へ分割します。
+    /// </summary>
+    /// <remarks>
+    /// selector が閉じた後の追加 selector や未閉じ selector を拒否し、既存 XPath-like path の境界規則を維持します。
+    /// </remarks>
     private static bool TrySplitSegments(string pattern, out List<string> segments)
     {
         segments = [];
@@ -239,6 +254,9 @@ public sealed class ParallelDiffPathPattern
 
         public PatternSelector? Selector { get; }
 
+        /// <summary>
+        /// member 名と selector の両方を比較して、候補 segment がこの pattern segment に一致するか判定します。
+        /// </summary>
         public bool IsMatch(XPathLikePathSegment candidate)
         {
             if (!string.Equals(MemberName, candidate.MemberName, StringComparison.Ordinal))
@@ -269,11 +287,19 @@ public sealed class ParallelDiffPathPattern
 
         public XPathLikePathSelector? ExactSelector { get; }
 
+        /// <summary>
+        /// 指定した selector を保持し、wildcard を使わない exact selector pattern を生成します。
+        /// </summary>
+        /// <param name="selector">生成した pattern が照合時に比較する selector。</param>
+        /// <returns>指定した <paramref name="selector"/> を exact selector として保持する pattern。</returns>
         public static PatternSelector Exact(XPathLikePathSelector selector)
         {
             return new PatternSelector(matchesAny: false, selector);
         }
 
+        /// <summary>
+        /// wildcard または exact selector の規則で候補 selector が一致するか判定します。
+        /// </summary>
         public bool IsMatch(XPathLikePathSelector candidate)
         {
             if (MatchesAny)
@@ -310,6 +336,7 @@ public static class ParallelDiffEntryPathExtensions
     /// <param name="entry">判定する差分 entry。</param>
     /// <param name="pattern">照合する path pattern。</param>
     /// <returns>一致する場合は <see langword="true"/>。</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entry"/> または <paramref name="pattern"/> が <see langword="null"/> の場合。</exception>
     public static bool PathMatches(
         this ParallelDiffEntry entry,
         ParallelDiffPathPattern pattern)

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -37,6 +37,7 @@
 
 - Status: Done
 - Notes:
+  - T-092でPR #45の差分パスLINQフィルターをレビューし、`*` escape、XML documentation、nullable契約、設計grammar・索引、境界・回帰テストの指摘を解消した
   - T-091でT-090追加分のXML documentationを日本語化した
   - T-090 の polymorphic sequence runtime 型比較とレビュー指摘の XML documentation 修正を完了した
   - T-089 を完了し、generated object view / direct scalar generated member / `Select(...)` 派生 value / dynamic materialized path の `ToString()` を underlying node 表示へ委譲した
@@ -152,6 +153,7 @@
 
 - Status: Done
 - Notes:
+  - T-092はRelease 133テスト、focused 21テスト、format、diff check、coding standards validation、`gpt-5.6-sol / high`同一レビュアー再レビューに成功した
   - T-091はRelease 112テスト、format、diff check、XML整形式、非コメント差分照合、独立reviewに成功した
   - T-090 は Release 112テスト、format、diff check、standards validation、`gpt-5.6-sol / high` 再レビューに成功した
   - T-089 で `dotnet test SSC.sln --configuration Release`、`dotnet format SSC.sln --verify-no-changes`、`git diff --check` が成功した（Markdown lint は missing script のため unsupported）

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -12,6 +12,46 @@
 
 ## Done
 
+- T-092: PR #45 差分パスのLINQフィルターをレビューし、指摘を解消する
+  - Status: 完了（初回レビュー4件と再レビュー1件を解消し、独立検証・同一レビュアー再レビューに合格した）
+  - Phase: Phase 3
+  - Estimate: M
+  - Depends on:
+    - T-077 XPath-like path parser と public result 型の追加
+    - T-079 通常 node 差分の `GetDiffEntries()` 追加
+  - Exit Criteria:
+    - PR #45 の public API、path pattern grammar、matching semantics、例外契約、設計書、テストを独立レビューする
+    - blocking finding を TDD で修正し、必要な happy path・境界・error path をテストで保証する
+    - 新規・変更する関数および public/protected/internal API の XML documentation を自然な日本語にする
+    - `[*]` はwildcard、`[\*]` は `*` をエスケープして通常のkey文字として扱う契約を実装・設計・テストで一致させる
+    - public contract と番号衝突を解消した差分path filter設計書を一致させ、`doc/design/README.md` の索引へ追加する
+    - breaking change の有無を判断し、必要な場合は `Design/BreakingChanges.md` に記録する
+    - 全テスト、format、diff check、coding standards validation、独立再レビューが成功する
+    - PR #45 の branch に修正、追跡、report を commit・push する
+  - Output:
+    - PR #45
+    - `doc/design/detail/10-DiffEntryPathFilter.md`
+    - `src/SSC/ParallelDiffPathPattern.cs`
+    - `tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs`
+    - `reports/task-t-092-initial-review-20260711221140.md`
+    - `reports/task-t-092-review-fix-implementation-20260711222105.md`
+    - `reports/task-t-092-review-fix-verification-20260711222629.md`
+    - `reports/task-t-092-review-fix-implementation-r2-20260711222941.md`
+    - `reports/task-t-092-review-fix-verification-r2-20260711223108.md`
+    - `reports/task-t-092-review-fix-rereview-20260711223300.md`
+    - `reports/task-t-092-review-fix-implementation-r3-20260711223708.md`
+    - `reports/task-t-092-review-fix-rereview-r2-20260711223811.md`
+  - Verification:
+    - TDD赤確認: `[\*]` が未対応でfocused test 21件中1件失敗
+    - `dotnet test SSC.sln --configuration Release` 成功（Unit 52件 / E2E 81件、計133件）
+    - focused unit test 21件成功
+    - `dotnet format SSC.sln --verify-no-changes` 成功
+    - `git diff --check` 成功
+    - 日本語XML documentation standards validation 成功
+    - Markdown lintはrepository wiring不在のためfocused/fullともunsupported
+    - `gpt-5.6-terra / medium` implementation agentで修正
+    - `gpt-5.6-sol / high` の同一reviewerで最終指摘なし
+
 - T-091: T-090で追加したXML documentationを日本語化する
   - Status: 完了（PR #43由来のXML documentationを日本語化し、非コメント差分なしを検証した）
   - Phase: Phase 3

--- a/tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs
+++ b/tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs
@@ -1,0 +1,137 @@
+using SSC;
+
+namespace SSC.Unit.Tests;
+
+public sealed class ParallelDiffPathPatternUnitTests
+{
+    [Fact]
+    public void Parse_WithExactAndWildcardSelectors_MatchesExpectedPath()
+    {
+        // Intent: 変動する board/file/child selector を [*] で吸収し、固定構造と属性名は厳密に比較する。
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+            "Boards[*].Files[*].Document.Root.Children[*].Children[*].Attribute[LastEditingTime].Value");
+
+        bool matched = pattern.IsMatch(
+            "Boards[Board-A].Files[No1/ygx].Document.Root.Children[0].Children[#2].Attribute[LastEditingTime].Value");
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_WithWildcardSelector_MatchesKeyAndOrdinalSelectors()
+    {
+        // Intent: [*] は key text と #ordinal のどちらにも一致する。
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
+
+        Assert.True(pattern.IsMatch("Items[A].Value"));
+        Assert.True(pattern.IsMatch("Items[0].Value"));
+        Assert.True(pattern.IsMatch("Items[#0].Value"));
+    }
+
+    [Fact]
+    public void IsMatch_WithExactSelectors_DistinguishesKeyFromOrdinal()
+    {
+        // Intent: [0] は key、[#0] は ordinal として既存 path grammar の意味を維持する。
+        ParallelDiffPathPattern keyPattern = ParallelDiffPathPattern.Parse("Items[0].Value");
+        ParallelDiffPathPattern ordinalPattern = ParallelDiffPathPattern.Parse("Items[#0].Value");
+
+        Assert.True(keyPattern.IsMatch("Items[0].Value"));
+        Assert.False(keyPattern.IsMatch("Items[#0].Value"));
+        Assert.True(ordinalPattern.IsMatch("Items[#0].Value"));
+        Assert.False(ordinalPattern.IsMatch("Items[0].Value"));
+    }
+
+    [Fact]
+    public void IsMatch_WithDifferentMemberOrSegmentCount_ReturnsFalse()
+    {
+        // Intent: wildcard は selector だけに作用し、member 名や path 深度は曖昧化しない。
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+            "Boards[*].Attribute[LastEditingTime].Value");
+
+        Assert.False(pattern.IsMatch("Boards[A].Attribute[CreatedAt].Value"));
+        Assert.False(pattern.IsMatch("Boards[A].Metadata.Attribute[LastEditingTime].Value"));
+        Assert.False(pattern.IsMatch("Boards.Attribute[LastEditingTime].Value"));
+    }
+
+    [Fact]
+    public void IsMatch_WithEscapedKeyAndDotInsideSelector_PreservesExistingGrammar()
+    {
+        // Intent: bracket 内の dot と既存 escape を通常 path と同じ意味で扱う。
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+            "Items[A.B].Attributes[A\\]B].Value");
+
+        Assert.True(pattern.IsMatch("Items[A.B].Attributes[A\\]B].Value"));
+        Assert.False(pattern.IsMatch("Items[A].Attributes[A\\]B].Value"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(".Items[*]")]
+    [InlineData("Items[*].")]
+    [InlineData("Items[]")]
+    [InlineData("Items[A")]
+    [InlineData("Items[A][B]")]
+    [InlineData("Items[A\\x]")]
+    public void TryParse_WithInvalidPattern_ReturnsFalse(string patternText)
+    {
+        // Intent: 解釈不能な pattern は例外を漏らさず TryParse=false とする。
+        bool parsed = ParallelDiffPathPattern.TryParse(patternText, out ParallelDiffPathPattern? pattern);
+
+        Assert.False(parsed);
+        Assert.Null(pattern);
+    }
+
+    [Fact]
+    public void Parse_WithInvalidPattern_ThrowsFormatException()
+    {
+        // Intent: Parse は不正構文を明示的な FormatException として通知する。
+        Assert.Throws<FormatException>(() => ParallelDiffPathPattern.Parse("Items[]"));
+    }
+
+    [Fact]
+    public void IsMatch_WithInvalidCandidatePath_ReturnsFalse()
+    {
+        // Intent: 外部から渡された不正な diff path は一致なしとして扱う。
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
+
+        Assert.False(pattern.IsMatch("Items[A"));
+    }
+
+    [Fact]
+    public void PathMatches_CanBeUsedDirectlyFromLinqWhere()
+    {
+        // Intent: 全差分を保持したまま、標準 LINQ の Where で対象差分だけ判定から除外できる。
+        ParallelDiffEntry[] allDiffs =
+        [
+            new ParallelDiffEntry
+            {
+                Path = "Boards[A].Files[No1/ygx].Document.Root.Children[0].Children[0].Attribute[LastEditingTime].Value",
+            },
+            new ParallelDiffEntry
+            {
+                Path = "Boards[A].Files[No1/ygx].Document.Root.Children[0].Children[0].Attribute[Width].Value",
+            },
+        ];
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+            "Boards[*].Files[*].Document.Root.Children[*].Children[*].Attribute[LastEditingTime].Value");
+
+        ParallelDiffEntry[] effectiveDiffs = allDiffs
+            .Where(entry => !entry.PathMatches(pattern))
+            .ToArray();
+
+        ParallelDiffEntry remaining = Assert.Single(effectiveDiffs);
+        Assert.Contains("Attribute[Width]", remaining.Path, StringComparison.Ordinal);
+        Assert.Equal(2, allDiffs.Length);
+    }
+
+    [Fact]
+    public void PathMatches_WithNullArguments_ThrowsArgumentNullException()
+    {
+        // Intent: extension の引数不正を既存 BCL 方針と同じ ArgumentNullException で通知する。
+        ParallelDiffEntry entry = new() { Path = "Items[A].Value" };
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
+
+        Assert.Throws<ArgumentNullException>(() => ParallelDiffEntryPathExtensions.PathMatches(null!, pattern));
+        Assert.Throws<ArgumentNullException>(() => entry.PathMatches(null!));
+    }
+}

--- a/tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs
+++ b/tests/SSC.Unit.Tests/ParallelDiffPathPatternUnitTests.cs
@@ -2,12 +2,17 @@ using SSC;
 
 namespace SSC.Unit.Tests;
 
+/// <summary>
+/// 差分 path pattern の構文、照合、および比較結果を変更しない絞り込み契約を検証します。
+/// </summary>
 public sealed class ParallelDiffPathPatternUnitTests
 {
+    /// <summary>
+    /// 固定構造と属性名を比較しながら、変動する selector を <c>[*]</c> で吸収できることを検証します。
+    /// </summary>
     [Fact]
     public void Parse_WithExactAndWildcardSelectors_MatchesExpectedPath()
     {
-        // Intent: 変動する board/file/child selector を [*] で吸収し、固定構造と属性名は厳密に比較する。
         ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
             "Boards[*].Files[*].Document.Root.Children[*].Children[*].Attribute[LastEditingTime].Value");
 
@@ -17,10 +22,12 @@ public sealed class ParallelDiffPathPatternUnitTests
         Assert.True(matched);
     }
 
+    /// <summary>
+    /// <c>[*]</c> が key selector と ordinal selector の両方に一致することを検証します。
+    /// </summary>
     [Fact]
     public void IsMatch_WithWildcardSelector_MatchesKeyAndOrdinalSelectors()
     {
-        // Intent: [*] は key text と #ordinal のどちらにも一致する。
         ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
 
         Assert.True(pattern.IsMatch("Items[A].Value"));
@@ -28,10 +35,12 @@ public sealed class ParallelDiffPathPatternUnitTests
         Assert.True(pattern.IsMatch("Items[#0].Value"));
     }
 
+    /// <summary>
+    /// key の <c>[0]</c> と ordinal の <c>[#0]</c> を既存 path grammar に従って区別することを検証します。
+    /// </summary>
     [Fact]
     public void IsMatch_WithExactSelectors_DistinguishesKeyFromOrdinal()
     {
-        // Intent: [0] は key、[#0] は ordinal として既存 path grammar の意味を維持する。
         ParallelDiffPathPattern keyPattern = ParallelDiffPathPattern.Parse("Items[0].Value");
         ParallelDiffPathPattern ordinalPattern = ParallelDiffPathPattern.Parse("Items[#0].Value");
 
@@ -41,10 +50,12 @@ public sealed class ParallelDiffPathPatternUnitTests
         Assert.False(ordinalPattern.IsMatch("Items[0].Value"));
     }
 
+    /// <summary>
+    /// wildcard が selector だけに作用し、member 名と path 深度を曖昧にしないことを検証します。
+    /// </summary>
     [Fact]
     public void IsMatch_WithDifferentMemberOrSegmentCount_ReturnsFalse()
     {
-        // Intent: wildcard は selector だけに作用し、member 名や path 深度は曖昧化しない。
         ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
             "Boards[*].Attribute[LastEditingTime].Value");
 
@@ -53,17 +64,38 @@ public sealed class ParallelDiffPathPatternUnitTests
         Assert.False(pattern.IsMatch("Boards.Attribute[LastEditingTime].Value"));
     }
 
+    /// <summary>
+    /// bracket 内の dot、閉じ bracket、backslash、および <c>#</c> の既存 escape を通常 path と同じ意味で扱うことを検証します。
+    /// </summary>
     [Fact]
     public void IsMatch_WithEscapedKeyAndDotInsideSelector_PreservesExistingGrammar()
     {
-        // Intent: bracket 内の dot と既存 escape を通常 path と同じ意味で扱う。
         ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
-            "Items[A.B].Attributes[A\\]B].Value");
+            "Items[A.B].Attributes[A\\]B].EscapedBackslash[A\\\\B].EscapedHash[\\#0].Value");
 
-        Assert.True(pattern.IsMatch("Items[A.B].Attributes[A\\]B].Value"));
-        Assert.False(pattern.IsMatch("Items[A].Attributes[A\\]B].Value"));
+        Assert.True(pattern.IsMatch("Items[A.B].Attributes[A\\]B].EscapedBackslash[A\\\\B].EscapedHash[\\#0].Value"));
+        Assert.False(pattern.IsMatch("Items[A].Attributes[A\\]B].EscapedBackslash[A\\\\B].EscapedHash[\\#0].Value"));
+        Assert.False(pattern.IsMatch("Items[A.B].Attributes[A\\]B].EscapedBackslash[A\\\\B].EscapedHash[#0].Value"));
     }
 
+    /// <summary>
+    /// <c>[\\*]</c> が <c>*</c> をエスケープして通常文字の key として扱い、<c>[*]</c> の wildcard と区別することを検証します。
+    /// </summary>
+    [Fact]
+    public void IsMatch_WithEscapedAsteriskSelector_TreatsAsteriskAsRegularKeyCharacter()
+    {
+        ParallelDiffPathPattern escapedPattern = ParallelDiffPathPattern.Parse("Items[\\*].Value");
+        ParallelDiffPathPattern wildcardPattern = ParallelDiffPathPattern.Parse("Items[*].Value");
+
+        Assert.True(escapedPattern.IsMatch("Items[*].Value"));
+        Assert.False(escapedPattern.IsMatch("Items[other].Value"));
+        Assert.True(wildcardPattern.IsMatch("Items[*].Value"));
+        Assert.True(wildcardPattern.IsMatch("Items[other].Value"));
+    }
+
+    /// <summary>
+    /// 解釈不能な non-null pattern を例外を漏らさず <see langword="false"/> として扱うことを検証します。
+    /// </summary>
     [Theory]
     [InlineData("")]
     [InlineData(".Items[*]")]
@@ -74,33 +106,70 @@ public sealed class ParallelDiffPathPatternUnitTests
     [InlineData("Items[A\\x]")]
     public void TryParse_WithInvalidPattern_ReturnsFalse(string patternText)
     {
-        // Intent: 解釈不能な pattern は例外を漏らさず TryParse=false とする。
         bool parsed = ParallelDiffPathPattern.TryParse(patternText, out ParallelDiffPathPattern? pattern);
 
         Assert.False(parsed);
         Assert.Null(pattern);
     }
 
+    /// <summary>
+    /// <see langword="null"/> の pattern を TryParse が失敗として扱い、解析結果を返さないことを検証します。
+    /// </summary>
+    [Fact]
+    public void TryParse_WithNullPattern_ReturnsFalse()
+    {
+        bool parsed = ParallelDiffPathPattern.TryParse(null, out ParallelDiffPathPattern? pattern);
+
+        Assert.False(parsed);
+        Assert.Null(pattern);
+    }
+
+    /// <summary>
+    /// Parse が不正な non-null pattern を <see cref="FormatException"/> として通知することを検証します。
+    /// </summary>
     [Fact]
     public void Parse_WithInvalidPattern_ThrowsFormatException()
     {
-        // Intent: Parse は不正構文を明示的な FormatException として通知する。
         Assert.Throws<FormatException>(() => ParallelDiffPathPattern.Parse("Items[]"));
     }
 
+    /// <summary>
+    /// Parse が <see langword="null"/> の pattern を <see cref="ArgumentNullException"/> として通知することを検証します。
+    /// </summary>
+    [Fact]
+    public void Parse_WithNullPattern_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ParallelDiffPathPattern.Parse(null!));
+    }
+
+    /// <summary>
+    /// 外部から渡された不正な diff path を一致なしとして扱うことを検証します。
+    /// </summary>
     [Fact]
     public void IsMatch_WithInvalidCandidatePath_ReturnsFalse()
     {
-        // Intent: 外部から渡された不正な diff path は一致なしとして扱う。
         ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
 
         Assert.False(pattern.IsMatch("Items[A"));
     }
 
+    /// <summary>
+    /// IsMatch が <see langword="null"/> の path を <see cref="ArgumentNullException"/> として通知することを検証します。
+    /// </summary>
+    [Fact]
+    public void IsMatch_WithNullPath_ThrowsArgumentNullException()
+    {
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
+
+        Assert.Throws<ArgumentNullException>(() => pattern.IsMatch(null!));
+    }
+
+    /// <summary>
+    /// 全差分を保持したまま、標準 LINQ の Where で一致する差分だけを除外できることを検証します。
+    /// </summary>
     [Fact]
     public void PathMatches_CanBeUsedDirectlyFromLinqWhere()
     {
-        // Intent: 全差分を保持したまま、標準 LINQ の Where で対象差分だけ判定から除外できる。
         ParallelDiffEntry[] allDiffs =
         [
             new ParallelDiffEntry
@@ -124,14 +193,52 @@ public sealed class ParallelDiffPathPatternUnitTests
         Assert.Equal(2, allDiffs.Length);
     }
 
+    /// <summary>
+    /// path filter が比較済み result の Issues、Root の差分状態、および CompareIgnore による比較対象除外を変更しないことを検証します。
+    /// </summary>
+    [Fact]
+    public void PathMatches_FilteringDoesNotChangeResultStateOrCompareIgnoreBehavior()
+    {
+        PathFilterRegressionModel[] models =
+        [
+            new PathFilterRegressionModel { Included = "left", Ignored = "left ignored" },
+            new PathFilterRegressionModel { Included = "right", Ignored = "right ignored" },
+        ];
+        CompareResult<PathFilterRegressionModel> result = ParallelCompareApi.Compare(models);
+        IReadOnlyList<CompareIssue> issuesBeforeFiltering = result.Issues;
+        bool hasDifferencesBeforeFiltering = ((IParallelNode)result.Root!).HasDifferences();
+        ParallelDiffEntry[] allDiffs = result.GetDiffEntries().ToArray();
+        ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Included");
+
+        ParallelDiffEntry[] filteredDiffs = allDiffs.Where(entry => !entry.PathMatches(pattern)).ToArray();
+
+        Assert.Empty(result.Issues);
+        Assert.Same(issuesBeforeFiltering, result.Issues);
+        Assert.True(hasDifferencesBeforeFiltering);
+        Assert.True(((IParallelNode)result.Root!).HasDifferences());
+        Assert.Single(allDiffs);
+        Assert.Equal("Included", allDiffs[0].Path);
+        Assert.Empty(filteredDiffs);
+    }
+
+    /// <summary>
+    /// PathMatches が null の entry と pattern を <see cref="ArgumentNullException"/> として通知することを検証します。
+    /// </summary>
     [Fact]
     public void PathMatches_WithNullArguments_ThrowsArgumentNullException()
     {
-        // Intent: extension の引数不正を既存 BCL 方針と同じ ArgumentNullException で通知する。
         ParallelDiffEntry entry = new() { Path = "Items[A].Value" };
         ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse("Items[*].Value");
 
         Assert.Throws<ArgumentNullException>(() => ParallelDiffEntryPathExtensions.PathMatches(null!, pattern));
         Assert.Throws<ArgumentNullException>(() => entry.PathMatches(null!));
+    }
+
+    private sealed class PathFilterRegressionModel
+    {
+        public string? Included { get; init; }
+
+        [CompareIgnore]
+        public string? Ignored { get; init; }
     }
 }


### PR DESCRIPTION
## 概要

`GetDiffEntries()` が返す差分一覧を、XPath-likeなpath patternで後段フィルタリングできるAPIを追加します。

既存の `[CompareIgnore]` とは分離し、比較済みの `ParallelDiffEntry` 一覧をLINQで選別します。

関連issue: なし（既存Draft PR #45のレビュー修正をT-092として追跡）

## 変更内容

- `ParallelDiffPathPattern` を追加
- `[*]` で任意のkey selectorまたはordinal selectorへ一致
- `[\*]` で `*` をエスケープし、通常文字のkeyとして扱う
- `ParallelDiffEntry.PathMatches(...)` を追加
- 通常のLINQ `Where` から利用可能
- 日本語XML documentation、設計書、境界・回帰単体テストを追加

## 利用例

```csharp
ParallelDiffPathPattern ignoreLastEditingTime =
    ParallelDiffPathPattern.Parse(
        "Boards[*].Files[*].Document.Root.Children[*].Children[*].Attribute[LastEditingTime].Value");

ParallelDiffEntry[] effectiveDiffs = result
    .GetDiffEntries()
    .Where(entry => !entry.PathMatches(ignoreLastEditingTime))
    .ToArray();
```

## CompareIgnoreへの影響

`CompareIgnoreAttribute`、metadata解決、比較node構築、`GetDiffEntries()` の差分生成規則は変更していません。

## 検証

- TDD赤確認: `[\*]` 未対応でfocused test 21件中1件失敗
- `dotnet test SSC.sln --configuration Release`: 成功（Unit 52件 / E2E 81件、計133件）
- focused unit test: 21件成功
- `dotnet format SSC.sln --verify-no-changes`: 成功
- `git diff --check`: 成功
- `gpt-5.6-sol / high` の同一レビュアー再レビュー: 指摘なし
- GitHub Actions `PR .NET Tests`: 成功

Markdown lintはrepository wiring不在のためfocused/fullともunsupportedです。