### PR TITLE
差分entryの利用側定義path投影APIを追加する

### DIFF
--- a/.github/workflows/pr-xunit-tests.yml
+++ b/.github/workflows/pr-xunit-tests.yml
@@ -65,12 +65,86 @@ jobs:
         if: ${{ steps.discover.outputs.has_tests == 'true' }}
         shell: bash
         run: |
+          results_dir="$GITHUB_WORKSPACE/artifacts/test-results"
+          rm -rf "$results_dir"
+          mkdir -p "$results_dir"
+          test_status=0
+
           while IFS= read -r project; do
             [[ -z "$project" ]] && continue
             echo "Testing: $project"
-            dotnet restore "$project"
-            dotnet test "$project" --configuration Release --no-restore --verbosity minimal
+
+            result_name="$(printf '%s' "${project%.csproj}" | sed -E 's#[^A-Za-z0-9._-]+#_#g')"
+            if ! dotnet restore "$project"; then
+              test_status=1
+              continue
+            fi
+
+            if ! dotnet test "$project" \
+              --configuration Release \
+              --no-restore \
+              --verbosity minimal \
+              --logger "trx;LogFileName=${result_name}.trx" \
+              --results-directory "$results_dir"; then
+              test_status=1
+            fi
           done <<< "${{ steps.discover.outputs.test_projects }}"
+
+          exit "$test_status"
+
+      - name: Create test result manifest
+        if: ${{ always() && steps.discover.outputs.has_tests == 'true' }}
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TEST_PROJECTS: ${{ steps.discover.outputs.test_projects }}
+        run: |
+          results_dir="$GITHUB_WORKSPACE/artifacts/test-results"
+          mkdir -p "$results_dir"
+
+          {
+            echo "# SSC .NET test results"
+            echo
+            echo "- Repository: \`$GITHUB_REPOSITORY\`"
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Workflow run: \`$GITHUB_RUN_ID\`"
+            echo "- Run attempt: \`$GITHUB_RUN_ATTEMPT\`"
+            if [[ -n "${PR_NUMBER:-}" ]]; then
+              echo "- Pull request: \`#$PR_NUMBER\`"
+            fi
+            echo "- Authorization: The repository owner explicitly approved retaining these test results as a GitHub Actions artifact for ChatGPT-assisted review when this workflow behavior was added in PR #46."
+            echo
+            echo "## Test projects"
+            while IFS= read -r project; do
+              [[ -z "$project" ]] && continue
+              echo "- \`$project\`"
+            done <<< "$TEST_PROJECTS"
+            echo
+            echo "## Result files"
+
+            shopt -s nullglob
+            trx_files=("$results_dir"/*.trx)
+            if [[ ${#trx_files[@]} -eq 0 ]]; then
+              echo "- No TRX files were produced."
+            else
+              for trx_file in "${trx_files[@]}"; do
+                echo "- \`$(basename "$trx_file")\`"
+              done
+            fi
+          } > "$results_dir/manifest.md"
+
+          cat "$results_dir/manifest.md" >> "$GITHUB_STEP_SUMMARY"
+
+      # The repository owner explicitly approved retaining this artifact so
+      # ChatGPT-assisted review can inspect the same test evidence as maintainers.
+      - name: Upload .NET test results for ChatGPT review
+        if: ${{ always() && steps.discover.outputs.has_tests == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssc-pr-test-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/test-results
+          if-no-files-found: error
+          retention-days: 7
 
       - name: No test projects found
         if: ${{ steps.discover.outputs.has_tests != 'true' }}

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ For `ParallelDiffEntryKind.Node`, `GetNodeByPath(entry.Path)` resolves the same 
 IReadOnlyList<ParallelDiffEntry> entries = result.GetDiffEntries();
 
 ParallelDiffEntry priceDiff = entries.Single(entry => entry.Path == "Items[2].Price");
-
 IParallelNode? sameNode = result.GetNodeByPath(priceDiff.Path);
 bool resolvesSameNode = ReferenceEquals(priceDiff.Node, sameNode); // true
 
@@ -196,7 +195,6 @@ CompareResult<OptionalProductModel> emptyContainerResult = ParallelCompareApi.Co
 IReadOnlyList<ParallelDiffEntry> containerEntries = emptyContainerResult.GetDiffEntries();
 ParallelDiffEntry containerDiff = containerEntries.Single(entry =>
     entry.Kind == ParallelDiffEntryKind.ContainerPresence);
-
 IParallelNode? unresolved = emptyContainerResult.GetNodeByPath(containerDiff.Path); // null
 
 Console.WriteLine(containerDiff);
@@ -207,6 +205,52 @@ public sealed class OptionalProductModel
     public List<ProductItem>? Items { get; init; }
 }
 ```
+
+## Custom Diff Entry Paths
+
+A standard path (canonical path) is the official comparison-tree address stored in `ParallelDiffEntry.Path`.
+A custom path is a caller-defined representation used for display, classification, and path-pattern filtering.
+Custom path projection never replaces the standard path, so node lookup continues to use `projection.Entry.Path`.
+
+Implement `IParallelDiffPathProjector` to keep, replace, or omit each standard path segment.
+The projection context exposes the current node, parent node, sibling nodes, ancestors, and the standard segment.
+
+```csharp
+public sealed class ProductPathProjector : IParallelDiffPathProjector
+{
+    public ParallelDiffPathSegmentProjection Project(
+        ParallelDiffPathProjectionContext context)
+    {
+        ParallelDiffPathSegment standard = context.Current.StandardSegment;
+
+        return standard.MemberName == "Items"
+            ? ParallelDiffPathSegmentProjection.Replace(
+                standard.WithMemberName("Products"))
+            : ParallelDiffPathSegmentProjection.KeepStandard();
+    }
+}
+
+IReadOnlyList<ParallelDiffEntryPathProjection> projections =
+    result.GetDiffEntryPathProjections(new ProductPathProjector());
+
+ParallelDiffEntryPathProjection projectedPrice = projections.Single(
+    projection => projection.Entry.Path == "Items[2].Price");
+
+Console.WriteLine(projectedPrice.Entry.Path);    // Items[2].Price
+Console.WriteLine(projectedPrice.ProjectedPath); // Products[2].Price
+
+ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+    "Products[*].Price");
+
+bool matchesCustomPath = projectedPrice.PathMatches(pattern); // true
+IParallelNode? standardNode = result.GetNodeByPath(projectedPrice.Entry.Path);
+```
+
+`WithMemberName()` preserves the existing selector. For example, `Items[2]` becomes `Products[2]`, while an ordinal selector such as `Items[#0]` becomes `Products[#0]`.
+The projector may inspect `context.Current.Node.GetValue(modelIndex)` when the custom name depends on runtime model values.
+Domain-specific rules, such as treating an XML node's `Name` property as the path name, belong in the caller's projector rather than SSC.
+
+See `doc/design/detail/11-DiffEntryCustomPath.md` for the responsibility boundary, terminology, API contract, and recursive-model example.
 
 ## Source Generator Example
 

--- a/doc/design/detail/11-DiffEntryCustomPath.md
+++ b/doc/design/detail/11-DiffEntryCustomPath.md
@@ -1,30 +1,57 @@
-# Diff Entry Custom Path Projection
+# 差分 entry の利用側定義 path 投影（Diff Entry Custom Path Projection）
 
 ## 1. 目的
 
-`CompareResult<T>.GetDiffEntries()` が返す差分 entry に対し、SSC が生成する既存の path を変更せず、利用側が用途に応じた別の path 表現を生成できるようにする。
+`CompareResult<T>.GetDiffEntries()` が返す差分 entry に対し、SSC が生成する既存 path を変更せず、利用側が用途に応じた別の path 表現を生成できるようにする。
 
-再帰的なモデルでは、既存 path が次のように同じ member 名を繰り返すことがある。
+再帰的な model では、既存 path が次のように同じ member 名を繰り返すことがある。
 
 ```text
 Root.Children[#0].Children[#0].Fields[#0].Value
 ```
 
-利用側が各 node の `Name` などの実行時の値を使い、次のような読みやすい path を生成できることを目的とする。
+利用側が各 node の `Name` など、比較対象 instance が持つ実際の値を使い、次のような読みやすい path を生成できることを目的とする。
 
 ```text
 Root.Child1[#0].Child2[#0].Attribute1[#0].Value
 ```
 
-本機能は path の表示と絞り込みを改善するための後段処理であり、比較対象、比較結果、sequence の対応付けには影響しない。
+本機能は path の表示、分類、絞り込みを改善するための比較後処理である。比較対象、比較結果、container 要素の対応付けには影響しない。
 
 ## 2. 用語
 
-### 2.1 標準 path（canonical path）
+本設計では英語の用語だけで意味を省略せず、次の意味で使用する。
 
-標準 path は、SSC が現在 `ParallelDiffEntry.Path` に格納している正式な path を指す。
+| 用語 | 本設計での意味 |
+|---|---|
+| entry | 差分1件を表す `ParallelDiffEntry` またはその関連結果 |
+| node | SSC の比較 tree を構成する `IParallelNode` 1件 |
+| tree | 親子関係で構成される階層構造 |
+| member | C# model の property または field |
+| container | `List`、array、`IEnumerable`、dictionary など複数要素を保持する member |
+| sequence | 順序を持つ container 要素列 |
+| key | container 要素を対応付ける識別値 |
+| ordinal | key を持たない sequence 内の並び順。`0` から始まる |
+| model slot | 比較に渡した各 model の値位置。`modelIndex` と同じ意味 |
+| standard path / canonical path | SSC が `ParallelDiffEntry.Path` に格納する既存の正式 path。本設計では「標準 path」と呼ぶ |
+| custom path | 利用側が標準 path から生成する別表現。本設計では「利用側定義 path」と呼ぶ |
+| alias | 同じ対象に付ける別名 |
+| projection | 元の情報を保持したまま、別の見え方へ変換する処理。本設計では「投影」と呼ぶ |
+| projector | 投影規則を実装する利用側 component。本設計では「投影器」と呼ぶ |
+| segment | dot で区切られた path の構成要素1件 |
+| selector | container 要素を識別する `[]` 部分 |
+| context | 投影器の判断材料として SSC が渡す現在位置の情報。本設計では「文脈情報」と呼ぶ |
+| sibling | 同じ親を持つ兄弟 node |
+| ancestor | 現在位置より上位にある祖先 node |
+| fallback | 利用側定義名を決められない場合に安全な既定動作へ戻すこと |
+| pattern | path を照合するためのひな形 |
+| wildcard | 任意の値へ一致する記号。既存 API では selector の `[*]` |
 
-`canonical` は「基準となる正式な表現」という意味である。本設計では英語だけで呼ばず、以降は原則として「標準 path」と記載する。
+### 2.1 標準 path
+
+標準 path は、SSC が現在 `ParallelDiffEntry.Path` に格納している正式な path である。
+
+`canonical` は「基準となる正式な表現」という意味だが、本設計では英語だけで呼ばず、以降は「標準 path」と記載する。
 
 例:
 
@@ -37,66 +64,32 @@ Root.Children[#0].Fields[#0].Value
 
 - `GetNodeByPath()` で node を取得できる
 - `ParallelDiffEntry.Path` と `ParallelDiffEntry.ParentPath` に使用される
-- `ParallelDiffEntry.PathMatches()` の照合対象になる
-- 既存 API の後方互換対象である
+- 既存 `ParallelDiffEntry.PathMatches()` の照合対象になる
+- 後方互換の対象である
 
-### 2.2 利用側定義 path（custom path）
+### 2.2 利用側定義 path
 
-利用側定義 path は、利用側が標準 path を別の意味表現へ変換した path を指す。
-
-`custom` は「利用側が用途に合わせて定義する」という意味である。
+利用側定義 path は、利用側が標準 path を別の意味表現へ変換した path である。
 
 例:
 
 ```text
-Standard path:
+標準 path:
 Root.Children[#0].Fields[#0].Value
 
-Custom path:
+利用側定義 path:
 Root.Child1[#0].Attribute1[#0].Value
 ```
 
-利用側定義 path は表示、分類、filter に使用する。初期実装では node の住所としては扱わない。
+利用側定義 path は表示、分類、絞り込みに使用する。初期実装では node の住所として扱わない。
 
-### 2.3 別名（alias）
+### 2.3 Segment と selector
 
-`alias` は「同じ対象に付ける別の名前」を意味する。
-
-例えば `Children` を `Child1` と表示する場合、`Child1` は `Children` segment の別名に相当する。
-
-ただし本設計では、固定文字列の別名だけでなく実行時の node 値から名前を決めるため、公開 API の中心用語には `alias` ではなく `projection` を使う。
-
-### 2.4 投影（projection）
-
-`projection` は「元の情報を保持しながら、必要な見え方へ変換する処理」を意味する。
-
-本設計では、標準 path の各構成要素を次のいずれかへ変換する処理を指す。
-
-- 標準のまま維持する
-- 別の構成要素へ置き換える
-- 利用側定義 path から省略する
-
-標準 path 自体は変更しない。
-
-### 2.5 投影器（projector）
-
-`projector` は projection を実行する利用側実装を指す。
-
-SSC は node と path の構造情報を projector に渡す。projector は、その情報から利用側定義 path の構成要素を返す。
-
-SSC は `Name`、`Children`、`Attributes` などの業務上の意味を解釈しない。
-
-### 2.6 区間（segment）
-
-`segment` は dot で区切られた path の構成要素1件を指す。
-
-例:
+次の path は3 segment で構成される。
 
 ```text
 Root.Children[#0].Value
 ```
-
-この path は次の3 segment で構成される。
 
 ```text
 Root
@@ -104,47 +97,40 @@ Children[#0]
 Value
 ```
 
-### 2.7 選択子（selector）
-
-`selector` は、container member 配下の要素を識別する `[]` 部分を指す。
-
-例:
+`Children[#0]` の `[#0]` が selector である。
 
 ```text
-Items[A]
-Items[#0]
+Items[A]   key selector。key text A で要素を識別する
+Items[#0]  ordinal selector。並び順 0 で要素を識別する
 ```
 
-- `[A]` は key selector。比較 key の文字列表現 `A` で要素を識別する
-- `[#0]` は ordinal selector。key を持たない sequence の並び順 `0` で要素を識別する
+具体的な path segment では wildcard `[*]` を使用しない。`[*]` は `ParallelDiffPathPattern` 側だけの表現とする。
 
-具体的な path segment では wildcard selector `[*]` を使用しない。`[*]` は pattern 側だけの表現とする。
+### 2.4 投影と投影器
 
-### 2.8 文脈情報（context）
+投影は、標準 path の各 segment を次のいずれかへ変換する処理である。
 
-`context` は、projector が判断に使う現在位置の情報を指す。
+- 標準 segment のまま維持する
+- 別の具体的 segment へ置き換える
+- 利用側定義 path から省略する
 
-本設計では次の情報を含む。
+投影器は、この判断を行う利用側実装である。
 
-- 現在の標準 path segment
-- 親 node
-- 現在の node
-- 同じ child set に属する sibling node 一覧
-- 現在位置より上位の ancestor 情報
+SSC は node と path の構造情報を投影器へ渡す。投影器は利用側定義 path での segment を返す。
 
-`sibling` は「同じ親を持つ兄弟 node」、`ancestor` は「現在位置より上位にある祖先 node」を意味する。
+SSC は `Name`、`Children`、`Fields` などの業務上の意味を解釈しない。
 
-### 2.9 フォールバック（fallback）
+### 2.5 Fallback
 
-`fallback` は「利用側が別名を決定できない場合に、安全な既定動作へ戻すこと」を意味する。
-
-本設計で推奨する fallback は、該当 segment を標準 path のまま維持することである。
+利用側が runtime の値から別名を決定できない場合は、標準 segment の維持を推奨する。
 
 ```text
 Children[#0]
     ↓ 別名を決定できない
 Children[#0]
 ```
+
+SSC は model slot 間のどの値を採用すべきか自動判断しない。
 
 ## 3. 現状と問題
 
@@ -155,15 +141,9 @@ container child では次の規則を使用する。
 - `IParallelNode.KeyText` がある場合は key selector
 - `IParallelNode.KeyText` がない場合は ordinal selector
 
-そのため、汎用的な再帰モデルでは次のような path になる。
+この規則は SSC の構造を正確に表すが、汎用的な再帰 model では利用者が知りたい意味を直接表さない場合がある。
 
-```text
-Root.Children[#0].Children[#0].Fields[#0].Value
-```
-
-この path は SSC の model 構造としては正しいが、利用者が知りたい意味を直接表さない場合がある。
-
-例えば次の model を考える。
+例として次の model を考える。
 
 ```csharp
 public sealed class Document
@@ -197,14 +177,26 @@ Root
       └─ Attribute1 = "0"
 ```
 
-しかし SSC が `Name` を path 名として自動解釈することはできない。
+標準 path:
+
+```text
+Root.Children[#0].Children[#0].Fields[#0].Value
+```
+
+利用側が望む path:
+
+```text
+Root.Child1[#0].Child2[#0].Attribute1[#0].Value
+```
+
+SSC が `Name` を自動採用することはできない。
 
 - `Name` が path 名であるとは限らない
-- 別の model では `Code`、`Id`、`Label` などが意味名かもしれない
-- model slot 間で値が異なる場合の採用規則は利用側ごとに異なる
-- 同名 sibling の識別規則も利用側ごとに異なる
+- 別 model では `Code`、`Id`、`Label` が意味名かもしれない
+- model slot 間で名前が異なる場合の採用規則は利用側ごとに異なる
+- 同名 sibling の区別規則も利用側ごとに異なる
 
-SSC は判断材料を渡し、意味の決定は利用側に委ねる必要がある。
+SSC は判断材料だけを渡し、意味の決定は利用側に委ねる必要がある。
 
 ## 4. 責務境界
 
@@ -214,10 +206,10 @@ SSC は次を担当する。
 
 1. 既存の標準 path を変更せず生成する
 2. 標準 path を構造化された segment と selector として扱う
-3. path 生成時に把握している node context を projector へ渡す
-4. projector の結果を SSC の escape 規則で path 文字列へ変換する
-5. 標準 path と利用側定義 path を同じ結果オブジェクトから参照できるようにする
-6. 利用側定義 path に対して既存 `ParallelDiffPathPattern` を適用できるようにする
+3. path 生成時に把握している node の文脈情報を投影器へ渡す
+4. 投影器が返した具体的 segment を標準 path と同じ grammar で文字列化する
+5. 標準 entry と利用側定義 path を同じ結果から参照できるようにする
+6. 利用側定義 path に既存 `ParallelDiffPathPattern` を適用できるようにする
 7. 既存 `GetDiffEntries()` の件数、順序、path、node 参照を維持する
 
 ### 4.2 利用側の責務
@@ -225,24 +217,22 @@ SSC は次を担当する。
 利用側は次を担当する。
 
 1. どの member を置換または省略するか決める
-2. node のどの実行時の値を利用側定義名として使うか決める
+2. node のどの runtime 値を利用側定義名として使うか決める
 3. model slot 間で候補名が異なる場合の規則を決める
 4. 同名 sibling をどう区別するか決める
-5. 名前を決定できない場合に標準 segment へ戻すか、別の名前を使うか決める
-6. 利用側定義 path を report、log、分類へどう表示するか決める
+5. 名前を決定できない場合の fallback を決める
+6. 利用側定義 path をレポート、ログ、分類へどう表示するか決める
 
 ### 4.3 SSC が解釈しない情報
 
-SSC は次の意味を自動判定しない。
+SSC は次のような model 固有の意味を自動判定しない。
 
 ```text
-Name        = node 名
-Children    = XML の子要素
-Fields      = 属性
-Value       = report では省略可能
+Name      = node 名
+Children  = XML の子要素
+Fields    = 属性
+Value     = レポートでは省略可能
 ```
-
-これらは model 固有または利用用途固有の規則である。
 
 ## 5. 非目的
 
@@ -250,26 +240,35 @@ Value       = report では省略可能
 
 - `ParallelDiffEntry.Path` の意味変更
 - `ParallelDiffEntry.ParentPath` の意味変更
-- `GetNodeByPath()` による利用側定義 path の解決
-- `CompareConfiguration` への path projector 設定追加
+- 利用側定義 path を使う `GetNodeByPath()` 相当 API
+- `CompareConfiguration` への投影器設定追加
 - 比較対象 member の変更
 - `CompareKey` の代替
 - sequence alignment の変更
-- `CompareIssue.Path` の projection
-- XML、JSON、tree model 固有の projector 実装
+- `CompareIssue.Path` の投影
+- XML、JSON、tree model 固有の投影器実装
 - property 名から `Name` や `Id` を自動発見する規則
 - 利用側定義 path の一意性保証
 - member 名 wildcard や任意深度 wildcard の追加
-- report 用の `[#0]` から `[0]` への表記変換
+- `[#0]` を表示上の `[0]` へ自動変換する処理
 - 正規表現による path 変換
+
+`CompareConfiguration` に投影器を置かない理由は、同じ比較結果へ複数の見え方を適用できるようにするためである。
+
+```csharp
+var reportPaths = result.GetDiffEntryPathProjections(reportProjector);
+var logPaths = result.GetDiffEntryPathProjections(logProjector);
+```
+
+投影は比較設定ではなく、比較後の出力表現である。
 
 ## 6. 固定 alias attribute を対象外とする理由
 
-### 6.1 alias attribute の想定例
+### 6.1 Alias attribute とは
 
-`attribute` は C# の class、property、field などへ付加する metadata を意味する。
+C# の attribute は、class、property、field などに付加する metadata である。
 
-固定 alias attribute を導入する場合、概念的には次のような API になる。
+固定 alias attribute を導入する場合、概念的には次の API になる。
 
 ```csharp
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
@@ -294,7 +293,7 @@ public sealed class Order
 }
 ```
 
-この場合、次の固定置換は可能である。
+この仕組みなら固定置換は可能である。
 
 ```text
 Items[100].Price
@@ -304,7 +303,7 @@ Lines[100].Price
 
 ### 6.2 今回の要求を満たせない理由
 
-再帰 model で必要になる名前は、property に固定された名前ではなく各 node の実行時の値である。
+再帰 model で必要になる名前は、property に固定された名前ではなく各 node の runtime 値である。
 
 ```csharp
 public sealed class TreeNode
@@ -315,7 +314,7 @@ public sealed class TreeNode
 }
 ```
 
-同じ `Children` property の各要素が次の異なる名前を持つ。
+同じ `Children` property の要素が、実行時にはそれぞれ異なる名前を持つ。
 
 ```text
 Child1
@@ -323,27 +322,25 @@ Child2
 Child3
 ```
 
-次のような固定 attribute では表現できない。
+次の固定 attribute では表現できない。
 
 ```csharp
 [DiffPathAlias("Child1")]
 public List<TreeNode> Children { get; init; }
 ```
 
-この指定ではすべての child が `Child1` になってしまう。
+この指定ではすべての child が `Child1` になる。
 
 ### 6.3 初期設計での判断
 
 固定 alias attribute は初期対象に含めない。
 
-理由:
-
-- 実行時の node 値を参照できない
-- `TypeMetadataResolver` へ別名 metadata の責務が増える
-- 比較 metadata と出力表現の責務が混ざる
+- runtime の node 値を参照できない
+- `TypeMetadataResolver` に出力表現の責務が入る
+- 比較 metadata と比較後の表示規則が混ざる
 - 同じ比較結果へ異なる path 表現を適用しにくくなる
 
-固定 member rename の需要が別途明確になった場合は、本 projection API の簡易 projector として後続設計する。
+固定 member rename の需要が別途明確になった場合は、本設計の投影器を簡単に構築する補助 API として後続設計する。
 
 ## 7. 公開 API
 
@@ -366,7 +363,7 @@ public static class ParallelPathAccessExtensions
 
 `GetDiffEntryPathProjections()` は、標準差分 entry と利用側定義 path の組を返す。
 
-### 7.2 Projector
+### 7.2 投影器（projector）
 
 ```csharp
 public interface IParallelDiffPathProjector
@@ -378,11 +375,11 @@ public interface IParallelDiffPathProjector
 
 `Project()` は標準 path の segment 1件に対し、利用側定義 path での扱いを返す。
 
-projector は同じ入力に対して同じ結果を返す決定的な実装とする。
+投影器は同じ入力に対して同じ結果を返す決定的な実装とする。
 
-`deterministic` または「決定的」とは、同じ入力なら毎回同じ結果になる性質を意味する。時刻、乱数、外部の可変状態へ依存させない。
+「決定的」は、同じ入力なら毎回同じ結果になることを意味する。時刻、乱数、外部の可変状態へ依存させない。
 
-### 7.3 Projection context
+### 7.3 投影時の文脈情報（projection context）
 
 ```csharp
 public sealed class ParallelDiffPathProjectionContext
@@ -410,8 +407,6 @@ public sealed class ParallelDiffPathNodeContext
 }
 ```
 
-各 property の意味は次のとおり。
-
 | Property | 内容 |
 |---|---|
 | `StandardSegment` | SSC が生成する標準 path segment |
@@ -419,9 +414,9 @@ public sealed class ParallelDiffPathNodeContext
 | `Node` | segment が指す現在の node。container presence entry では `null` |
 | `Siblings` | 同じ `ParallelChildSet` に属する node 一覧。container presence entry では空 |
 
-### 7.4 Concrete path segment
+`container presence entry` は、空 container と missing container のように、要素 node を作れない container 自体の存在差分を表す entry である。
 
-`concrete` は「wildcard ではなく、特定の位置を表す具体的な値」という意味である。
+### 7.4 具体的な path segment
 
 ```csharp
 public sealed class ParallelDiffPathSegment
@@ -446,8 +441,6 @@ public sealed class ParallelDiffPathSegment
 
 `WithMemberName()` は selector を維持して member 名だけを変更する。
 
-例:
-
 ```csharp
 ParallelDiffPathSegment standard =
     ParallelDiffPathSegment.Ordinal("Children", 0);
@@ -456,15 +449,13 @@ ParallelDiffPathSegment custom =
     standard.WithMemberName("Child1");
 ```
 
-結果:
-
 ```text
 Children[#0]
     ↓
 Child1[#0]
 ```
 
-### 7.5 Selector
+### 7.5 選択子（selector）
 
 ```csharp
 public enum ParallelDiffPathSelectorKind
@@ -475,7 +466,7 @@ public enum ParallelDiffPathSelectorKind
 ```
 
 ```csharp
-public sealed class ParallelDiffPathSelector
+public readonly struct ParallelDiffPathSelector
 {
     public ParallelDiffPathSelectorKind Kind { get; }
 
@@ -485,13 +476,13 @@ public sealed class ParallelDiffPathSelector
 }
 ```
 
-path segment factory が selector の整合性を保証する。
+path segment の生成 method が selector の整合性を保証する。
 
-- `Key()` は `KeyText` を持つ
+- `Key()` は空でない `KeyText` を持つ
 - `Ordinal()` は非負の `Ordinal` を持つ
-- wildcard は持たない
+- 具体 path なので wildcard は持たない
 
-### 7.6 Segment projection result
+### 7.6 Segment 投影結果
 
 ```csharp
 public enum ParallelDiffPathSegmentProjectionKind
@@ -548,7 +539,7 @@ DocumentWrapper.Root.Children[#0]
 Root.Children[#0]
 ```
 
-### 7.7 Projection result
+### 7.7 投影結果
 
 ```csharp
 public sealed class ParallelDiffEntryPathProjection
@@ -563,12 +554,10 @@ public sealed class ParallelDiffEntryPathProjection
 
 | Property | 内容 |
 |---|---|
-| `Entry` | 既存の標準差分 entry |
+| `Entry` | 標準差分 entry |
 | `Entry.Path` | SSC が生成した標準 path |
-| `ProjectedPath` | projector を適用した利用側定義 path |
-| `ProjectedParentPath` | 標準 parent path と同じ segment 範囲へ projector を適用した path |
-
-利用例:
+| `ProjectedPath` | 投影器を適用した利用側定義 path |
+| `ProjectedParentPath` | 標準 parent path と同じ segment 範囲へ投影器を適用した path |
 
 ```csharp
 ParallelDiffEntryPathProjection projected = projections[0];
@@ -576,8 +565,6 @@ ParallelDiffEntryPathProjection projected = projections[0];
 string standardPath = projected.Entry.Path;
 string customPath = projected.ProjectedPath;
 ```
-
-結果例:
 
 ```text
 standardPath:
@@ -587,7 +574,9 @@ customPath:
 Root.Child1[#0].Attribute1[#0].Value
 ```
 
-### 7.8 Pattern matching
+別々に呼び出した `GetDiffEntries()` と `GetDiffEntryPathProjections()` の entry について、object の参照一致は保証しない。件数、順序、property 値、node 参照の意味を一致させる。
+
+### 7.8 Pattern 照合
 
 ```csharp
 public static class ParallelDiffEntryPathProjectionExtensions
@@ -598,17 +587,15 @@ public static class ParallelDiffEntryPathProjectionExtensions
 }
 ```
 
-この overload は `ProjectedPath` を照合する。
+この同名別引数版は `ProjectedPath` を照合する。
 
-既存 overload は変更しない。
+既存 API は変更しない。
 
 ```csharp
 entry.PathMatches(pattern);
 ```
 
-既存 overload は引き続き `ParallelDiffEntry.Path`、つまり標準 path を照合する。
-
-利用例:
+既存 API は引き続き `ParallelDiffEntry.Path`、つまり標準 path を照合する。
 
 ```csharp
 ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
@@ -620,11 +607,11 @@ ParallelDiffEntryPathProjection[] matched = result
     .ToArray();
 ```
 
-## 8. Projection 規則
+## 8. 投影規則
 
-### 8.1 標準 path の維持
+### 8.1 標準 entry の維持
 
-`GetDiffEntryPathProjections()` が返す `Entry` は、既存 `GetDiffEntries()` が返す entry と同じ標準情報を持つ。
+`GetDiffEntryPathProjections()` が返す `Entry` は、既存 `GetDiffEntries()` と同じ標準情報を持つ。
 
 次を変更しない。
 
@@ -648,24 +635,36 @@ Fields[#0]
 Value
 ```
 
-各 segment に対して projector を適用し、結果を順番に連結する。
+各 segment に投影器を適用し、結果を順番に連結する。
 
-### 8.3 Escape
+### 8.3 Member 名の検証と key text の escape
 
-利用側が返す member 名と key text は、SSC が既存 path grammar に従って escape する。
+現行 path grammar は member 名の escape を定義していない。
 
-利用側は文字列連結で path を作らない。
+そのため、利用側が返す `MemberName` は次を満たす必要がある。
+
+- 空でない
+- `.` を含まない
+- `[` を含まない
+- `]` を含まない
+
+不正な member 名は `ParallelDiffPathSegment` の生成時に `ArgumentException` とする。
 
 例:
 
 ```text
-Member name: A.B
-Key text:    A]B
+Valid:   Child1
+Invalid: Child.1
+Invalid: Child[1]
 ```
 
-これらを path として安全に表現する責務は SSC が持つ。
+key text は既存規則に従って SSC が escape する。
 
-既存 grammar が member 名の dot escape を許容していない場合は、初期実装で対応可能な member 名の範囲を明示し、不正な member 名を拒否する。暗黙に不正 path を生成しない。
+- `]` を `\]` として表す
+- `\` を `\\` として表す
+- 先頭 `#` を `\#` として表す
+
+利用側は path 文字列を手作業で連結しない。
 
 ### 8.4 Selector の維持
 
@@ -685,13 +684,11 @@ Child1[#0]
 
 `[#0]` は ordinal、`[0]` は key text `0` を表すため、意味が異なる。
 
-report 上だけ `[0]` と表示したい場合は report renderer の責務とする。
+レポート上だけ `[0]` と表示したい場合は、SSC の path grammar ではなく利用側の表示処理で変換する。
 
 ### 8.5 Omit
 
 中間 segment と末尾 segment の両方を省略可能とする。
-
-例:
 
 ```text
 DocumentWrapper.Root.Child1[#0].Value
@@ -711,9 +708,7 @@ Root.Child1[#0]
 
 ### 8.7 重複 path
 
-複数の entry が同じ `ProjectedPath` になることを許容する。
-
-例:
+複数 entry が同じ `ProjectedPath` になることを許容する。
 
 ```text
 Root.Item.Value
@@ -722,92 +717,51 @@ Root.Item.Value
 
 SSC は利用側定義 path の一意性を保証しない。
 
-理由:
-
-- projection は表示と filter のための機能である
-- entry は `Entry.Path` により標準位置を保持している
+- 投影は表示と絞り込みのための機能である
+- 各 entry は `Entry.Path` により標準位置を保持する
 - 同名 node の区別規則は利用側固有である
 
-filter は一致したすべての entry を返す。
+pattern は一致したすべての entry を返す。
 
 ### 8.8 Model slot 間の値
 
 SSC は複数 model slot のどの値を採用するか決めない。
 
-projector は `IParallelNode.Count`、`GetValue()`、`GetState()` を使って判断する。
+投影器は `IParallelNode.Count`、`GetValue()`、`GetState()` を使って判断する。
 
-推奨例:
+利用側規則の例:
 
 1. `Missing` ではない slot から候補名を取得する
 2. すべて同じ場合だけその名前を使う
 3. 異なる場合は `KeepStandard()` へ fallback する
 
-ただし、この規則自体は SSC の production code へ実装しない。
+この規則自体は SSC の製品コードへ実装しない。
 
 ### 8.9 Container presence entry
 
-empty container の有無差分では、対応する child node が存在しない。
+空 container と missing container の存在差分では、対応する child node が存在しない。
 
-その場合の context は次とする。
+その場合の文脈情報は次とする。
 
 ```text
-Current.Node     = null
-Current.Siblings = empty
+Current.Node       = null
+Current.Siblings   = empty
 Current.ParentNode = container owner node
 ```
 
-projector は node 値を必要とする置換を行えないため、通常は `KeepStandard()` を返す。
+投影器は node 値を必要とする置換を行えないため、通常は `KeepStandard()` を返す。
 
-### 8.10 Projector の呼び出し
+### 8.10 投影器の呼び出し
 
-projector は同期的に呼び出す。
+投影器は同期的に呼び出す。初期実装では並列呼び出しを行わない。
 
-初期実装では並列呼び出しを行わない。
-
-同じ node に対応する segment が複数 entry の path に現れる場合、projector が複数回呼ばれる可能性がある。projector は呼び出し回数へ依存しない実装とする。
+同じ node に対応する segment が複数 entry の path に現れる場合、投影器が複数回呼ばれる可能性がある。投影器は呼び出し回数へ依存しない実装とする。
 
 ## 9. 利用例
 
-### 9.1 Named tree model
+### 9.1 利用側投影器の概念例
 
-```csharp
-public sealed class Document
-{
-    public TreeNode Root { get; init; } = new();
-}
-
-public sealed class TreeNode
-{
-    public string Name { get; init; } = string.Empty;
-
-    public List<TreeNode> Children { get; init; } = [];
-
-    public List<NamedValue> Fields { get; init; } = [];
-}
-
-public sealed class NamedValue
-{
-    public string Name { get; init; } = string.Empty;
-
-    public string Value { get; init; } = string.Empty;
-}
-```
-
-標準 path:
-
-```text
-Root.Children[#0].Children[#0].Fields[#0].Value
-```
-
-利用側が目指す path:
-
-```text
-Root.Child1[#0].Child2[#0].Attribute1[#0].Value
-```
-
-### 9.2 利用側 projector の概念例
-
-次のコードは利用方法を示す概念例であり、SSC が提供する具体的 projector ではない。
+次は利用方法を示す概念例であり、SSC が特定 model 向けに提供する投影器ではない。
 
 ```csharp
 public sealed class NamedTreePathProjector : IParallelDiffPathProjector
@@ -853,23 +807,26 @@ SSC は次を知らない。
 - `NamedValue.Name` が field 名であること
 - model slot 間で名前が一致すべきこと
 
-### 9.3 Filter
+### 9.2 絞り込み
 
 ```csharp
 IReadOnlyList<ParallelDiffEntryPathProjection> projections =
     result.GetDiffEntryPathProjections(new NamedTreePathProjector());
 
-ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+ParallelDiffPathPattern customPattern = ParallelDiffPathPattern.Parse(
     "Root.Child1[*].Child2[*].Attribute1[*].Value");
 
-ParallelDiffEntryPathProjection[] matched = projections
-    .Where(projection => projection.PathMatches(pattern))
+ParallelDiffEntryPathProjection[] customMatches = projections
+    .Where(projection => projection.PathMatches(customPattern))
     .ToArray();
 ```
 
-標準 path に対する既存 filter も同時に利用できる。
+標準 path に対する既存絞り込みも同時に利用できる。
 
 ```csharp
+ParallelDiffPathPattern standardPattern = ParallelDiffPathPattern.Parse(
+    "Root.Children[*].Children[*].Fields[*].Value");
+
 ParallelDiffEntry[] standardMatches = result
     .GetDiffEntries()
     .Where(entry => entry.PathMatches(standardPattern))
@@ -881,14 +838,13 @@ ParallelDiffEntry[] standardMatches = result
 - `GetDiffEntryPathProjections(null result, ...)` は `ArgumentNullException`
 - `GetDiffEntryPathProjections(..., null projector)` は `ArgumentNullException`
 - `ParallelDiffPathSegment.Member(null または空文字)` は `ArgumentException`
+- member 名に `.`, `[`, `]` が含まれる場合は `ArgumentException`
 - `ParallelDiffPathSegment.Key(..., null または空文字)` は `ArgumentException`
 - `ParallelDiffPathSegment.Ordinal(..., 負数)` は `ArgumentOutOfRangeException`
 - `Replace(null)` は `ArgumentNullException`
 - 全 segment を省略した場合は `InvalidOperationException`
-- projector が送出した例外は握りつぶさず、そのまま呼び出し元へ伝播する
-- projector が不正な path segment を返すことは factory validation により防ぐ
-
-`validation` は入力値が API 契約を満たすか検査することを意味する。
+- 投影器が送出した例外は握りつぶさず、そのまま呼び出し元へ伝播する
+- 投影器が不正な segment を返すことは生成 method の入力検証で防ぐ
 
 ## 11. 実装方針
 
@@ -896,9 +852,7 @@ ParallelDiffEntry[] standardMatches = result
 
 現行 `AddNodeDiffEntries()` と `AddChildSetDiffEntries()` が文字列 path を直接連結する処理を、内部の segment stack を使う形へ整理する。
 
-`stack` は「現在の再帰位置までの要素を順番に積み上げた構造」を意味する。
-
-概念:
+`stack` は、現在の再帰位置までの要素を順番に積み上げた構造である。
 
 ```text
 Root
@@ -920,37 +874,33 @@ Node
 Siblings
 ```
 
-差分 entry を生成する時点で、この stack を root から順に projector へ渡す。
+差分 entry を生成する時点で、この stack を root から順に投影器へ渡す。
 
-標準 path 文字列を再解析しない。
+標準 path 文字列を再解析しない。`GetNodeByPath()` で root から node を再探索しない。
 
-`GetNodeByPath()` で root から node を再探索しない。
+### 11.3 文字列化処理の共有
 
-### 11.3 Formatter の共有
-
-標準 path と利用側定義 path は同じ formatter を使用する。
-
-`formatter` は構造化された segment を文字列へ変換する処理を意味する。
+標準 path と利用側定義 path は同じ文字列化処理を使用する。
 
 次を共有する。
 
 - dot 連結
 - `[]` の生成
-- key escape
+- key text の escape
 - 先頭 `#` の escape
 - ordinal の `#` 表記
 
 標準 path と利用側定義 path で異なる grammar を作らない。
 
-### 11.4 Pattern parser の再利用
+### 11.4 `ParallelDiffPathPattern` の再利用
 
-利用側定義 path は既存 path grammar で文字列化するため、`ParallelDiffPathPattern` の既存 parser と matcher を再利用する。
+利用側定義 path は既存 path grammar で文字列化するため、既存 pattern parser と照合処理を再利用する。
 
 新しい wildcard grammar は追加しない。
 
-### 11.5 比較 pipeline との分離
+### 11.5 比較処理との分離
 
-本機能の production code から次を変更しない。
+本機能では次を変更しない。
 
 - `ParallelCompareApi.Compare()`
 - `CompareConfiguration`
@@ -961,8 +911,6 @@ Siblings
 - key union
 - node の value/state 判定
 
-`pipeline` は入力から比較結果を生成する一連の処理を意味する。
-
 本機能は比較結果の列挙時にだけ動作する。
 
 ```text
@@ -970,15 +918,17 @@ models
   -> metadata resolution
   -> comparison tree construction
   -> CompareResult<T>
-  -> GetDiffEntries()                     標準 entry
+  -> GetDiffEntries()                       標準 entry
   -> GetDiffEntryPathProjections(projector) 利用側定義 path 付き結果
 ```
+
+`metadata resolution` は、比較対象 member や `CompareKey` などの metadata を解決する既存処理である。
 
 ## 12. 後方互換
 
 ### 12.1 既存 API
 
-次の API の signature と挙動を変更しない。
+次の公開形式と挙動を変更しない。
 
 ```csharp
 result.GetDiffEntries();
@@ -987,8 +937,6 @@ result.GetNodeByPath(path);
 result.GetValueByPath(path, modelIndex);
 result.GetStateByPath(path, modelIndex);
 ```
-
-`signature` は method 名、引数、戻り値からなる公開形式を意味する。
 
 ### 12.2 `ParallelDiffEntry.ToString()`
 
@@ -1010,7 +958,7 @@ entry.Node == result.GetNodeByPath(entry.Path)
 
 ### 13.1 既存回帰
 
-- options なしの `GetDiffEntries()` が既存 entry 件数を維持する
+- 既存 `GetDiffEntries()` が entry 件数を維持する
 - 標準 `Path` と `ParentPath` が完全一致する
 - entry 順序が変わらない
 - `Entry.Node` が `GetNodeByPath(Entry.Path)` で解決できる
@@ -1018,7 +966,7 @@ entry.Node == result.GetNodeByPath(entry.Path)
 - 既存 `ParallelDiffPathPattern` test を変更せず通す
 - 既存 `CompareIgnore` test を変更せず通す
 
-### 13.2 Segment projection
+### 13.2 Segment 投影
 
 - `KeepStandard()` が標準 segment を維持する
 - `Replace()` が member 名を変更できる
@@ -1028,7 +976,7 @@ entry.Node == result.GetNodeByPath(entry.Path)
 - `Omit()` が末尾 segment を省略できる
 - 全 segment の `Omit()` を拒否する
 
-### 13.3 Context
+### 13.3 文脈情報
 
 - root 直下では ancestor が空になる
 - nested node では ancestor が root 順に渡る
@@ -1038,15 +986,15 @@ entry.Node == result.GetNodeByPath(entry.Path)
 - key child で標準 selector が `[key]` になる
 - container presence entry で `Node == null`、siblings が空になる
 
-### 13.4 Escape
+### 13.4 Grammar と escape
 
+- member 名の `.`, `[`, `]` を拒否する
 - key text 内の `]` を escape する
 - key text 内の `\` を escape する
 - key text 先頭の `#` を escape する
-- projector が返した member 名の許容範囲を検証する
-- 不正な member 名から不正 path を生成しない
+- 不正な segment から不正 path を生成しない
 
-### 13.5 Pattern matching
+### 13.5 Pattern 照合
 
 - projection extension が `ProjectedPath` を照合する
 - 既存 entry extension が標準 `Path` を照合し続ける
@@ -1057,9 +1005,9 @@ entry.Node == result.GetNodeByPath(entry.Path)
 ### 13.6 重複と fallback
 
 - 同じ `ProjectedPath` を持つ複数 entry を保持する
-- projector が `KeepStandard()` を返した segment だけ標準名へ戻る
+- `KeepStandard()` を返した segment だけ標準名へ戻る
 - 一部 segment だけ置換できる
-- projector 例外を呼び出し元へ伝播する
+- 投影器の例外を呼び出し元へ伝播する
 
 ### 13.7 比較結果への非影響
 
@@ -1067,9 +1015,9 @@ entry.Node == result.GetNodeByPath(entry.Path)
 - `CompareResult<T>.Issues` が変化しない
 - `CompareResult<T>.HasError` が変化しない
 - `Root.HasDifferences()` が変化しない
-- `GetDiffEntries()` の結果が projection 呼び出し前後で変化しない
+- projection 呼び出し前後で既存 `GetDiffEntries()` の結果が変化しない
 
-## 14. 実装対象ファイルの想定
+## 14. 実装対象の想定
 
 初期実装では概ね次を対象とする。
 
@@ -1080,7 +1028,8 @@ src/SSC/
   ParallelPathAccessExtensions.cs
 
 src/SSC/Internal/
-  path formatter / traversal context helper
+  path segment formatter
+  traversal context helper
 
 tests/SSC.Unit.Tests/
   ParallelDiffPathProjectionUnitTests.cs
@@ -1093,15 +1042,15 @@ doc/design/detail/
   11-DiffEntryCustomPath.md
 ```
 
-実装時の class 分割は既存の source 配置と責務に合わせて調整する。
+実際の class 分割は既存 source 配置と責務に合わせて調整する。
 
 ## 15. 完了条件
 
 - 既存 `ParallelDiffEntry.Path` が標準 path として維持される
-- 利用側が node context から segment を置換または省略できる
+- 利用側が node の文脈情報から segment を置換または省略できる
 - 利用側が path 文字列を手作業で組み立てる必要がない
 - 再帰 model でも意味名を使った利用側定義 path を生成できる
 - 利用側定義 path を既存 `ParallelDiffPathPattern` で絞り込める
-- XML 等の domain 固有規則が SSC production code に入らない
+- XML 等の domain 固有規則が SSC の製品コードに入らない
 - `CompareConfiguration`、metadata resolution、比較 tree 構築へ影響しない
 - 既存 path access、diff entry、filter の全回帰が通る

--- a/doc/design/detail/11-DiffEntryCustomPath.md
+++ b/doc/design/detail/11-DiffEntryCustomPath.md
@@ -1,0 +1,1107 @@
+# Diff Entry Custom Path Projection
+
+## 1. 目的
+
+`CompareResult<T>.GetDiffEntries()` が返す差分 entry に対し、SSC が生成する既存の path を変更せず、利用側が用途に応じた別の path 表現を生成できるようにする。
+
+再帰的なモデルでは、既存 path が次のように同じ member 名を繰り返すことがある。
+
+```text
+Root.Children[#0].Children[#0].Fields[#0].Value
+```
+
+利用側が各 node の `Name` などの実行時の値を使い、次のような読みやすい path を生成できることを目的とする。
+
+```text
+Root.Child1[#0].Child2[#0].Attribute1[#0].Value
+```
+
+本機能は path の表示と絞り込みを改善するための後段処理であり、比較対象、比較結果、sequence の対応付けには影響しない。
+
+## 2. 用語
+
+### 2.1 標準 path（canonical path）
+
+標準 path は、SSC が現在 `ParallelDiffEntry.Path` に格納している正式な path を指す。
+
+`canonical` は「基準となる正式な表現」という意味である。本設計では英語だけで呼ばず、以降は原則として「標準 path」と記載する。
+
+例:
+
+```text
+Groups[1].Items[100].MetricA
+Root.Children[#0].Fields[#0].Value
+```
+
+標準 path は SSC の比較 tree 上の位置を表す。
+
+- `GetNodeByPath()` で node を取得できる
+- `ParallelDiffEntry.Path` と `ParallelDiffEntry.ParentPath` に使用される
+- `ParallelDiffEntry.PathMatches()` の照合対象になる
+- 既存 API の後方互換対象である
+
+### 2.2 利用側定義 path（custom path）
+
+利用側定義 path は、利用側が標準 path を別の意味表現へ変換した path を指す。
+
+`custom` は「利用側が用途に合わせて定義する」という意味である。
+
+例:
+
+```text
+Standard path:
+Root.Children[#0].Fields[#0].Value
+
+Custom path:
+Root.Child1[#0].Attribute1[#0].Value
+```
+
+利用側定義 path は表示、分類、filter に使用する。初期実装では node の住所としては扱わない。
+
+### 2.3 別名（alias）
+
+`alias` は「同じ対象に付ける別の名前」を意味する。
+
+例えば `Children` を `Child1` と表示する場合、`Child1` は `Children` segment の別名に相当する。
+
+ただし本設計では、固定文字列の別名だけでなく実行時の node 値から名前を決めるため、公開 API の中心用語には `alias` ではなく `projection` を使う。
+
+### 2.4 投影（projection）
+
+`projection` は「元の情報を保持しながら、必要な見え方へ変換する処理」を意味する。
+
+本設計では、標準 path の各構成要素を次のいずれかへ変換する処理を指す。
+
+- 標準のまま維持する
+- 別の構成要素へ置き換える
+- 利用側定義 path から省略する
+
+標準 path 自体は変更しない。
+
+### 2.5 投影器（projector）
+
+`projector` は projection を実行する利用側実装を指す。
+
+SSC は node と path の構造情報を projector に渡す。projector は、その情報から利用側定義 path の構成要素を返す。
+
+SSC は `Name`、`Children`、`Attributes` などの業務上の意味を解釈しない。
+
+### 2.6 区間（segment）
+
+`segment` は dot で区切られた path の構成要素1件を指す。
+
+例:
+
+```text
+Root.Children[#0].Value
+```
+
+この path は次の3 segment で構成される。
+
+```text
+Root
+Children[#0]
+Value
+```
+
+### 2.7 選択子（selector）
+
+`selector` は、container member 配下の要素を識別する `[]` 部分を指す。
+
+例:
+
+```text
+Items[A]
+Items[#0]
+```
+
+- `[A]` は key selector。比較 key の文字列表現 `A` で要素を識別する
+- `[#0]` は ordinal selector。key を持たない sequence の並び順 `0` で要素を識別する
+
+具体的な path segment では wildcard selector `[*]` を使用しない。`[*]` は pattern 側だけの表現とする。
+
+### 2.8 文脈情報（context）
+
+`context` は、projector が判断に使う現在位置の情報を指す。
+
+本設計では次の情報を含む。
+
+- 現在の標準 path segment
+- 親 node
+- 現在の node
+- 同じ child set に属する sibling node 一覧
+- 現在位置より上位の ancestor 情報
+
+`sibling` は「同じ親を持つ兄弟 node」、`ancestor` は「現在位置より上位にある祖先 node」を意味する。
+
+### 2.9 フォールバック（fallback）
+
+`fallback` は「利用側が別名を決定できない場合に、安全な既定動作へ戻すこと」を意味する。
+
+本設計で推奨する fallback は、該当 segment を標準 path のまま維持することである。
+
+```text
+Children[#0]
+    ↓ 別名を決定できない
+Children[#0]
+```
+
+## 3. 現状と問題
+
+現行 `GetDiffEntries()` は、比較 tree を再帰的に走査し、member 名と selector を連結して `ParallelDiffEntry.Path` を生成する。
+
+container child では次の規則を使用する。
+
+- `IParallelNode.KeyText` がある場合は key selector
+- `IParallelNode.KeyText` がない場合は ordinal selector
+
+そのため、汎用的な再帰モデルでは次のような path になる。
+
+```text
+Root.Children[#0].Children[#0].Fields[#0].Value
+```
+
+この path は SSC の model 構造としては正しいが、利用者が知りたい意味を直接表さない場合がある。
+
+例えば次の model を考える。
+
+```csharp
+public sealed class Document
+{
+    public TreeNode Root { get; init; } = new();
+}
+
+public sealed class TreeNode
+{
+    public string Name { get; init; } = string.Empty;
+
+    public List<TreeNode> Children { get; init; } = [];
+
+    public List<NamedValue> Fields { get; init; } = [];
+}
+
+public sealed class NamedValue
+{
+    public string Name { get; init; } = string.Empty;
+
+    public string Value { get; init; } = string.Empty;
+}
+```
+
+実データが次の場合、利用者には `Name` の方が意味を持つ。
+
+```text
+Root
+└─ Child1
+   └─ Child2
+      └─ Attribute1 = "0"
+```
+
+しかし SSC が `Name` を path 名として自動解釈することはできない。
+
+- `Name` が path 名であるとは限らない
+- 別の model では `Code`、`Id`、`Label` などが意味名かもしれない
+- model slot 間で値が異なる場合の採用規則は利用側ごとに異なる
+- 同名 sibling の識別規則も利用側ごとに異なる
+
+SSC は判断材料を渡し、意味の決定は利用側に委ねる必要がある。
+
+## 4. 責務境界
+
+### 4.1 SSC の責務
+
+SSC は次を担当する。
+
+1. 既存の標準 path を変更せず生成する
+2. 標準 path を構造化された segment と selector として扱う
+3. path 生成時に把握している node context を projector へ渡す
+4. projector の結果を SSC の escape 規則で path 文字列へ変換する
+5. 標準 path と利用側定義 path を同じ結果オブジェクトから参照できるようにする
+6. 利用側定義 path に対して既存 `ParallelDiffPathPattern` を適用できるようにする
+7. 既存 `GetDiffEntries()` の件数、順序、path、node 参照を維持する
+
+### 4.2 利用側の責務
+
+利用側は次を担当する。
+
+1. どの member を置換または省略するか決める
+2. node のどの実行時の値を利用側定義名として使うか決める
+3. model slot 間で候補名が異なる場合の規則を決める
+4. 同名 sibling をどう区別するか決める
+5. 名前を決定できない場合に標準 segment へ戻すか、別の名前を使うか決める
+6. 利用側定義 path を report、log、分類へどう表示するか決める
+
+### 4.3 SSC が解釈しない情報
+
+SSC は次の意味を自動判定しない。
+
+```text
+Name        = node 名
+Children    = XML の子要素
+Fields      = 属性
+Value       = report では省略可能
+```
+
+これらは model 固有または利用用途固有の規則である。
+
+## 5. 非目的
+
+初期実装では次を行わない。
+
+- `ParallelDiffEntry.Path` の意味変更
+- `ParallelDiffEntry.ParentPath` の意味変更
+- `GetNodeByPath()` による利用側定義 path の解決
+- `CompareConfiguration` への path projector 設定追加
+- 比較対象 member の変更
+- `CompareKey` の代替
+- sequence alignment の変更
+- `CompareIssue.Path` の projection
+- XML、JSON、tree model 固有の projector 実装
+- property 名から `Name` や `Id` を自動発見する規則
+- 利用側定義 path の一意性保証
+- member 名 wildcard や任意深度 wildcard の追加
+- report 用の `[#0]` から `[0]` への表記変換
+- 正規表現による path 変換
+
+## 6. 固定 alias attribute を対象外とする理由
+
+### 6.1 alias attribute の想定例
+
+`attribute` は C# の class、property、field などへ付加する metadata を意味する。
+
+固定 alias attribute を導入する場合、概念的には次のような API になる。
+
+```csharp
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class DiffPathAliasAttribute : Attribute
+{
+    public DiffPathAliasAttribute(string alias)
+    {
+        Alias = alias;
+    }
+
+    public string Alias { get; }
+}
+```
+
+利用例:
+
+```csharp
+public sealed class Order
+{
+    [DiffPathAlias("Lines")]
+    public List<OrderLine> Items { get; init; } = [];
+}
+```
+
+この場合、次の固定置換は可能である。
+
+```text
+Items[100].Price
+    ↓
+Lines[100].Price
+```
+
+### 6.2 今回の要求を満たせない理由
+
+再帰 model で必要になる名前は、property に固定された名前ではなく各 node の実行時の値である。
+
+```csharp
+public sealed class TreeNode
+{
+    public string Name { get; init; } = string.Empty;
+
+    public List<TreeNode> Children { get; init; } = [];
+}
+```
+
+同じ `Children` property の各要素が次の異なる名前を持つ。
+
+```text
+Child1
+Child2
+Child3
+```
+
+次のような固定 attribute では表現できない。
+
+```csharp
+[DiffPathAlias("Child1")]
+public List<TreeNode> Children { get; init; }
+```
+
+この指定ではすべての child が `Child1` になってしまう。
+
+### 6.3 初期設計での判断
+
+固定 alias attribute は初期対象に含めない。
+
+理由:
+
+- 実行時の node 値を参照できない
+- `TypeMetadataResolver` へ別名 metadata の責務が増える
+- 比較 metadata と出力表現の責務が混ざる
+- 同じ比較結果へ異なる path 表現を適用しにくくなる
+
+固定 member rename の需要が別途明確になった場合は、本 projection API の簡易 projector として後続設計する。
+
+## 7. 公開 API
+
+### 7.1 利用側定義 path の取得
+
+```csharp
+public static class ParallelPathAccessExtensions
+{
+    public static IReadOnlyList<ParallelDiffEntry> GetDiffEntries<T>(
+        this CompareResult<T> result);
+
+    public static IReadOnlyList<ParallelDiffEntryPathProjection>
+        GetDiffEntryPathProjections<T>(
+            this CompareResult<T> result,
+            IParallelDiffPathProjector projector);
+}
+```
+
+既存 `GetDiffEntries()` は変更しない。
+
+`GetDiffEntryPathProjections()` は、標準差分 entry と利用側定義 path の組を返す。
+
+### 7.2 Projector
+
+```csharp
+public interface IParallelDiffPathProjector
+{
+    ParallelDiffPathSegmentProjection Project(
+        ParallelDiffPathProjectionContext context);
+}
+```
+
+`Project()` は標準 path の segment 1件に対し、利用側定義 path での扱いを返す。
+
+projector は同じ入力に対して同じ結果を返す決定的な実装とする。
+
+`deterministic` または「決定的」とは、同じ入力なら毎回同じ結果になる性質を意味する。時刻、乱数、外部の可変状態へ依存させない。
+
+### 7.3 Projection context
+
+```csharp
+public sealed class ParallelDiffPathProjectionContext
+{
+    public IReadOnlyList<ParallelDiffPathNodeContext> Ancestors { get; }
+
+    public ParallelDiffPathNodeContext Current { get; }
+}
+```
+
+`Ancestors` は root 側から現在の親までの順序で保持する。現在位置自身は含めず、`Current` で参照する。
+
+root 直下 segment では `Ancestors.Count == 0` になる。
+
+```csharp
+public sealed class ParallelDiffPathNodeContext
+{
+    public ParallelDiffPathSegment StandardSegment { get; }
+
+    public IParallelNode ParentNode { get; }
+
+    public IParallelNode? Node { get; }
+
+    public IReadOnlyList<IParallelNode> Siblings { get; }
+}
+```
+
+各 property の意味は次のとおり。
+
+| Property | 内容 |
+|---|---|
+| `StandardSegment` | SSC が生成する標準 path segment |
+| `ParentNode` | `StandardSegment` を所有する親 node |
+| `Node` | segment が指す現在の node。container presence entry では `null` |
+| `Siblings` | 同じ `ParallelChildSet` に属する node 一覧。container presence entry では空 |
+
+### 7.4 Concrete path segment
+
+`concrete` は「wildcard ではなく、特定の位置を表す具体的な値」という意味である。
+
+```csharp
+public sealed class ParallelDiffPathSegment
+{
+    public string MemberName { get; }
+
+    public ParallelDiffPathSelector? Selector { get; }
+
+    public static ParallelDiffPathSegment Member(string memberName);
+
+    public static ParallelDiffPathSegment Key(
+        string memberName,
+        string keyText);
+
+    public static ParallelDiffPathSegment Ordinal(
+        string memberName,
+        int ordinal);
+
+    public ParallelDiffPathSegment WithMemberName(string memberName);
+}
+```
+
+`WithMemberName()` は selector を維持して member 名だけを変更する。
+
+例:
+
+```csharp
+ParallelDiffPathSegment standard =
+    ParallelDiffPathSegment.Ordinal("Children", 0);
+
+ParallelDiffPathSegment custom =
+    standard.WithMemberName("Child1");
+```
+
+結果:
+
+```text
+Children[#0]
+    ↓
+Child1[#0]
+```
+
+### 7.5 Selector
+
+```csharp
+public enum ParallelDiffPathSelectorKind
+{
+    Key,
+    Ordinal,
+}
+```
+
+```csharp
+public sealed class ParallelDiffPathSelector
+{
+    public ParallelDiffPathSelectorKind Kind { get; }
+
+    public string? KeyText { get; }
+
+    public int? Ordinal { get; }
+}
+```
+
+path segment factory が selector の整合性を保証する。
+
+- `Key()` は `KeyText` を持つ
+- `Ordinal()` は非負の `Ordinal` を持つ
+- wildcard は持たない
+
+### 7.6 Segment projection result
+
+```csharp
+public enum ParallelDiffPathSegmentProjectionKind
+{
+    KeepStandard,
+    Replace,
+    Omit,
+}
+```
+
+```csharp
+public readonly struct ParallelDiffPathSegmentProjection
+{
+    public ParallelDiffPathSegmentProjectionKind Kind { get; }
+
+    public ParallelDiffPathSegment? Replacement { get; }
+
+    public static ParallelDiffPathSegmentProjection KeepStandard();
+
+    public static ParallelDiffPathSegmentProjection Replace(
+        ParallelDiffPathSegment segment);
+
+    public static ParallelDiffPathSegmentProjection Omit();
+}
+```
+
+#### `KeepStandard`
+
+標準 segment をそのまま利用する。
+
+```text
+Value
+    ↓
+Value
+```
+
+#### `Replace`
+
+指定した具体的 segment へ置き換える。
+
+```text
+Children[#0]
+    ↓
+Child1[#0]
+```
+
+#### `Omit`
+
+利用側定義 path から segment を省略する。
+
+```text
+DocumentWrapper.Root.Children[#0]
+    ↓ DocumentWrapper を省略
+Root.Children[#0]
+```
+
+### 7.7 Projection result
+
+```csharp
+public sealed class ParallelDiffEntryPathProjection
+{
+    public ParallelDiffEntry Entry { get; }
+
+    public string ProjectedPath { get; }
+
+    public string? ProjectedParentPath { get; }
+}
+```
+
+| Property | 内容 |
+|---|---|
+| `Entry` | 既存の標準差分 entry |
+| `Entry.Path` | SSC が生成した標準 path |
+| `ProjectedPath` | projector を適用した利用側定義 path |
+| `ProjectedParentPath` | 標準 parent path と同じ segment 範囲へ projector を適用した path |
+
+利用例:
+
+```csharp
+ParallelDiffEntryPathProjection projected = projections[0];
+
+string standardPath = projected.Entry.Path;
+string customPath = projected.ProjectedPath;
+```
+
+結果例:
+
+```text
+standardPath:
+Root.Children[#0].Fields[#0].Value
+
+customPath:
+Root.Child1[#0].Attribute1[#0].Value
+```
+
+### 7.8 Pattern matching
+
+```csharp
+public static class ParallelDiffEntryPathProjectionExtensions
+{
+    public static bool PathMatches(
+        this ParallelDiffEntryPathProjection projection,
+        ParallelDiffPathPattern pattern);
+}
+```
+
+この overload は `ProjectedPath` を照合する。
+
+既存 overload は変更しない。
+
+```csharp
+entry.PathMatches(pattern);
+```
+
+既存 overload は引き続き `ParallelDiffEntry.Path`、つまり標準 path を照合する。
+
+利用例:
+
+```csharp
+ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+    "Root.Child1[*].Child2[*].Attribute1[*].Value");
+
+ParallelDiffEntryPathProjection[] matched = result
+    .GetDiffEntryPathProjections(projector)
+    .Where(entry => entry.PathMatches(pattern))
+    .ToArray();
+```
+
+## 8. Projection 規則
+
+### 8.1 標準 path の維持
+
+`GetDiffEntryPathProjections()` が返す `Entry` は、既存 `GetDiffEntries()` が返す entry と同じ標準情報を持つ。
+
+次を変更しない。
+
+- entry 件数
+- entry 順序
+- `Entry.Path`
+- `Entry.ParentPath`
+- `Entry.Kind`
+- `Entry.ParentNode`
+- `Entry.Node`
+- `Entry.Values`
+
+### 8.2 Segment 単位の処理
+
+標準 path を root 側から segment 単位で処理する。
+
+```text
+Root
+Children[#0]
+Fields[#0]
+Value
+```
+
+各 segment に対して projector を適用し、結果を順番に連結する。
+
+### 8.3 Escape
+
+利用側が返す member 名と key text は、SSC が既存 path grammar に従って escape する。
+
+利用側は文字列連結で path を作らない。
+
+例:
+
+```text
+Member name: A.B
+Key text:    A]B
+```
+
+これらを path として安全に表現する責務は SSC が持つ。
+
+既存 grammar が member 名の dot escape を許容していない場合は、初期実装で対応可能な member 名の範囲を明示し、不正な member 名を拒否する。暗黙に不正 path を生成しない。
+
+### 8.4 Selector の維持
+
+member 名だけを変える場合は `WithMemberName()` を使用し、key と ordinal の意味を維持する。
+
+```text
+Children[#0]
+    ↓
+Child1[#0]
+```
+
+次の自動変換は行わない。
+
+```text
+[#0] -> [0]
+```
+
+`[#0]` は ordinal、`[0]` は key text `0` を表すため、意味が異なる。
+
+report 上だけ `[0]` と表示したい場合は report renderer の責務とする。
+
+### 8.5 Omit
+
+中間 segment と末尾 segment の両方を省略可能とする。
+
+例:
+
+```text
+DocumentWrapper.Root.Child1[#0].Value
+    ↓ DocumentWrapper と Value を省略
+Root.Child1[#0]
+```
+
+末尾 segment を省略した場合、`ProjectedPath` と `ProjectedParentPath` が同じ文字列になることがある。
+
+利用側定義 path は node lookup 用の住所ではないため、これを許容する。
+
+### 8.6 空 path の拒否
+
+すべての segment が `Omit` され、`ProjectedPath` が空になる場合は `InvalidOperationException` とする。
+
+空文字を有効な利用側定義 path として返さない。
+
+### 8.7 重複 path
+
+複数の entry が同じ `ProjectedPath` になることを許容する。
+
+例:
+
+```text
+Root.Item.Value
+Root.Item.Value
+```
+
+SSC は利用側定義 path の一意性を保証しない。
+
+理由:
+
+- projection は表示と filter のための機能である
+- entry は `Entry.Path` により標準位置を保持している
+- 同名 node の区別規則は利用側固有である
+
+filter は一致したすべての entry を返す。
+
+### 8.8 Model slot 間の値
+
+SSC は複数 model slot のどの値を採用するか決めない。
+
+projector は `IParallelNode.Count`、`GetValue()`、`GetState()` を使って判断する。
+
+推奨例:
+
+1. `Missing` ではない slot から候補名を取得する
+2. すべて同じ場合だけその名前を使う
+3. 異なる場合は `KeepStandard()` へ fallback する
+
+ただし、この規則自体は SSC の production code へ実装しない。
+
+### 8.9 Container presence entry
+
+empty container の有無差分では、対応する child node が存在しない。
+
+その場合の context は次とする。
+
+```text
+Current.Node     = null
+Current.Siblings = empty
+Current.ParentNode = container owner node
+```
+
+projector は node 値を必要とする置換を行えないため、通常は `KeepStandard()` を返す。
+
+### 8.10 Projector の呼び出し
+
+projector は同期的に呼び出す。
+
+初期実装では並列呼び出しを行わない。
+
+同じ node に対応する segment が複数 entry の path に現れる場合、projector が複数回呼ばれる可能性がある。projector は呼び出し回数へ依存しない実装とする。
+
+## 9. 利用例
+
+### 9.1 Named tree model
+
+```csharp
+public sealed class Document
+{
+    public TreeNode Root { get; init; } = new();
+}
+
+public sealed class TreeNode
+{
+    public string Name { get; init; } = string.Empty;
+
+    public List<TreeNode> Children { get; init; } = [];
+
+    public List<NamedValue> Fields { get; init; } = [];
+}
+
+public sealed class NamedValue
+{
+    public string Name { get; init; } = string.Empty;
+
+    public string Value { get; init; } = string.Empty;
+}
+```
+
+標準 path:
+
+```text
+Root.Children[#0].Children[#0].Fields[#0].Value
+```
+
+利用側が目指す path:
+
+```text
+Root.Child1[#0].Child2[#0].Attribute1[#0].Value
+```
+
+### 9.2 利用側 projector の概念例
+
+次のコードは利用方法を示す概念例であり、SSC が提供する具体的 projector ではない。
+
+```csharp
+public sealed class NamedTreePathProjector : IParallelDiffPathProjector
+{
+    public ParallelDiffPathSegmentProjection Project(
+        ParallelDiffPathProjectionContext context)
+    {
+        ParallelDiffPathNodeContext current = context.Current;
+
+        if (current.Node is null)
+        {
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        }
+
+        if (current.StandardSegment.MemberName == "Children")
+        {
+            string? name = TryGetCommonTreeNodeName(current.Node);
+            return name is null
+                ? ParallelDiffPathSegmentProjection.KeepStandard()
+                : ParallelDiffPathSegmentProjection.Replace(
+                    current.StandardSegment.WithMemberName(name));
+        }
+
+        if (current.StandardSegment.MemberName == "Fields")
+        {
+            string? name = TryGetCommonNamedValueName(current.Node);
+            return name is null
+                ? ParallelDiffPathSegmentProjection.KeepStandard()
+                : ParallelDiffPathSegmentProjection.Replace(
+                    current.StandardSegment.WithMemberName(name));
+        }
+
+        return ParallelDiffPathSegmentProjection.KeepStandard();
+    }
+}
+```
+
+`TryGetCommonTreeNodeName()` と `TryGetCommonNamedValueName()` は利用側が実装する。
+
+SSC は次を知らない。
+
+- `TreeNode.Name` が path 名であること
+- `NamedValue.Name` が field 名であること
+- model slot 間で名前が一致すべきこと
+
+### 9.3 Filter
+
+```csharp
+IReadOnlyList<ParallelDiffEntryPathProjection> projections =
+    result.GetDiffEntryPathProjections(new NamedTreePathProjector());
+
+ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
+    "Root.Child1[*].Child2[*].Attribute1[*].Value");
+
+ParallelDiffEntryPathProjection[] matched = projections
+    .Where(projection => projection.PathMatches(pattern))
+    .ToArray();
+```
+
+標準 path に対する既存 filter も同時に利用できる。
+
+```csharp
+ParallelDiffEntry[] standardMatches = result
+    .GetDiffEntries()
+    .Where(entry => entry.PathMatches(standardPattern))
+    .ToArray();
+```
+
+## 10. 例外と失敗
+
+- `GetDiffEntryPathProjections(null result, ...)` は `ArgumentNullException`
+- `GetDiffEntryPathProjections(..., null projector)` は `ArgumentNullException`
+- `ParallelDiffPathSegment.Member(null または空文字)` は `ArgumentException`
+- `ParallelDiffPathSegment.Key(..., null または空文字)` は `ArgumentException`
+- `ParallelDiffPathSegment.Ordinal(..., 負数)` は `ArgumentOutOfRangeException`
+- `Replace(null)` は `ArgumentNullException`
+- 全 segment を省略した場合は `InvalidOperationException`
+- projector が送出した例外は握りつぶさず、そのまま呼び出し元へ伝播する
+- projector が不正な path segment を返すことは factory validation により防ぐ
+
+`validation` は入力値が API 契約を満たすか検査することを意味する。
+
+## 11. 実装方針
+
+### 11.1 標準 path の segment 化
+
+現行 `AddNodeDiffEntries()` と `AddChildSetDiffEntries()` が文字列 path を直接連結する処理を、内部の segment stack を使う形へ整理する。
+
+`stack` は「現在の再帰位置までの要素を順番に積み上げた構造」を意味する。
+
+概念:
+
+```text
+Root
+Root + Children[#0]
+Root + Children[#0] + Fields[#0]
+Root + Children[#0] + Fields[#0] + Value
+```
+
+既存 `Path` の文字列結果は完全一致させる。
+
+### 11.2 Node context stack
+
+path segment と同じ階層で次を保持する。
+
+```text
+StandardSegment
+ParentNode
+Node
+Siblings
+```
+
+差分 entry を生成する時点で、この stack を root から順に projector へ渡す。
+
+標準 path 文字列を再解析しない。
+
+`GetNodeByPath()` で root から node を再探索しない。
+
+### 11.3 Formatter の共有
+
+標準 path と利用側定義 path は同じ formatter を使用する。
+
+`formatter` は構造化された segment を文字列へ変換する処理を意味する。
+
+次を共有する。
+
+- dot 連結
+- `[]` の生成
+- key escape
+- 先頭 `#` の escape
+- ordinal の `#` 表記
+
+標準 path と利用側定義 path で異なる grammar を作らない。
+
+### 11.4 Pattern parser の再利用
+
+利用側定義 path は既存 path grammar で文字列化するため、`ParallelDiffPathPattern` の既存 parser と matcher を再利用する。
+
+新しい wildcard grammar は追加しない。
+
+### 11.5 比較 pipeline との分離
+
+本機能の production code から次を変更しない。
+
+- `ParallelCompareApi.Compare()`
+- `CompareConfiguration`
+- `CompareIgnoreAttribute`
+- `CompareKeyAttribute`
+- `TypeMetadataResolver`
+- container normalization
+- key union
+- node の value/state 判定
+
+`pipeline` は入力から比較結果を生成する一連の処理を意味する。
+
+本機能は比較結果の列挙時にだけ動作する。
+
+```text
+models
+  -> metadata resolution
+  -> comparison tree construction
+  -> CompareResult<T>
+  -> GetDiffEntries()                     標準 entry
+  -> GetDiffEntryPathProjections(projector) 利用側定義 path 付き結果
+```
+
+## 12. 後方互換
+
+### 12.1 既存 API
+
+次の API の signature と挙動を変更しない。
+
+```csharp
+result.GetDiffEntries();
+entry.PathMatches(pattern);
+result.GetNodeByPath(path);
+result.GetValueByPath(path, modelIndex);
+result.GetStateByPath(path, modelIndex);
+```
+
+`signature` は method 名、引数、戻り値からなる公開形式を意味する。
+
+### 12.2 `ParallelDiffEntry.ToString()`
+
+既存どおり `ParallelDiffEntry.Path`、つまり標準 path を表示する。
+
+利用側定義 path を暗黙に使用しない。
+
+### 12.3 標準 path の解決可能性
+
+次の既存契約を維持する。
+
+```csharp
+entry.Node == result.GetNodeByPath(entry.Path)
+```
+
+利用側定義 path にはこの契約を適用しない。
+
+## 13. テスト方針
+
+### 13.1 既存回帰
+
+- options なしの `GetDiffEntries()` が既存 entry 件数を維持する
+- 標準 `Path` と `ParentPath` が完全一致する
+- entry 順序が変わらない
+- `Entry.Node` が `GetNodeByPath(Entry.Path)` で解決できる
+- `ParallelDiffEntry.ToString()` が変わらない
+- 既存 `ParallelDiffPathPattern` test を変更せず通す
+- 既存 `CompareIgnore` test を変更せず通す
+
+### 13.2 Segment projection
+
+- `KeepStandard()` が標準 segment を維持する
+- `Replace()` が member 名を変更できる
+- `Replace()` が key selector を維持できる
+- `Replace()` が ordinal selector を維持できる
+- `Omit()` が中間 segment を省略できる
+- `Omit()` が末尾 segment を省略できる
+- 全 segment の `Omit()` を拒否する
+
+### 13.3 Context
+
+- root 直下では ancestor が空になる
+- nested node では ancestor が root 順に渡る
+- scalar/object member で `Node` が渡る
+- container element で sibling 一覧が渡る
+- ordinal child で標準 selector が `[#n]` になる
+- key child で標準 selector が `[key]` になる
+- container presence entry で `Node == null`、siblings が空になる
+
+### 13.4 Escape
+
+- key text 内の `]` を escape する
+- key text 内の `\` を escape する
+- key text 先頭の `#` を escape する
+- projector が返した member 名の許容範囲を検証する
+- 不正な member 名から不正 path を生成しない
+
+### 13.5 Pattern matching
+
+- projection extension が `ProjectedPath` を照合する
+- 既存 entry extension が標準 `Path` を照合し続ける
+- `[*]` が projected key selector に一致する
+- `[*]` が projected ordinal selector に一致する
+- exact key と exact ordinal を区別する
+
+### 13.6 重複と fallback
+
+- 同じ `ProjectedPath` を持つ複数 entry を保持する
+- projector が `KeepStandard()` を返した segment だけ標準名へ戻る
+- 一部 segment だけ置換できる
+- projector 例外を呼び出し元へ伝播する
+
+### 13.7 比較結果への非影響
+
+- `CompareResult<T>.Root` が変化しない
+- `CompareResult<T>.Issues` が変化しない
+- `CompareResult<T>.HasError` が変化しない
+- `Root.HasDifferences()` が変化しない
+- `GetDiffEntries()` の結果が projection 呼び出し前後で変化しない
+
+## 14. 実装対象ファイルの想定
+
+初期実装では概ね次を対象とする。
+
+```text
+src/SSC/
+  ParallelDiffPathProjection.cs
+  ParallelDiffPathSegments.cs
+  ParallelPathAccessExtensions.cs
+
+src/SSC/Internal/
+  path formatter / traversal context helper
+
+tests/SSC.Unit.Tests/
+  ParallelDiffPathProjectionUnitTests.cs
+
+tests/SSC.E2E.Tests/
+  ParallelDiffPathProjectionE2ETests.cs
+
+doc/design/detail/
+  02-PublicApi.md
+  11-DiffEntryCustomPath.md
+```
+
+実装時の class 分割は既存の source 配置と責務に合わせて調整する。
+
+## 15. 完了条件
+
+- 既存 `ParallelDiffEntry.Path` が標準 path として維持される
+- 利用側が node context から segment を置換または省略できる
+- 利用側が path 文字列を手作業で組み立てる必要がない
+- 再帰 model でも意味名を使った利用側定義 path を生成できる
+- 利用側定義 path を既存 `ParallelDiffPathPattern` で絞り込める
+- XML 等の domain 固有規則が SSC production code に入らない
+- `CompareConfiguration`、metadata resolution、比較 tree 構築へ影響しない
+- 既存 path access、diff entry、filter の全回帰が通る

--- a/doc/design/detail/11-DiffEntryCustomPath.md
+++ b/doc/design/detail/11-DiffEntryCustomPath.md
@@ -1,22 +1,33 @@
-# 差分 entry の利用側定義 path 投影（Diff Entry Custom Path Projection）
+# 差分 entry の利用側定義 path 投影
 
 ## 1. 目的
 
 `CompareResult<T>.GetDiffEntries()` が返す差分 entry に対し、SSC が生成する既存 path を変更せず、利用側が用途に応じた別の path 表現を生成できるようにする。
 
-再帰的な model では、既存 path が次のように同じ member 名を繰り返すことがある。
+再帰的な model では、標準 path が次のように同じ member 名を繰り返すことがある。
 
 ```text
-Root.Children[#0].Children[#0].Fields[#0].Value
+Root.Children[0].Children[0].Fields[0].Value
 ```
 
-利用側が各 node の `Name` など、比較対象 instance が持つ実際の値を使い、次のような読みやすい path を生成できることを目的とする。
+この path は SSC の model 構造として正しいが、利用者が知りたい node 名や field 名を直接表していない。
+
+利用側が各 node の `Name` など、比較対象 instance が持つ実行時の値を使い、次のような path を生成できるようにする。
 
 ```text
-Root.Child1[#0].Child2[#0].Attribute1[#0].Value
+Root.Child1[0].Child2[0].Attribute1[0].Value
 ```
 
-本機能は path の表示、分類、絞り込みを改善するための比較後処理である。比較対象、比較結果、container 要素の対応付けには影響しない。
+本機能は path の表示、分類、絞り込みを改善するための比較後処理である。
+
+次には影響しない。
+
+- 比較対象 member
+- model 間の比較結果
+- container 要素の対応付け
+- `CompareKey`
+- `CompareResult<T>.Root`
+- `CompareResult<T>.Issues`
 
 ## 2. 用語
 
@@ -24,19 +35,20 @@ Root.Child1[#0].Child2[#0].Attribute1[#0].Value
 
 | 用語 | 本設計での意味 |
 |---|---|
-| entry | 差分1件を表す `ParallelDiffEntry` またはその関連結果 |
+| entry | 差分1件を表す `ParallelDiffEntry`、またはその関連結果 |
 | node | SSC の比較 tree を構成する `IParallelNode` 1件 |
 | tree | 親子関係で構成される階層構造 |
 | member | C# model の property または field |
 | container | `List`、array、`IEnumerable`、dictionary など複数要素を保持する member |
 | sequence | 順序を持つ container 要素列 |
 | key | container 要素を対応付ける識別値 |
-| ordinal | key を持たない sequence 内の並び順。`0` から始まる |
-| model slot | 比較に渡した各 model の値位置。`modelIndex` と同じ意味 |
+| index alignment | `CompareKey` がない sequence を同じ index 同士で対応付ける処理。本設計では「index 対応付け」と呼ぶ |
+| ordinal | node の `KeyText` がない場合に、同じ child set 内の並び順で識別する値。`0` から始まる |
+| model slot | 比較へ渡した各 model の値位置。`modelIndex` と同じ意味 |
 | standard path / canonical path | SSC が `ParallelDiffEntry.Path` に格納する既存の正式 path。本設計では「標準 path」と呼ぶ |
 | custom path | 利用側が標準 path から生成する別表現。本設計では「利用側定義 path」と呼ぶ |
-| alias | 同じ対象に付ける別名 |
-| projection | 元の情報を保持したまま、別の見え方へ変換する処理。本設計では「投影」と呼ぶ |
+| alias | 同じ対象へ付ける別名 |
+| projection | 元の情報を保持したまま別の見え方へ変換する処理。本設計では「投影」と呼ぶ |
 | projector | 投影規則を実装する利用側 component。本設計では「投影器」と呼ぶ |
 | segment | dot で区切られた path の構成要素1件 |
 | selector | container 要素を識別する `[]` 部分 |
@@ -45,68 +57,109 @@ Root.Child1[#0].Child2[#0].Attribute1[#0].Value
 | ancestor | 現在位置より上位にある祖先 node |
 | fallback | 利用側定義名を決められない場合に安全な既定動作へ戻すこと |
 | pattern | path を照合するためのひな形 |
-| wildcard | 任意の値へ一致する記号。既存 API では selector の `[*]` |
+| wildcard | 任意の selector へ一致する記号。既存 API では `[*]` |
+| formatter | 構造化された segment を path 文字列へ変換する処理 |
+| pipeline | 入力 model から比較結果を構築する一連の処理 |
+| deterministic | 同じ入力なら毎回同じ結果になる性質。本設計では「決定的」と呼ぶ |
+| validation | API へ渡された値が契約を満たすか検査する処理 |
 
-### 2.1 標準 path
+### 2.1 標準 path（canonical path）
 
-標準 path は、SSC が現在 `ParallelDiffEntry.Path` に格納している正式な path である。
+`canonical` は「基準となる正式な表現」という意味である。
 
-`canonical` は「基準となる正式な表現」という意味だが、本設計では英語だけで呼ばず、以降は「標準 path」と記載する。
+本設計では英語だけで呼ばず、「標準 path」と記載する。
+
+標準 path は、SSC が現在 `ParallelDiffEntry.Path` に格納している比較 tree 上の正式な住所である。
 
 例:
 
 ```text
 Groups[1].Items[100].MetricA
-Root.Children[#0].Fields[#0].Value
+Root.Children[0].Fields[0].Value
 ```
 
-標準 path は SSC の比較 tree 上の位置を表す。
+標準 path は次の既存契約を持つ。
 
 - `GetNodeByPath()` で node を取得できる
 - `ParallelDiffEntry.Path` と `ParallelDiffEntry.ParentPath` に使用される
 - 既存 `ParallelDiffEntry.PathMatches()` の照合対象になる
+- `ParallelDiffEntry.ToString()` に使用される
 - 後方互換の対象である
 
-### 2.2 利用側定義 path
+### 2.2 利用側定義 path（custom path）
 
-利用側定義 path は、利用側が標準 path を別の意味表現へ変換した path である。
+`custom` は「利用側が用途に合わせて定義する」という意味である。
 
-例:
+利用側定義 path は、標準 path を別の意味表現へ変換した path である。
 
 ```text
 標準 path:
-Root.Children[#0].Fields[#0].Value
+Root.Children[0].Fields[0].Value
 
 利用側定義 path:
-Root.Child1[#0].Attribute1[#0].Value
+Root.Child1[0].Attribute1[0].Value
 ```
 
-利用側定義 path は表示、分類、絞り込みに使用する。初期実装では node の住所として扱わない。
+利用側定義 path は次に使用する。
 
-### 2.3 Segment と selector
+- report 表示
+- log 表示
+- 差分分類
+- `ParallelDiffPathPattern` による絞り込み
 
-次の path は3 segment で構成される。
+初期実装では node の住所として扱わない。
+
+### 2.3 Segment
+
+`segment` は、dot で区切られた path の構成要素1件を指す。
 
 ```text
-Root.Children[#0].Value
+Root.Children[0].Value
 ```
+
+この path は次の3 segment で構成される。
 
 ```text
 Root
-Children[#0]
+Children[0]
 Value
 ```
 
-`Children[#0]` の `[#0]` が selector である。
+### 2.4 Selector
+
+`selector` は、container member 配下の要素を識別する `[]` 部分を指す。
 
 ```text
-Items[A]   key selector。key text A で要素を識別する
-Items[#0]  ordinal selector。並び順 0 で要素を識別する
+Items[A]
+Items[0]
+Items[#0]
+```
+
+selector は2種類ある。
+
+| 表現 | 種類 | 意味 |
+|---|---|---|
+| `[A]` | key selector | `KeyText == "A"` の node |
+| `[0]` | key selector | `KeyText == "0"` の node |
+| `[#0]` | ordinal selector | `KeyText` がない child set の0番目の node |
+
+`[0]` と `[#0]` は意味が異なる。
+
+現在の index 対応付けでは、SSC が index を `KeyText` として保持するため、標準 path は通常 `[0]` になる。
+
+```text
+Children[0]
+```
+
+一方、`IParallelNode.KeyText == null` の child は ordinal selector を使う。
+
+```text
+Children[#0]
 ```
 
 具体的な path segment では wildcard `[*]` を使用しない。`[*]` は `ParallelDiffPathPattern` 側だけの表現とする。
 
-### 2.4 投影と投影器
+### 2.5 投影（projection）
 
 投影は、標準 path の各 segment を次のいずれかへ変換する処理である。
 
@@ -114,29 +167,44 @@ Items[#0]  ordinal selector。並び順 0 で要素を識別する
 - 別の具体的 segment へ置き換える
 - 利用側定義 path から省略する
 
-投影器は、この判断を行う利用側実装である。
+標準 path 自体は変更しない。
 
-SSC は node と path の構造情報を投影器へ渡す。投影器は利用側定義 path での segment を返す。
+### 2.6 投影器（projector）
 
-SSC は `Name`、`Children`、`Fields` などの業務上の意味を解釈しない。
+投影器は、各 segment の投影規則を実装する利用側 component である。
 
-### 2.5 Fallback
+SSC は node と path の構造情報を投影器へ渡す。
 
-利用側が runtime の値から別名を決定できない場合は、標準 segment の維持を推奨する。
+投影器は、利用側定義 path でその segment をどう扱うか返す。
+
+SSC は次の意味を解釈しない。
 
 ```text
-Children[#0]
-    ↓ 別名を決定できない
-Children[#0]
+Name      = node 名
+Children  = XML の子要素
+Fields    = 属性
+Value     = report では省略可能
+```
+
+### 2.7 Fallback
+
+`fallback` は、利用側が別名を決定できない場合に安全な既定動作へ戻すことを意味する。
+
+推奨 fallback は標準 segment の維持である。
+
+```text
+Children[0]
+    ↓ 名前を決定できない
+Children[0]
 ```
 
 SSC は model slot 間のどの値を採用すべきか自動判断しない。
 
 ## 3. 現状と問題
 
-現行 `GetDiffEntries()` は、比較 tree を再帰的に走査し、member 名と selector を連結して `ParallelDiffEntry.Path` を生成する。
+現行 `GetDiffEntries()` は比較 tree を再帰的に走査し、member 名と selector を連結して `ParallelDiffEntry.Path` を生成する。
 
-container child では次の規則を使用する。
+container child では次の規則を使う。
 
 - `IParallelNode.KeyText` がある場合は key selector
 - `IParallelNode.KeyText` がない場合は ordinal selector
@@ -168,7 +236,7 @@ public sealed class NamedValue
 }
 ```
 
-実データが次の場合、利用者には `Name` の方が意味を持つ。
+実データ:
 
 ```text
 Root
@@ -180,13 +248,13 @@ Root
 標準 path:
 
 ```text
-Root.Children[#0].Children[#0].Fields[#0].Value
+Root.Children[0].Children[0].Fields[0].Value
 ```
 
 利用側が望む path:
 
 ```text
-Root.Child1[#0].Child2[#0].Attribute1[#0].Value
+Root.Child1[0].Child2[0].Attribute1[0].Value
 ```
 
 SSC が `Name` を自動採用することはできない。
@@ -196,7 +264,7 @@ SSC が `Name` を自動採用することはできない。
 - model slot 間で名前が異なる場合の採用規則は利用側ごとに異なる
 - 同名 sibling の区別規則も利用側ごとに異なる
 
-SSC は判断材料だけを渡し、意味の決定は利用側に委ねる必要がある。
+SSC は判断材料だけを渡し、意味の決定は利用側へ委ねる必要がある。
 
 ## 4. 責務境界
 
@@ -211,27 +279,28 @@ SSC は次を担当する。
 5. 標準 entry と利用側定義 path を同じ結果から参照できるようにする
 6. 利用側定義 path に既存 `ParallelDiffPathPattern` を適用できるようにする
 7. 既存 `GetDiffEntries()` の件数、順序、path、node 参照を維持する
+8. key text の escape と member 名の validation を一元管理する
 
 ### 4.2 利用側の責務
 
 利用側は次を担当する。
 
 1. どの member を置換または省略するか決める
-2. node のどの runtime 値を利用側定義名として使うか決める
+2. node のどの実行時値を利用側定義名として使うか決める
 3. model slot 間で候補名が異なる場合の規則を決める
 4. 同名 sibling をどう区別するか決める
 5. 名前を決定できない場合の fallback を決める
-6. 利用側定義 path をレポート、ログ、分類へどう表示するか決める
+6. 利用側定義 path を report、log、分類へどう表示するか決める
 
 ### 4.3 SSC が解釈しない情報
 
-SSC は次のような model 固有の意味を自動判定しない。
+SSC は次のような domain 固有情報を自動判定しない。
 
 ```text
-Name      = node 名
-Children  = XML の子要素
-Fields    = 属性
-Value     = レポートでは省略可能
+TreeNode.Name       が element 名である
+NamedValue.Name     が attribute 名である
+Children            が XML の子要素である
+Fields              が XML の属性である
 ```
 
 ## 5. 非目的
@@ -250,25 +319,16 @@ Value     = レポートでは省略可能
 - property 名から `Name` や `Id` を自動発見する規則
 - 利用側定義 path の一意性保証
 - member 名 wildcard や任意深度 wildcard の追加
-- `[#0]` を表示上の `[0]` へ自動変換する処理
-- 正規表現による path 変換
+- report 固有の `[0]` / `[#0]` 表記変換
+- 非同期 projector
 
-`CompareConfiguration` に投影器を置かない理由は、同じ比較結果へ複数の見え方を適用できるようにするためである。
+## 6. Alias attribute
 
-```csharp
-var reportPaths = result.GetDiffEntryPathProjections(reportProjector);
-var logPaths = result.GetDiffEntryPathProjections(logProjector);
-```
+### 6.1 どのようなものか
 
-投影は比較設定ではなく、比較後の出力表現である。
+`alias attribute` は、C# member に固定的な別名を指定する attribute を意味する。
 
-## 6. 固定 alias attribute を対象外とする理由
-
-### 6.1 Alias attribute とは
-
-C# の attribute は、class、property、field などに付加する metadata である。
-
-固定 alias attribute を導入する場合、概念的には次の API になる。
+仮に次の API があるとする。
 
 ```csharp
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
@@ -293,7 +353,7 @@ public sealed class Order
 }
 ```
 
-この仕組みなら固定置換は可能である。
+この場合は固定的な member rename を表現できる。
 
 ```text
 Items[100].Price
@@ -303,7 +363,7 @@ Lines[100].Price
 
 ### 6.2 今回の要求を満たせない理由
 
-再帰 model で必要になる名前は、property に固定された名前ではなく各 node の runtime 値である。
+再帰 model で必要になる名前は property に固定された名前ではなく、各 node の実行時値である。
 
 ```csharp
 public sealed class TreeNode
@@ -314,7 +374,7 @@ public sealed class TreeNode
 }
 ```
 
-同じ `Children` property の要素が、実行時にはそれぞれ異なる名前を持つ。
+同じ `Children` property の要素が実行時にはそれぞれ異なる名前を持つ。
 
 ```text
 Child1
@@ -331,16 +391,16 @@ public List<TreeNode> Children { get; init; }
 
 この指定ではすべての child が `Child1` になる。
 
-### 6.3 初期設計での判断
+### 6.3 初期実装での判断
 
 固定 alias attribute は初期対象に含めない。
 
-- runtime の node 値を参照できない
+- 実行時の node 値を参照できない
 - `TypeMetadataResolver` に出力表現の責務が入る
 - 比較 metadata と比較後の表示規則が混ざる
 - 同じ比較結果へ異なる path 表現を適用しにくくなる
 
-固定 member rename の需要が別途明確になった場合は、本設計の投影器を簡単に構築する補助 API として後続設計する。
+固定 member rename の需要が明確になった場合は、本設計の投影器を簡単に構築する補助 API として別途設計する。
 
 ## 7. 公開 API
 
@@ -363,7 +423,7 @@ public static class ParallelPathAccessExtensions
 
 `GetDiffEntryPathProjections()` は、標準差分 entry と利用側定義 path の組を返す。
 
-### 7.2 投影器（projector）
+### 7.2 投影器
 
 ```csharp
 public interface IParallelDiffPathProjector
@@ -377,9 +437,9 @@ public interface IParallelDiffPathProjector
 
 投影器は同じ入力に対して同じ結果を返す決定的な実装とする。
 
-「決定的」は、同じ入力なら毎回同じ結果になることを意味する。時刻、乱数、外部の可変状態へ依存させない。
+時刻、乱数、外部の可変状態へ依存させない。
 
-### 7.3 投影時の文脈情報（projection context）
+### 7.3 投影時の文脈情報
 
 ```csharp
 public sealed class ParallelDiffPathProjectionContext
@@ -390,7 +450,9 @@ public sealed class ParallelDiffPathProjectionContext
 }
 ```
 
-`Ancestors` は root 側から現在の親までの順序で保持する。現在位置自身は含めず、`Current` で参照する。
+`Ancestors` は root 側から現在の親までの順序で保持する。
+
+現在位置自身は含めず、`Current` で参照する。
 
 root 直下 segment では `Ancestors.Count == 0` になる。
 
@@ -441,6 +503,24 @@ public sealed class ParallelDiffPathSegment
 
 `WithMemberName()` は selector を維持して member 名だけを変更する。
 
+index 対応付けの node:
+
+```csharp
+ParallelDiffPathSegment standard =
+    ParallelDiffPathSegment.Key("Children", "0");
+
+ParallelDiffPathSegment custom =
+    standard.WithMemberName("Child1");
+```
+
+```text
+Children[0]
+    ↓
+Child1[0]
+```
+
+ordinal node:
+
 ```csharp
 ParallelDiffPathSegment standard =
     ParallelDiffPathSegment.Ordinal("Children", 0);
@@ -455,7 +535,7 @@ Children[#0]
 Child1[#0]
 ```
 
-### 7.5 選択子（selector）
+### 7.5 Selector
 
 ```csharp
 public enum ParallelDiffPathSelectorKind
@@ -524,9 +604,9 @@ Value
 指定した具体的 segment へ置き換える。
 
 ```text
-Children[#0]
+Children[0]
     ↓
-Child1[#0]
+Child1[0]
 ```
 
 #### `Omit`
@@ -534,9 +614,9 @@ Child1[#0]
 利用側定義 path から segment を省略する。
 
 ```text
-DocumentWrapper.Root.Children[#0]
+DocumentWrapper.Root.Children[0]
     ↓ DocumentWrapper を省略
-Root.Children[#0]
+Root.Children[0]
 ```
 
 ### 7.7 投影結果
@@ -568,13 +648,20 @@ string customPath = projected.ProjectedPath;
 
 ```text
 standardPath:
-Root.Children[#0].Fields[#0].Value
+Root.Children[0].Fields[0].Value
 
 customPath:
-Root.Child1[#0].Attribute1[#0].Value
+Root.Child1[0].Attribute1[0].Value
 ```
 
-別々に呼び出した `GetDiffEntries()` と `GetDiffEntryPathProjections()` の entry について、object の参照一致は保証しない。件数、順序、property 値、node 参照の意味を一致させる。
+別々に呼び出した `GetDiffEntries()` と `GetDiffEntryPathProjections()` の entry について、object の参照一致は保証しない。
+
+次は一致させる。
+
+- 件数
+- 順序
+- property 値
+- `Node` と `ParentNode` の意味
 
 ### 7.8 Pattern 照合
 
@@ -630,14 +717,14 @@ ParallelDiffEntryPathProjection[] matched = result
 
 ```text
 Root
-Children[#0]
-Fields[#0]
+Children[0]
+Fields[0]
 Value
 ```
 
 各 segment に投影器を適用し、結果を順番に連結する。
 
-### 8.3 Member 名の検証と key text の escape
+### 8.3 Member 名の validation
 
 現行 path grammar は member 名の escape を定義していない。
 
@@ -650,13 +737,13 @@ Value
 
 不正な member 名は `ParallelDiffPathSegment` の生成時に `ArgumentException` とする。
 
-例:
-
 ```text
 Valid:   Child1
 Invalid: Child.1
 Invalid: Child[1]
 ```
+
+### 8.4 Key text の escape
 
 key text は既存規則に従って SSC が escape する。
 
@@ -666,49 +753,49 @@ key text は既存規則に従って SSC が escape する。
 
 利用側は path 文字列を手作業で連結しない。
 
-### 8.4 Selector の維持
+### 8.5 Selector の維持
 
 member 名だけを変える場合は `WithMemberName()` を使用し、key と ordinal の意味を維持する。
 
 ```text
-Children[#0]
+Children[0]
     ↓
-Child1[#0]
+Child1[0]
 ```
 
 次の自動変換は行わない。
 
 ```text
-[#0] -> [0]
+[0] <-> [#0]
 ```
 
-`[#0]` は ordinal、`[0]` は key text `0` を表すため、意味が異なる。
+`[0]` は key text `0`、`[#0]` は ordinal `0` を表すため、意味が異なる。
 
-レポート上だけ `[0]` と表示したい場合は、SSC の path grammar ではなく利用側の表示処理で変換する。
+report 上だけ表記を変えたい場合は report renderer の責務とする。
 
-### 8.5 Omit
+### 8.6 Omit
 
 中間 segment と末尾 segment の両方を省略可能とする。
 
 ```text
-DocumentWrapper.Root.Child1[#0].Value
+DocumentWrapper.Root.Child1[0].Value
     ↓ DocumentWrapper と Value を省略
-Root.Child1[#0]
+Root.Child1[0]
 ```
 
 末尾 segment を省略した場合、`ProjectedPath` と `ProjectedParentPath` が同じ文字列になることがある。
 
 利用側定義 path は node lookup 用の住所ではないため、これを許容する。
 
-### 8.6 空 path の拒否
+### 8.7 空 path の拒否
 
 すべての segment が `Omit` され、`ProjectedPath` が空になる場合は `InvalidOperationException` とする。
 
 空文字を有効な利用側定義 path として返さない。
 
-### 8.7 重複 path
+### 8.8 重複 path
 
-複数 entry が同じ `ProjectedPath` になることを許容する。
+複数の entry が同じ `ProjectedPath` になることを許容する。
 
 ```text
 Root.Item.Value
@@ -717,31 +804,37 @@ Root.Item.Value
 
 SSC は利用側定義 path の一意性を保証しない。
 
-- 投影は表示と絞り込みのための機能である
-- 各 entry は `Entry.Path` により標準位置を保持する
+理由:
+
+- 投影は表示と filter のための機能である
+- entry は `Entry.Path` により標準位置を保持している
 - 同名 node の区別規則は利用側固有である
 
-pattern は一致したすべての entry を返す。
+filter は一致したすべての entry を返す。
 
-### 8.8 Model slot 間の値
+### 8.9 Model slot 間の値
 
 SSC は複数 model slot のどの値を採用するか決めない。
 
-投影器は `IParallelNode.Count`、`GetValue()`、`GetState()` を使って判断する。
+投影器は次を使って判断する。
 
-利用側規則の例:
+- `IParallelNode.Count`
+- `IParallelNode.GetValue()`
+- `IParallelNode.GetState()`
+
+推奨例:
 
 1. `Missing` ではない slot から候補名を取得する
 2. すべて同じ場合だけその名前を使う
 3. 異なる場合は `KeepStandard()` へ fallback する
 
-この規則自体は SSC の製品コードへ実装しない。
+この規則自体は SSC の production code へ実装しない。
 
-### 8.9 Container presence entry
+### 8.10 Container presence entry
 
-空 container と missing container の存在差分では、対応する child node が存在しない。
+empty container の有無差分では対応する child node が存在しない。
 
-その場合の文脈情報は次とする。
+その場合の context は次とする。
 
 ```text
 Current.Node       = null
@@ -749,19 +842,60 @@ Current.Siblings   = empty
 Current.ParentNode = container owner node
 ```
 
-投影器は node 値を必要とする置換を行えないため、通常は `KeepStandard()` を返す。
+node 値を必要とする投影器は通常 `KeepStandard()` を返す。
 
-### 8.10 投影器の呼び出し
+### 8.11 投影器の呼び出し
 
-投影器は同期的に呼び出す。初期実装では並列呼び出しを行わない。
+投影器は同期的に呼び出す。
 
-同じ node に対応する segment が複数 entry の path に現れる場合、投影器が複数回呼ばれる可能性がある。投影器は呼び出し回数へ依存しない実装とする。
+初期実装では並列呼び出しを行わない。
+
+同じ node に対応する segment が複数 entry の path に現れる場合、投影器が複数回呼ばれる可能性がある。
+
+投影器は呼び出し回数へ依存しない実装とする。
 
 ## 9. 利用例
 
-### 9.1 利用側投影器の概念例
+### 9.1 比較 model
 
-次は利用方法を示す概念例であり、SSC が特定 model 向けに提供する投影器ではない。
+```csharp
+public sealed class Document
+{
+    public TreeNode Root { get; init; } = new();
+}
+
+public sealed class TreeNode
+{
+    public string Name { get; init; } = string.Empty;
+
+    public List<TreeNode> Children { get; init; } = [];
+
+    public List<NamedValue> Fields { get; init; } = [];
+}
+
+public sealed class NamedValue
+{
+    public string Name { get; init; } = string.Empty;
+
+    public string Value { get; init; } = string.Empty;
+}
+```
+
+標準 path:
+
+```text
+Root.Children[0].Children[0].Fields[0].Value
+```
+
+利用側が目指す path:
+
+```text
+Root.Child1[0].Child2[0].Attribute1[0].Value
+```
+
+### 9.2 利用側投影器の概念例
+
+次のコードは利用方法を示す概念例であり、SSC が domain 固有投影器として提供するものではない。
 
 ```csharp
 public sealed class NamedTreePathProjector : IParallelDiffPathProjector
@@ -807,26 +941,23 @@ SSC は次を知らない。
 - `NamedValue.Name` が field 名であること
 - model slot 間で名前が一致すべきこと
 
-### 9.2 絞り込み
+### 9.3 Filter
 
 ```csharp
 IReadOnlyList<ParallelDiffEntryPathProjection> projections =
     result.GetDiffEntryPathProjections(new NamedTreePathProjector());
 
-ParallelDiffPathPattern customPattern = ParallelDiffPathPattern.Parse(
+ParallelDiffPathPattern pattern = ParallelDiffPathPattern.Parse(
     "Root.Child1[*].Child2[*].Attribute1[*].Value");
 
-ParallelDiffEntryPathProjection[] customMatches = projections
-    .Where(projection => projection.PathMatches(customPattern))
+ParallelDiffEntryPathProjection[] matched = projections
+    .Where(projection => projection.PathMatches(pattern))
     .ToArray();
 ```
 
-標準 path に対する既存絞り込みも同時に利用できる。
+標準 path に対する既存 filter も同時に利用できる。
 
 ```csharp
-ParallelDiffPathPattern standardPattern = ParallelDiffPathPattern.Parse(
-    "Root.Children[*].Children[*].Fields[*].Value");
-
 ParallelDiffEntry[] standardMatches = result
     .GetDiffEntries()
     .Where(entry => entry.PathMatches(standardPattern))
@@ -837,35 +968,29 @@ ParallelDiffEntry[] standardMatches = result
 
 - `GetDiffEntryPathProjections(null result, ...)` は `ArgumentNullException`
 - `GetDiffEntryPathProjections(..., null projector)` は `ArgumentNullException`
-- `ParallelDiffPathSegment.Member(null または空文字)` は `ArgumentException`
-- member 名に `.`, `[`, `]` が含まれる場合は `ArgumentException`
-- `ParallelDiffPathSegment.Key(..., null または空文字)` は `ArgumentException`
+- `ParallelDiffPathSegment.Member(null)` は `ArgumentNullException`
+- `ParallelDiffPathSegment.Member(空文字)` は `ArgumentException`
+- `ParallelDiffPathSegment.Key(..., null)` は `ArgumentNullException`
+- `ParallelDiffPathSegment.Key(..., 空文字)` は `ArgumentException`
 - `ParallelDiffPathSegment.Ordinal(..., 負数)` は `ArgumentOutOfRangeException`
 - `Replace(null)` は `ArgumentNullException`
 - 全 segment を省略した場合は `InvalidOperationException`
-- 投影器が送出した例外は握りつぶさず、そのまま呼び出し元へ伝播する
-- 投影器が不正な segment を返すことは生成 method の入力検証で防ぐ
+- 投影器が送出した例外は握りつぶさず、呼び出し元へ伝播する
+- 不正な member 名は segment factory の validation で拒否する
 
 ## 11. 実装方針
 
-### 11.1 標準 path の segment 化
+### 11.1 比較 tree の1回走査
 
-現行 `AddNodeDiffEntries()` と `AddChildSetDiffEntries()` が文字列 path を直接連結する処理を、内部の segment stack を使う形へ整理する。
+標準差分 entry と利用側定義 path は、同じ `DiffEntryCollector` の再帰走査から生成する。
 
-`stack` は、現在の再帰位置までの要素を順番に積み上げた構造である。
+標準 path を文字列から再解析しない。
 
-```text
-Root
-Root + Children[#0]
-Root + Children[#0] + Fields[#0]
-Root + Children[#0] + Fields[#0] + Value
-```
+`GetNodeByPath()` で root から再探索しない。
 
-既存 `Path` の文字列結果は完全一致させる。
+### 11.2 Path frame
 
-### 11.2 Node context stack
-
-path segment と同じ階層で次を保持する。
+再帰中は path 階層ごとに次を保持する。
 
 ```text
 StandardSegment
@@ -874,33 +999,64 @@ Node
 Siblings
 ```
 
-差分 entry を生成する時点で、この stack を root から順に投影器へ渡す。
+この1階層分の情報を path frame として stack 状に保持する。
 
-標準 path 文字列を再解析しない。`GetNodeByPath()` で root から node を再探索しない。
+`stack` は、現在の再帰位置までの要素を順番に積み上げた構造を意味する。
 
-### 11.3 文字列化処理の共有
+```text
+Root
+Root + Children[0]
+Root + Children[0] + Fields[0]
+Root + Children[0] + Fields[0] + Value
+```
 
-標準 path と利用側定義 path は同じ文字列化処理を使用する。
+### 11.3 標準 entry の生成
 
-次を共有する。
+標準 entry の生成時は frame 内の標準 segment を formatter へ渡す。
+
+```text
+frames[0..last]     -> Entry.Path
+frames[0..last - 1] -> Entry.ParentPath
+```
+
+既存 path の文字列結果を維持する。
+
+### 11.4 利用側定義 path の生成
+
+各 frame を `ParallelDiffPathNodeContext` へ変換し、root 側から投影器へ渡す。
+
+投影結果を具体 segment の列へ変換し、同じ formatter で文字列化する。
+
+```text
+KeepStandard -> StandardSegment
+Replace      -> Replacement
+Omit         -> segment を追加しない
+```
+
+### 11.5 Formatter の共有
+
+標準 path と利用側定義 path は `ParallelDiffPathFormatter` を共有する。
+
+formatter は次を担当する。
 
 - dot 連結
 - `[]` の生成
-- key text の escape
+- key escape
 - 先頭 `#` の escape
 - ordinal の `#` 表記
+- invariant culture による ordinal 文字列化
 
 標準 path と利用側定義 path で異なる grammar を作らない。
 
-### 11.4 `ParallelDiffPathPattern` の再利用
+### 11.6 Pattern parser の再利用
 
-利用側定義 path は既存 path grammar で文字列化するため、既存 pattern parser と照合処理を再利用する。
+利用側定義 path は既存 path grammar で文字列化するため、`ParallelDiffPathPattern` の既存 parser と matcher を再利用する。
 
 新しい wildcard grammar は追加しない。
 
-### 11.5 比較処理との分離
+### 11.7 比較 pipeline との分離
 
-本機能では次を変更しない。
+本機能の production code から次を変更しない。
 
 - `ParallelCompareApi.Compare()`
 - `CompareConfiguration`
@@ -918,17 +1074,15 @@ models
   -> metadata resolution
   -> comparison tree construction
   -> CompareResult<T>
-  -> GetDiffEntries()                       標準 entry
-  -> GetDiffEntryPathProjections(projector) 利用側定義 path 付き結果
+  -> GetDiffEntries()                         標準 entry
+  -> GetDiffEntryPathProjections(projector)  利用側定義 path 付き結果
 ```
-
-`metadata resolution` は、比較対象 member や `CompareKey` などの metadata を解決する既存処理である。
 
 ## 12. 後方互換
 
 ### 12.1 既存 API
 
-次の公開形式と挙動を変更しない。
+次の API の signature と挙動を変更しない。
 
 ```csharp
 result.GetDiffEntries();
@@ -937,6 +1091,8 @@ result.GetNodeByPath(path);
 result.GetValueByPath(path, modelIndex);
 result.GetStateByPath(path, modelIndex);
 ```
+
+`signature` は method 名、引数、戻り値からなる公開形式を意味する。
 
 ### 12.2 `ParallelDiffEntry.ToString()`
 
@@ -954,19 +1110,30 @@ entry.Node == result.GetNodeByPath(entry.Path)
 
 利用側定義 path にはこの契約を適用しない。
 
+### 12.4 比較結果への非影響
+
+投影前後で次を変更しない。
+
+- `CompareResult<T>.Root`
+- `CompareResult<T>.Issues`
+- `CompareResult<T>.HasError`
+- `Root.HasDifferences()`
+- 標準 diff entry の件数と順序
+
 ## 13. テスト方針
 
-### 13.1 既存回帰
+### 13.1 Segment contract
 
-- 既存 `GetDiffEntries()` が entry 件数を維持する
-- 標準 `Path` と `ParentPath` が完全一致する
-- entry 順序が変わらない
-- `Entry.Node` が `GetNodeByPath(Entry.Path)` で解決できる
-- `ParallelDiffEntry.ToString()` が変わらない
-- 既存 `ParallelDiffPathPattern` test を変更せず通す
-- 既存 `CompareIgnore` test を変更せず通す
+- member segment を生成できる
+- key selector segment を生成できる
+- ordinal selector segment を生成できる
+- `WithMemberName()` が selector を維持する
+- 空 member 名を拒否する
+- `.`, `[`, `]` を含む member 名を拒否する
+- 空 key text を拒否する
+- 負の ordinal を拒否する
 
-### 13.2 Segment 投影
+### 13.2 Segment projection
 
 - `KeepStandard()` が標準 segment を維持する
 - `Replace()` が member 名を変更できる
@@ -976,25 +1143,24 @@ entry.Node == result.GetNodeByPath(entry.Path)
 - `Omit()` が末尾 segment を省略できる
 - 全 segment の `Omit()` を拒否する
 
-### 13.3 文脈情報
+### 13.3 Context
 
 - root 直下では ancestor が空になる
 - nested node では ancestor が root 順に渡る
 - scalar/object member で `Node` が渡る
 - container element で sibling 一覧が渡る
-- ordinal child で標準 selector が `[#n]` になる
 - key child で標準 selector が `[key]` になる
+- ordinal child で標準 selector が `[#n]` になる
 - container presence entry で `Node == null`、siblings が空になる
 
-### 13.4 Grammar と escape
+### 13.4 Escape
 
-- member 名の `.`, `[`, `]` を拒否する
 - key text 内の `]` を escape する
 - key text 内の `\` を escape する
 - key text 先頭の `#` を escape する
-- 不正な segment から不正 path を生成しない
+- 不正な member 名から不正 path を生成しない
 
-### 13.5 Pattern 照合
+### 13.5 Pattern matching
 
 - projection extension が `ProjectedPath` を照合する
 - 既存 entry extension が標準 `Path` を照合し続ける
@@ -1005,21 +1171,40 @@ entry.Node == result.GetNodeByPath(entry.Path)
 ### 13.6 重複と fallback
 
 - 同じ `ProjectedPath` を持つ複数 entry を保持する
-- `KeepStandard()` を返した segment だけ標準名へ戻る
+- 投影器が `KeepStandard()` を返した segment だけ標準名へ戻る
 - 一部 segment だけ置換できる
-- 投影器の例外を呼び出し元へ伝播する
+- 投影器例外を呼び出し元へ伝播する
 
-### 13.7 比較結果への非影響
+### 13.7 実比較 E2E
 
-- `CompareResult<T>.Root` が変化しない
-- `CompareResult<T>.Issues` が変化しない
-- `CompareResult<T>.HasError` が変化しない
-- `Root.HasDifferences()` が変化しない
-- projection 呼び出し前後で既存 `GetDiffEntries()` の結果が変化しない
+再帰 model を実際に `ParallelCompareApi.Compare()` へ渡し、次を確認する。
 
-## 14. 実装対象の想定
+```text
+標準 path:
+Root.Children[0].Children[0].Fields[0].Value
 
-初期実装では概ね次を対象とする。
+利用側定義 path:
+Root.Child1[0].Child2[0].Attribute1[0].Value
+```
+
+あわせて次を確認する。
+
+- 標準 path で node を解決できる
+- 利用側定義 pattern が projected path に一致する
+- 同じ pattern が標準 path には一致しない
+- 投影呼び出し前後で標準 entry が変化しない
+
+### 13.8 既存回帰
+
+- options なしの `GetDiffEntries()` が既存 entry 件数を維持する
+-標準 `Path` と `ParentPath` が完全一致する
+- entry 順序が変わらない
+- `Entry.Node` が `GetNodeByPath(Entry.Path)` で解決できる
+- `ParallelDiffEntry.ToString()` が変わらない
+- 既存 `ParallelDiffPathPattern` test を変更せず通す
+- 既存 `CompareIgnore` test を変更せず通す
+
+## 14. 実装対象ファイル
 
 ```text
 src/SSC/
@@ -1028,8 +1213,7 @@ src/SSC/
   ParallelPathAccessExtensions.cs
 
 src/SSC/Internal/
-  path segment formatter
-  traversal context helper
+  ParallelDiffPathFormatter.cs
 
 tests/SSC.Unit.Tests/
   ParallelDiffPathProjectionUnitTests.cs
@@ -1038,19 +1222,16 @@ tests/SSC.E2E.Tests/
   ParallelDiffPathProjectionE2ETests.cs
 
 doc/design/detail/
-  02-PublicApi.md
   11-DiffEntryCustomPath.md
 ```
-
-実際の class 分割は既存 source 配置と責務に合わせて調整する。
 
 ## 15. 完了条件
 
 - 既存 `ParallelDiffEntry.Path` が標準 path として維持される
-- 利用側が node の文脈情報から segment を置換または省略できる
+- 利用側が node context から segment を置換または省略できる
 - 利用側が path 文字列を手作業で組み立てる必要がない
-- 再帰 model でも意味名を使った利用側定義 path を生成できる
+- 再帰 model でも実行時の意味名を使った利用側定義 path を生成できる
 - 利用側定義 path を既存 `ParallelDiffPathPattern` で絞り込める
-- XML 等の domain 固有規則が SSC の製品コードに入らない
+- XML 等の domain 固有規則が SSC production code に入らない
 - `CompareConfiguration`、metadata resolution、比較 tree 構築へ影響しない
 - 既存 path access、diff entry、filter の全回帰が通る

--- a/src/SSC/Internal/ParallelDiffPathFormatter.cs
+++ b/src/SSC/Internal/ParallelDiffPathFormatter.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using System.Text;
+
+namespace SSC.Internal;
+
+internal static class ParallelDiffPathFormatter
+{
+    public static string Format(IReadOnlyList<ParallelDiffPathSegment> segments)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+        return Format(segments, segments.Count);
+    }
+
+    public static string Format(
+        IReadOnlyList<ParallelDiffPathSegment> segments,
+        int count)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+        if (count < 0 || count > segments.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        if (count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        for (var index = 0; index < count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append('.');
+            }
+
+            AppendSegment(builder, segments[index]);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendSegment(
+        StringBuilder builder,
+        ParallelDiffPathSegment segment)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+        builder.Append(segment.MemberName);
+
+        if (segment.Selector is not ParallelDiffPathSelector selector)
+        {
+            return;
+        }
+
+        builder.Append('[');
+        switch (selector.Kind)
+        {
+            case ParallelDiffPathSelectorKind.Key:
+                if (selector.KeyText is null)
+                {
+                    throw new InvalidOperationException("Key selector must contain key text.");
+                }
+
+                builder.Append(EscapeKeyText(selector.KeyText));
+                break;
+            case ParallelDiffPathSelectorKind.Ordinal:
+                if (selector.Ordinal is not int ordinal)
+                {
+                    throw new InvalidOperationException("Ordinal selector must contain an ordinal.");
+                }
+
+                builder.Append('#');
+                builder.Append(ordinal.ToString(CultureInfo.InvariantCulture));
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown diff path selector kind '{selector.Kind}'.");
+        }
+
+        builder.Append(']');
+    }
+
+    private static string EscapeKeyText(string keyText)
+    {
+        var escaped = keyText.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("]", "\\]", StringComparison.Ordinal);
+
+        if (escaped.Length > 0 && escaped[0] == '#')
+        {
+            return $"\\{escaped}";
+        }
+
+        return escaped;
+    }
+}

--- a/src/SSC/ParallelDiffPathProjection.cs
+++ b/src/SSC/ParallelDiffPathProjection.cs
@@ -1,0 +1,232 @@
+namespace SSC;
+
+/// <summary>
+/// 標準 path の各 segment を利用側定義 path へ変換します。
+/// </summary>
+/// <remarks>
+/// 標準 path は SSC が <see cref="ParallelDiffEntry.Path"/> に格納する比較 tree 上の正式な path です。
+/// 利用側定義 path は表示、分類、filter のために利用側が生成する別表現であり、node lookup には使用しません。
+/// </remarks>
+public interface IParallelDiffPathProjector
+{
+    /// <summary>
+    /// 現在の標準 path segment を利用側定義 path でどのように扱うか返します。
+    /// </summary>
+    /// <param name="context">現在位置と祖先 node の文脈情報。</param>
+    /// <returns>標準 segment の維持、置換、または省略を表す結果。</returns>
+    ParallelDiffPathSegmentProjection Project(
+        ParallelDiffPathProjectionContext context);
+}
+
+/// <summary>
+/// 差分 path segment を投影する際の現在位置と祖先情報を表します。
+/// </summary>
+public sealed class ParallelDiffPathProjectionContext
+{
+    internal ParallelDiffPathProjectionContext(
+        IReadOnlyList<ParallelDiffPathNodeContext> ancestors,
+        ParallelDiffPathNodeContext current)
+    {
+        ArgumentNullException.ThrowIfNull(ancestors);
+        ArgumentNullException.ThrowIfNull(current);
+        Ancestors = Array.AsReadOnly(ancestors.ToArray());
+        Current = current;
+    }
+
+    /// <summary>
+    /// root 側から現在の親までの文脈情報を取得します。現在位置自身は含みません。
+    /// </summary>
+    public IReadOnlyList<ParallelDiffPathNodeContext> Ancestors { get; }
+
+    /// <summary>
+    /// 現在投影している path segment の文脈情報を取得します。
+    /// </summary>
+    public ParallelDiffPathNodeContext Current { get; }
+}
+
+/// <summary>
+/// 差分 path の1階層に対応する node と標準 segment の文脈情報を表します。
+/// </summary>
+public sealed class ParallelDiffPathNodeContext
+{
+    internal ParallelDiffPathNodeContext(
+        ParallelDiffPathSegment standardSegment,
+        IParallelNode parentNode,
+        IParallelNode? node,
+        IReadOnlyList<IParallelNode> siblings)
+    {
+        ArgumentNullException.ThrowIfNull(standardSegment);
+        ArgumentNullException.ThrowIfNull(parentNode);
+        ArgumentNullException.ThrowIfNull(siblings);
+        StandardSegment = standardSegment;
+        ParentNode = parentNode;
+        Node = node;
+        Siblings = Array.AsReadOnly(siblings.ToArray());
+    }
+
+    /// <summary>
+    /// SSC が現在位置に生成する標準 path segment を取得します。
+    /// </summary>
+    public ParallelDiffPathSegment StandardSegment { get; }
+
+    /// <summary>
+    /// <see cref="StandardSegment"/> を所有する親 node を取得します。
+    /// </summary>
+    public IParallelNode ParentNode { get; }
+
+    /// <summary>
+    /// segment が指す現在の node を取得します。
+    /// </summary>
+    /// <remarks>
+    /// empty container と missing container の差分など、要素 node を持たない container presence entry では
+    /// <see langword="null"/> です。
+    /// </remarks>
+    public IParallelNode? Node { get; }
+
+    /// <summary>
+    /// 同じ <see cref="ParallelChildSet"/> に属する sibling node 一覧を取得します。
+    /// </summary>
+    /// <remarks>
+    /// sibling は同じ親を持つ兄弟 node を意味します。container presence entry では空です。
+    /// </remarks>
+    public IReadOnlyList<IParallelNode> Siblings { get; }
+}
+
+/// <summary>
+/// 標準 path segment に対する投影方法を表します。
+/// </summary>
+public enum ParallelDiffPathSegmentProjectionKind
+{
+    /// <summary>
+    /// 標準 segment をそのまま利用します。
+    /// </summary>
+    KeepStandard,
+
+    /// <summary>
+    /// 指定された別の具体 segment へ置き換えます。
+    /// </summary>
+    Replace,
+
+    /// <summary>
+    /// 利用側定義 path から標準 segment を省略します。
+    /// </summary>
+    Omit,
+}
+
+/// <summary>
+/// 標準 path segment 1件に対する投影結果を表します。
+/// </summary>
+public readonly struct ParallelDiffPathSegmentProjection
+{
+    private ParallelDiffPathSegmentProjection(
+        ParallelDiffPathSegmentProjectionKind kind,
+        ParallelDiffPathSegment? replacement)
+    {
+        Kind = kind;
+        Replacement = replacement;
+    }
+
+    /// <summary>
+    /// 投影方法を取得します。
+    /// </summary>
+    public ParallelDiffPathSegmentProjectionKind Kind { get; }
+
+    /// <summary>
+    /// <see cref="Kind"/> が <see cref="ParallelDiffPathSegmentProjectionKind.Replace"/> の場合の置換先を取得します。
+    /// </summary>
+    public ParallelDiffPathSegment? Replacement { get; }
+
+    /// <summary>
+    /// 標準 segment をそのまま利用する結果を返します。
+    /// </summary>
+    /// <returns>標準 segment を維持する結果。</returns>
+    public static ParallelDiffPathSegmentProjection KeepStandard()
+    {
+        return new ParallelDiffPathSegmentProjection(
+            ParallelDiffPathSegmentProjectionKind.KeepStandard,
+            replacement: null);
+    }
+
+    /// <summary>
+    /// 指定した具体 segment へ置き換える結果を返します。
+    /// </summary>
+    /// <param name="segment">利用側定義 path で使用する segment。</param>
+    /// <returns>指定 segment へ置き換える結果。</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="segment"/> が <see langword="null"/> の場合。</exception>
+    public static ParallelDiffPathSegmentProjection Replace(
+        ParallelDiffPathSegment segment)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+        return new ParallelDiffPathSegmentProjection(
+            ParallelDiffPathSegmentProjectionKind.Replace,
+            segment);
+    }
+
+    /// <summary>
+    /// 利用側定義 path から標準 segment を省略する結果を返します。
+    /// </summary>
+    /// <returns>標準 segment を省略する結果。</returns>
+    public static ParallelDiffPathSegmentProjection Omit()
+    {
+        return new ParallelDiffPathSegmentProjection(
+            ParallelDiffPathSegmentProjectionKind.Omit,
+            replacement: null);
+    }
+}
+
+/// <summary>
+/// 標準差分 entry と、投影器によって生成された利用側定義 path の組を表します。
+/// </summary>
+public sealed class ParallelDiffEntryPathProjection
+{
+    internal ParallelDiffEntryPathProjection(
+        ParallelDiffEntry entry,
+        string projectedPath,
+        string? projectedParentPath)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentException.ThrowIfNullOrEmpty(projectedPath);
+        Entry = entry;
+        ProjectedPath = projectedPath;
+        ProjectedParentPath = projectedParentPath;
+    }
+
+    /// <summary>
+    /// SSC が生成した標準差分 entry を取得します。
+    /// </summary>
+    public ParallelDiffEntry Entry { get; }
+
+    /// <summary>
+    /// 投影器を適用して生成した利用側定義 path を取得します。
+    /// </summary>
+    public string ProjectedPath { get; }
+
+    /// <summary>
+    /// 標準 parent path と同じ segment 範囲へ投影器を適用した path を取得します。
+    /// </summary>
+    public string? ProjectedParentPath { get; }
+}
+
+/// <summary>
+/// 利用側定義 path を持つ差分 entry の path pattern 判定を提供します。
+/// </summary>
+public static class ParallelDiffEntryPathProjectionExtensions
+{
+    /// <summary>
+    /// 利用側定義 path が指定 pattern に一致するか判定します。
+    /// </summary>
+    /// <param name="projection">判定する差分 entry projection。</param>
+    /// <param name="pattern">照合する path pattern。</param>
+    /// <returns><see cref="ParallelDiffEntryPathProjection.ProjectedPath"/> が一致する場合は <see langword="true"/>。</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="projection"/> または <paramref name="pattern"/> が <see langword="null"/> の場合。
+    /// </exception>
+    public static bool PathMatches(
+        this ParallelDiffEntryPathProjection projection,
+        ParallelDiffPathPattern pattern)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        ArgumentNullException.ThrowIfNull(pattern);
+        return pattern.IsMatch(projection.ProjectedPath);
+    }
+}

--- a/src/SSC/ParallelDiffPathSegments.cs
+++ b/src/SSC/ParallelDiffPathSegments.cs
@@ -143,6 +143,16 @@ public sealed class ParallelDiffPathSegment
         return new ParallelDiffPathSegment(memberName, Selector);
     }
 
+    internal static ParallelDiffPathSegment StandardKey(
+        string memberName,
+        string keyText)
+    {
+        ArgumentNullException.ThrowIfNull(keyText);
+        return new ParallelDiffPathSegment(
+            memberName,
+            ParallelDiffPathSelector.FromKey(keyText));
+    }
+
     private static void ValidateMemberName(string memberName)
     {
         ArgumentException.ThrowIfNullOrEmpty(memberName);

--- a/src/SSC/ParallelDiffPathSegments.cs
+++ b/src/SSC/ParallelDiffPathSegments.cs
@@ -147,9 +147,9 @@ public sealed class ParallelDiffPathSegment
     {
         ArgumentException.ThrowIfNullOrEmpty(memberName);
 
-        if (memberName.Contains('.', StringComparison.Ordinal)
-            || memberName.Contains('[', StringComparison.Ordinal)
-            || memberName.Contains(']', StringComparison.Ordinal))
+        if (memberName.Contains('.')
+            || memberName.Contains('[')
+            || memberName.Contains(']'))
         {
             throw new ArgumentException(
                 "Diff path member name cannot contain '.', '[' or ']'.",

--- a/src/SSC/ParallelDiffPathSegments.cs
+++ b/src/SSC/ParallelDiffPathSegments.cs
@@ -1,0 +1,159 @@
+namespace SSC;
+
+/// <summary>
+/// 差分 path の選択子が要素を識別する方法を表します。
+/// </summary>
+public enum ParallelDiffPathSelectorKind
+{
+    /// <summary>
+    /// 比較 key の文字列表現で要素を識別します。
+    /// </summary>
+    Key,
+
+    /// <summary>
+    /// key を持たない sequence 内の並び順で要素を識別します。
+    /// </summary>
+    Ordinal,
+}
+
+/// <summary>
+/// 差分 path segment の選択子を表します。
+/// </summary>
+public readonly struct ParallelDiffPathSelector
+{
+    private ParallelDiffPathSelector(
+        ParallelDiffPathSelectorKind kind,
+        string? keyText,
+        int? ordinal)
+    {
+        Kind = kind;
+        KeyText = keyText;
+        Ordinal = ordinal;
+    }
+
+    /// <summary>
+    /// 要素を識別する方法を取得します。
+    /// </summary>
+    public ParallelDiffPathSelectorKind Kind { get; }
+
+    /// <summary>
+    /// <see cref="Kind"/> が <see cref="ParallelDiffPathSelectorKind.Key"/> の場合の比較 key 文字列を取得します。
+    /// </summary>
+    public string? KeyText { get; }
+
+    /// <summary>
+    /// <see cref="Kind"/> が <see cref="ParallelDiffPathSelectorKind.Ordinal"/> の場合の並び順を取得します。
+    /// </summary>
+    public int? Ordinal { get; }
+
+    internal static ParallelDiffPathSelector FromKey(string keyText)
+    {
+        return new ParallelDiffPathSelector(ParallelDiffPathSelectorKind.Key, keyText, null);
+    }
+
+    internal static ParallelDiffPathSelector FromOrdinal(int ordinal)
+    {
+        return new ParallelDiffPathSelector(ParallelDiffPathSelectorKind.Ordinal, null, ordinal);
+    }
+}
+
+/// <summary>
+/// SSC の差分 path を構成する具体的な segment 1件を表します。
+/// </summary>
+/// <remarks>
+/// segment は <c>Root</c>、<c>Items[A]</c>、<c>Children[#0]</c> のような、dot で区切られる要素です。
+/// この型は特定位置を表すため、pattern 用の wildcard は保持しません。
+/// </remarks>
+public sealed class ParallelDiffPathSegment
+{
+    private ParallelDiffPathSegment(
+        string memberName,
+        ParallelDiffPathSelector? selector)
+    {
+        ValidateMemberName(memberName);
+        MemberName = memberName;
+        Selector = selector;
+    }
+
+    /// <summary>
+    /// member 名を取得します。
+    /// </summary>
+    public string MemberName { get; }
+
+    /// <summary>
+    /// container 要素を識別する選択子を取得します。通常の member の場合は <see langword="null"/> です。
+    /// </summary>
+    public ParallelDiffPathSelector? Selector { get; }
+
+    /// <summary>
+    /// 選択子を持たない member segment を生成します。
+    /// </summary>
+    /// <param name="memberName">member 名。</param>
+    /// <returns>生成した segment。</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="memberName"/> が空、または path grammar で表現できない文字を含む場合。
+    /// </exception>
+    public static ParallelDiffPathSegment Member(string memberName)
+    {
+        return new ParallelDiffPathSegment(memberName, selector: null);
+    }
+
+    /// <summary>
+    /// 比較 key で container 要素を識別する segment を生成します。
+    /// </summary>
+    /// <param name="memberName">container member 名。</param>
+    /// <param name="keyText">比較 key の文字列表現。</param>
+    /// <returns>生成した segment。</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="memberName"/> または <paramref name="keyText"/> が空、
+    /// もしくは <paramref name="memberName"/> が path grammar で表現できない文字を含む場合。
+    /// </exception>
+    public static ParallelDiffPathSegment Key(string memberName, string keyText)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyText);
+        return new ParallelDiffPathSegment(memberName, ParallelDiffPathSelector.FromKey(keyText));
+    }
+
+    /// <summary>
+    /// key を持たない sequence 内の並び順で要素を識別する segment を生成します。
+    /// </summary>
+    /// <param name="memberName">container member 名。</param>
+    /// <param name="ordinal">0から始まる並び順。</param>
+    /// <returns>生成した segment。</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="memberName"/> が空、または path grammar で表現できない文字を含む場合。
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="ordinal"/> が負数の場合。</exception>
+    public static ParallelDiffPathSegment Ordinal(string memberName, int ordinal)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+        return new ParallelDiffPathSegment(memberName, ParallelDiffPathSelector.FromOrdinal(ordinal));
+    }
+
+    /// <summary>
+    /// 現在の選択子を維持し、member 名だけを変更した segment を生成します。
+    /// </summary>
+    /// <param name="memberName">新しい member 名。</param>
+    /// <returns>member 名を変更した segment。</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="memberName"/> が空、または path grammar で表現できない文字を含む場合。
+    /// </exception>
+    public ParallelDiffPathSegment WithMemberName(string memberName)
+    {
+        return new ParallelDiffPathSegment(memberName, Selector);
+    }
+
+    private static void ValidateMemberName(string memberName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(memberName);
+
+        if (memberName.Contains('.', StringComparison.Ordinal)
+            || memberName.Contains('[', StringComparison.Ordinal)
+            || memberName.Contains(']', StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Diff path member name cannot contain '.', '[' or ']'.",
+                nameof(memberName));
+        }
+    }
+}

--- a/src/SSC/ParallelPathAccessExtensions.cs
+++ b/src/SSC/ParallelPathAccessExtensions.cs
@@ -53,13 +53,39 @@ public static class ParallelPathAccessExtensions
             return Array.Empty<ParallelDiffEntry>();
         }
 
-        var entries = new List<ParallelDiffEntry>();
-        foreach (var childSet in root.GetDirectChildren())
+        var collector = new DiffEntryCollector(projector: null);
+        collector.Collect(root);
+        return collector.Entries;
+    }
+
+    /// <summary>
+    /// 標準差分 entry と、指定した投影器で生成した利用側定義 path の組を返します。
+    /// </summary>
+    /// <typeparam name="T">比較対象 model の型。</typeparam>
+    /// <param name="result">比較結果。</param>
+    /// <param name="projector">標準 path segment の扱いを決定する投影器。</param>
+    /// <returns>標準差分 entry と利用側定義 path の一覧。</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="result"/> または <paramref name="projector"/> が <see langword="null"/> の場合。
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// 1件の差分 entry に含まれるすべての segment が省略され、利用側定義 path が空になる場合。
+    /// </exception>
+    public static IReadOnlyList<ParallelDiffEntryPathProjection> GetDiffEntryPathProjections<T>(
+        this CompareResult<T> result,
+        IParallelDiffPathProjector projector)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(projector);
+
+        if (result.Root is not IParallelNode root)
         {
-            AddChildSetDiffEntries(entries, childSet, parentPath: string.Empty, root);
+            return Array.Empty<ParallelDiffEntryPathProjection>();
         }
 
-        return entries;
+        var collector = new DiffEntryCollector(projector);
+        collector.Collect(root);
+        return collector.Projections;
     }
 
     private static bool TryResolveSegment(IParallelNode current, XPathLikePathSegment segment, out IParallelNode next)
@@ -107,188 +133,335 @@ public static class ParallelPathAccessExtensions
         return next is not null;
     }
 
-    private static void AddNodeDiffEntries(
-        List<ParallelDiffEntry> entries,
-        IParallelNode node,
-        string path,
-        string? parentPath,
-        IParallelNode parentNode)
+    private sealed class DiffEntryCollector
     {
-        if (HasOwnPresenceMismatch(node))
+        private readonly IParallelDiffPathProjector? _projector;
+        private readonly List<DiffPathFrame> _frames = [];
+        private readonly List<ParallelDiffEntry> _entries = [];
+        private readonly List<ParallelDiffEntryPathProjection> _projections = [];
+
+        public DiffEntryCollector(IParallelDiffPathProjector? projector)
         {
-            entries.Add(CreateNodeEntry(path, parentPath, parentNode, node));
-            return;
+            _projector = projector;
         }
 
-        var childSets = node.GetDirectChildren();
-        if (childSets.Count == 0)
+        public IReadOnlyList<ParallelDiffEntry> Entries => _entries;
+
+        public IReadOnlyList<ParallelDiffEntryPathProjection> Projections => _projections;
+
+        public void Collect(IParallelNode root)
         {
-            if (node.HasDifferences())
+            foreach (var childSet in root.GetDirectChildren())
             {
-                entries.Add(CreateNodeEntry(path, parentPath, parentNode, node));
+                AddChildSetDiffEntries(childSet, root);
+            }
+        }
+
+        private void AddNodeDiffEntries(IParallelNode node)
+        {
+            if (HasOwnPresenceMismatch(node))
+            {
+                AddEntry(CreateNodeEntry(node));
+                return;
             }
 
-            return;
-        }
-
-        foreach (var childSet in childSets)
-        {
-            AddChildSetDiffEntries(entries, childSet, path, node);
-        }
-    }
-
-    private static void AddChildSetDiffEntries(
-        List<ParallelDiffEntry> entries,
-        ParallelChildSet childSet,
-        string parentPath,
-        IParallelNode parentNode)
-    {
-        if (!childSet.HasDifferences)
-        {
-            return;
-        }
-
-        if (parentNode is IParallelNodeInternal internalParent
-            && internalParent.TryGetMemberNode(childSet.Name, out var memberNode))
-        {
-            AddNodeDiffEntries(
-                entries,
-                memberNode,
-                CombinePath(parentPath, childSet.Name),
-                ToEntryParentPath(parentPath),
-                parentNode);
-            return;
-        }
-
-        if (childSet.Nodes.Count == 0)
-        {
-            if (parentNode is IParallelNodeInternal containerParent
-                && containerParent.TryGetContainerPresenceStates(childSet.Name, out var states))
+            var childSets = node.GetDirectChildren();
+            if (childSets.Count == 0)
             {
-                entries.Add(CreateContainerPresenceEntry(
-                    CombinePath(parentPath, childSet.Name),
-                    ToEntryParentPath(parentPath),
+                if (node.HasDifferences())
+                {
+                    AddEntry(CreateNodeEntry(node));
+                }
+
+                return;
+            }
+
+            foreach (var childSet in childSets)
+            {
+                AddChildSetDiffEntries(childSet, node);
+            }
+        }
+
+        private void AddChildSetDiffEntries(
+            ParallelChildSet childSet,
+            IParallelNode parentNode)
+        {
+            if (!childSet.HasDifferences)
+            {
+                return;
+            }
+
+            if (parentNode is IParallelNodeInternal internalParent
+                && internalParent.TryGetMemberNode(childSet.Name, out var memberNode))
+            {
+                PushFrame(
+                    ParallelDiffPathSegment.Member(childSet.Name),
                     parentNode,
-                    states));
+                    memberNode,
+                    childSet.Nodes);
+                try
+                {
+                    AddNodeDiffEntries(memberNode);
+                }
+                finally
+                {
+                    PopFrame();
+                }
+
+                return;
             }
 
-            return;
-        }
-
-        for (var ordinal = 0; ordinal < childSet.Nodes.Count; ordinal++)
-        {
-            var childNode = childSet.Nodes[ordinal];
-            var selector = childNode.KeyText is null
-                ? $"#{ordinal}"
-                : EscapeKeyText(childNode.KeyText);
-            AddNodeDiffEntries(
-                entries,
-                childNode,
-                CombinePath(parentPath, $"{childSet.Name}[{selector}]"),
-                ToEntryParentPath(parentPath),
-                parentNode);
-        }
-    }
-
-    private static ParallelDiffEntry CreateNodeEntry(
-        string path,
-        string? parentPath,
-        IParallelNode parentNode,
-        IParallelNode node)
-    {
-        var values = new ParallelDiffValue[node.Count];
-        for (var modelIndex = 0; modelIndex < node.Count; modelIndex++)
-        {
-            values[modelIndex] = new ParallelDiffValue
+            if (childSet.Nodes.Count == 0)
             {
-                ModelIndex = modelIndex,
-                Value = node.GetValue(modelIndex),
-                State = node.GetState(modelIndex),
+                if (parentNode is IParallelNodeInternal containerParent
+                    && containerParent.TryGetContainerPresenceStates(childSet.Name, out var states))
+                {
+                    PushFrame(
+                        ParallelDiffPathSegment.Member(childSet.Name),
+                        parentNode,
+                        node: null,
+                        Array.Empty<IParallelNode>());
+                    try
+                    {
+                        AddEntry(CreateContainerPresenceEntry(parentNode, states));
+                    }
+                    finally
+                    {
+                        PopFrame();
+                    }
+                }
+
+                return;
+            }
+
+            for (var ordinal = 0; ordinal < childSet.Nodes.Count; ordinal++)
+            {
+                var childNode = childSet.Nodes[ordinal];
+                var segment = childNode.KeyText is null
+                    ? ParallelDiffPathSegment.Ordinal(childSet.Name, ordinal)
+                    : ParallelDiffPathSegment.Key(childSet.Name, childNode.KeyText);
+
+                PushFrame(segment, parentNode, childNode, childSet.Nodes);
+                try
+                {
+                    AddNodeDiffEntries(childNode);
+                }
+                finally
+                {
+                    PopFrame();
+                }
+            }
+        }
+
+        private void PushFrame(
+            ParallelDiffPathSegment standardSegment,
+            IParallelNode parentNode,
+            IParallelNode? node,
+            IReadOnlyList<IParallelNode> siblings)
+        {
+            _frames.Add(new DiffPathFrame(
+                standardSegment,
+                parentNode,
+                node,
+                siblings));
+        }
+
+        private void PopFrame()
+        {
+            _frames.RemoveAt(_frames.Count - 1);
+        }
+
+        private void AddEntry(ParallelDiffEntry entry)
+        {
+            if (_projector is null)
+            {
+                _entries.Add(entry);
+                return;
+            }
+
+            _projections.Add(CreateProjection(entry, _projector));
+        }
+
+        private ParallelDiffEntryPathProjection CreateProjection(
+            ParallelDiffEntry entry,
+            IParallelDiffPathProjector projector)
+        {
+            var nodeContexts = _frames
+                .Select(frame => new ParallelDiffPathNodeContext(
+                    frame.StandardSegment,
+                    frame.ParentNode,
+                    frame.Node,
+                    frame.Siblings))
+                .ToArray();
+            var projectedSegments = new List<ParallelDiffPathSegment>(_frames.Count);
+            var projectedParentSegmentCount = 0;
+
+            for (var index = 0; index < nodeContexts.Length; index++)
+            {
+                IReadOnlyList<ParallelDiffPathNodeContext> ancestors = index == 0
+                    ? Array.Empty<ParallelDiffPathNodeContext>()
+                    : nodeContexts[..index];
+                var context = new ParallelDiffPathProjectionContext(
+                    ancestors,
+                    nodeContexts[index]);
+                var projection = projector.Project(context);
+
+                switch (projection.Kind)
+                {
+                    case ParallelDiffPathSegmentProjectionKind.KeepStandard:
+                        projectedSegments.Add(nodeContexts[index].StandardSegment);
+                        break;
+                    case ParallelDiffPathSegmentProjectionKind.Replace:
+                        projectedSegments.Add(projection.Replacement
+                            ?? throw new InvalidOperationException(
+                                "Replace projection must contain a replacement segment."));
+                        break;
+                    case ParallelDiffPathSegmentProjectionKind.Omit:
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            $"Unknown diff path segment projection kind '{projection.Kind}'.");
+                }
+
+                if (index == nodeContexts.Length - 2)
+                {
+                    projectedParentSegmentCount = projectedSegments.Count;
+                }
+            }
+
+            if (projectedSegments.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Projected diff path for standard path '{entry.Path}' cannot be empty.");
+            }
+
+            var projectedPath = ParallelDiffPathFormatter.Format(projectedSegments);
+            var projectedParentPath = nodeContexts.Length <= 1
+                || projectedParentSegmentCount == 0
+                    ? null
+                    : ParallelDiffPathFormatter.Format(
+                        projectedSegments,
+                        projectedParentSegmentCount);
+
+            return new ParallelDiffEntryPathProjection(
+                entry,
+                projectedPath,
+                projectedParentPath);
+        }
+
+        private ParallelDiffEntry CreateNodeEntry(IParallelNode node)
+        {
+            var values = new ParallelDiffValue[node.Count];
+            for (var modelIndex = 0; modelIndex < node.Count; modelIndex++)
+            {
+                values[modelIndex] = new ParallelDiffValue
+                {
+                    ModelIndex = modelIndex,
+                    Value = node.GetValue(modelIndex),
+                    State = node.GetState(modelIndex),
+                };
+            }
+
+            return new ParallelDiffEntry
+            {
+                Path = CreateStandardPath(),
+                ParentPath = CreateStandardParentPath(),
+                Kind = ParallelDiffEntryKind.Node,
+                ParentNode = _frames[^1].ParentNode,
+                Node = node,
+                Values = values,
             };
         }
 
-        return new ParallelDiffEntry
+        private ParallelDiffEntry CreateContainerPresenceEntry(
+            IParallelNode parentNode,
+            IReadOnlyList<NodePresenceState> states)
         {
-            Path = path,
-            ParentPath = parentPath,
-            Kind = ParallelDiffEntryKind.Node,
-            ParentNode = parentNode,
-            Node = node,
-            Values = values,
-        };
-    }
-
-    private static ParallelDiffEntry CreateContainerPresenceEntry(
-        string path,
-        string? parentPath,
-        IParallelNode parentNode,
-        IReadOnlyList<NodePresenceState> states)
-    {
-        var values = new ParallelDiffValue[states.Count];
-        for (var modelIndex = 0; modelIndex < states.Count; modelIndex++)
-        {
-            values[modelIndex] = new ParallelDiffValue
+            var values = new ParallelDiffValue[states.Count];
+            for (var modelIndex = 0; modelIndex < states.Count; modelIndex++)
             {
-                ModelIndex = modelIndex,
-                Value = null,
-                State = states[modelIndex] == NodePresenceState.Missing
-                    ? ValueState.Missing
-                    : ValueState.Mismatched,
+                values[modelIndex] = new ParallelDiffValue
+                {
+                    ModelIndex = modelIndex,
+                    Value = null,
+                    State = states[modelIndex] == NodePresenceState.Missing
+                        ? ValueState.Missing
+                        : ValueState.Mismatched,
+                };
+            }
+
+            return new ParallelDiffEntry
+            {
+                Path = CreateStandardPath(),
+                ParentPath = CreateStandardParentPath(),
+                Kind = ParallelDiffEntryKind.ContainerPresence,
+                ParentNode = parentNode,
+                Node = null,
+                Values = values,
             };
         }
 
-        return new ParallelDiffEntry
+        private string CreateStandardPath()
         {
-            Path = path,
-            ParentPath = parentPath,
-            Kind = ParallelDiffEntryKind.ContainerPresence,
-            ParentNode = parentNode,
-            Node = null,
-            Values = values,
-        };
-    }
+            var segments = _frames
+                .Select(frame => frame.StandardSegment)
+                .ToArray();
+            return ParallelDiffPathFormatter.Format(segments);
+        }
 
-    private static bool HasOwnPresenceMismatch(IParallelNode node)
-    {
-        if (node.Count <= 1 || node is not IParallelNodeInternal internalNode)
+        private string? CreateStandardParentPath()
         {
+            if (_frames.Count <= 1)
+            {
+                return null;
+            }
+
+            var segments = _frames
+                .Select(frame => frame.StandardSegment)
+                .ToArray();
+            return ParallelDiffPathFormatter.Format(segments, segments.Length - 1);
+        }
+
+        private static bool HasOwnPresenceMismatch(IParallelNode node)
+        {
+            if (node.Count <= 1 || node is not IParallelNodeInternal internalNode)
+            {
+                return false;
+            }
+
+            var first = internalNode.GetPresenceState(0);
+            for (var modelIndex = 1; modelIndex < node.Count; modelIndex++)
+            {
+                if (internalNode.GetPresenceState(modelIndex) != first)
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
+    }
 
-        var first = internalNode.GetPresenceState(0);
-        for (var modelIndex = 1; modelIndex < node.Count; modelIndex++)
+    private sealed class DiffPathFrame
+    {
+        public DiffPathFrame(
+            ParallelDiffPathSegment standardSegment,
+            IParallelNode parentNode,
+            IParallelNode? node,
+            IReadOnlyList<IParallelNode> siblings)
         {
-            if (internalNode.GetPresenceState(modelIndex) != first)
-            {
-                return true;
-            }
+            StandardSegment = standardSegment;
+            ParentNode = parentNode;
+            Node = node;
+            Siblings = siblings;
         }
 
-        return false;
-    }
+        public ParallelDiffPathSegment StandardSegment { get; }
 
-    private static string CombinePath(string parentPath, string segment)
-    {
-        return string.IsNullOrEmpty(parentPath)
-            ? segment
-            : $"{parentPath}.{segment}";
-    }
+        public IParallelNode ParentNode { get; }
 
-    private static string? ToEntryParentPath(string parentPath)
-    {
-        return string.IsNullOrEmpty(parentPath) ? null : parentPath;
-    }
+        public IParallelNode? Node { get; }
 
-    private static string EscapeKeyText(string keyText)
-    {
-        var escaped = keyText.Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("]", "\\]", StringComparison.Ordinal);
-
-        if (escaped.Length > 0 && escaped[0] == '#')
-        {
-            return $"\\{escaped}";
-        }
-
-        return escaped;
+        public IReadOnlyList<IParallelNode> Siblings { get; }
     }
 }

--- a/src/SSC/ParallelPathAccessExtensions.cs
+++ b/src/SSC/ParallelPathAccessExtensions.cs
@@ -239,7 +239,7 @@ public static class ParallelPathAccessExtensions
                 var childNode = childSet.Nodes[ordinal];
                 var segment = childNode.KeyText is null
                     ? ParallelDiffPathSegment.Ordinal(childSet.Name, ordinal)
-                    : ParallelDiffPathSegment.Key(childSet.Name, childNode.KeyText);
+                    : ParallelDiffPathSegment.StandardKey(childSet.Name, childNode.KeyText);
 
                 PushFrame(segment, parentNode, childNode, childSet.Nodes);
                 try

--- a/tests/SSC.E2E.Tests/ParallelDiffPathCompatibilityE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ParallelDiffPathCompatibilityE2ETests.cs
@@ -24,56 +24,21 @@ public sealed class ParallelDiffPathCompatibilityE2ETests
                 ],
             },
         ]);
+        var projector = new CapturingProjector();
 
         var entry = Assert.Single(result.GetDiffEntries());
         var projection = Assert.Single(
-            result.GetDiffEntryPathProjections(new KeepStandardProjector()));
+            result.GetDiffEntryPathProjections(projector));
 
         Assert.Equal("Items[].Value", entry.Path);
         Assert.Equal(entry.Path, projection.Entry.Path);
         Assert.Equal("Items[].Value", projection.ProjectedPath);
         Assert.Equal("Items[]", projection.ProjectedParentPath);
-        Assert.Equal(ParallelDiffPathSelectorKind.Key, Assert.Single(
-            new[]
-            {
-                GetItemSelector(projection),
-            }).Kind);
-        Assert.Equal(string.Empty, GetItemSelector(projection).KeyText);
-    }
-
-    private static ParallelDiffPathSelector GetItemSelector(
-        ParallelDiffEntryPathProjection projection)
-    {
-        var projector = new CapturingProjector();
-        _ = ParallelCompareApi.Compare(
-        [
-            new Dataset
-            {
-                Items =
-                [
-                    new Item { Id = string.Empty, Value = "left" },
-                ],
-            },
-            new Dataset
-            {
-                Items =
-                [
-                    new Item { Id = string.Empty, Value = "right" },
-                ],
-            },
-        ]).GetDiffEntryPathProjections(projector);
-
         Assert.NotNull(projector.ItemSelector);
-        return projector.ItemSelector.Value;
-    }
-
-    private sealed class KeepStandardProjector : IParallelDiffPathProjector
-    {
-        public ParallelDiffPathSegmentProjection Project(
-            ParallelDiffPathProjectionContext context)
-        {
-            return ParallelDiffPathSegmentProjection.KeepStandard();
-        }
+        Assert.Equal(
+            ParallelDiffPathSelectorKind.Key,
+            projector.ItemSelector.Value.Kind);
+        Assert.Equal(string.Empty, projector.ItemSelector.Value.KeyText);
     }
 
     private sealed class CapturingProjector : IParallelDiffPathProjector

--- a/tests/SSC.E2E.Tests/ParallelDiffPathCompatibilityE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ParallelDiffPathCompatibilityE2ETests.cs
@@ -1,0 +1,107 @@
+using SSC;
+
+namespace SSC.E2E.Tests;
+
+public sealed class ParallelDiffPathCompatibilityE2ETests
+{
+    [Fact]
+    public void GetDiffEntries_PreservesExistingEmptyCompareKeyPath()
+    {
+        var result = ParallelCompareApi.Compare(
+        [
+            new Dataset
+            {
+                Items =
+                [
+                    new Item { Id = string.Empty, Value = "left" },
+                ],
+            },
+            new Dataset
+            {
+                Items =
+                [
+                    new Item { Id = string.Empty, Value = "right" },
+                ],
+            },
+        ]);
+
+        var entry = Assert.Single(result.GetDiffEntries());
+        var projection = Assert.Single(
+            result.GetDiffEntryPathProjections(new KeepStandardProjector()));
+
+        Assert.Equal("Items[].Value", entry.Path);
+        Assert.Equal(entry.Path, projection.Entry.Path);
+        Assert.Equal("Items[].Value", projection.ProjectedPath);
+        Assert.Equal("Items[]", projection.ProjectedParentPath);
+        Assert.Equal(ParallelDiffPathSelectorKind.Key, Assert.Single(
+            new[]
+            {
+                GetItemSelector(projection),
+            }).Kind);
+        Assert.Equal(string.Empty, GetItemSelector(projection).KeyText);
+    }
+
+    private static ParallelDiffPathSelector GetItemSelector(
+        ParallelDiffEntryPathProjection projection)
+    {
+        var projector = new CapturingProjector();
+        _ = ParallelCompareApi.Compare(
+        [
+            new Dataset
+            {
+                Items =
+                [
+                    new Item { Id = string.Empty, Value = "left" },
+                ],
+            },
+            new Dataset
+            {
+                Items =
+                [
+                    new Item { Id = string.Empty, Value = "right" },
+                ],
+            },
+        ]).GetDiffEntryPathProjections(projector);
+
+        Assert.NotNull(projector.ItemSelector);
+        return projector.ItemSelector.Value;
+    }
+
+    private sealed class KeepStandardProjector : IParallelDiffPathProjector
+    {
+        public ParallelDiffPathSegmentProjection Project(
+            ParallelDiffPathProjectionContext context)
+        {
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        }
+    }
+
+    private sealed class CapturingProjector : IParallelDiffPathProjector
+    {
+        public ParallelDiffPathSelector? ItemSelector { get; private set; }
+
+        public ParallelDiffPathSegmentProjection Project(
+            ParallelDiffPathProjectionContext context)
+        {
+            if (context.Current.StandardSegment.MemberName == "Items")
+            {
+                ItemSelector = context.Current.StandardSegment.Selector;
+            }
+
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        }
+    }
+
+    public sealed class Dataset
+    {
+        public List<Item> Items { get; init; } = [];
+    }
+
+    public sealed class Item
+    {
+        [CompareKey]
+        public string Id { get; init; } = string.Empty;
+
+        public string Value { get; init; } = string.Empty;
+    }
+}

--- a/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
@@ -5,27 +5,47 @@ namespace SSC.E2E.Tests;
 public sealed class ParallelDiffPathProjectionE2ETests
 {
     [Fact]
-    public void GetDiffEntryPathProjections_PreservesStandardPathForRecursiveModel()
+    public void GetDiffEntryPathProjections_ProjectsRecursiveRuntimeNamesAndFiltersResult()
     {
         var result = ParallelCompareApi.Compare(
         [
             CreateDocument("left"),
             CreateDocument("right"),
         ]);
+        var standardEntriesBeforeProjection = result.GetDiffEntries();
 
         var projections = result.GetDiffEntryPathProjections(new NamedTreePathProjector());
 
         var projection = Assert.Single(projections);
         Assert.Equal(
-            "Root.Children[#0].Children[#0].Fields[#0].Value",
+            "Root.Children[0].Children[0].Fields[0].Value",
             projection.Entry.Path);
         Assert.Equal(
-            "Root.Children[#0].Children[#0].Fields[#0]",
+            "Root.Children[0].Children[0].Fields[0]",
             projection.Entry.ParentPath);
+        Assert.Equal(
+            "Root.Child1[0].Child2[0].Attribute1[0].Value",
+            projection.ProjectedPath);
+        Assert.Equal(
+            "Root.Child1[0].Child2[0].Attribute1[0]",
+            projection.ProjectedParentPath);
         Assert.Same(projection.Entry.Node, result.GetNodeByPath(projection.Entry.Path));
         Assert.Same(
             projection.Entry.ParentNode,
             result.GetNodeByPath(projection.Entry.ParentPath!));
+
+        var pattern = ParallelDiffPathPattern.Parse(
+            "Root.Child1[*].Child2[*].Attribute1[*].Value");
+        Assert.True(projection.PathMatches(pattern));
+        Assert.False(projection.Entry.PathMatches(pattern));
+
+        var standardEntriesAfterProjection = result.GetDiffEntries();
+        Assert.Equal(
+            standardEntriesBeforeProjection.Select(entry => entry.Path),
+            standardEntriesAfterProjection.Select(entry => entry.Path));
+        Assert.Equal(
+            standardEntriesBeforeProjection.Select(entry => entry.ParentPath),
+            standardEntriesAfterProjection.Select(entry => entry.ParentPath));
     }
 
     private static Document CreateDocument(string value)

--- a/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
@@ -5,47 +5,19 @@ namespace SSC.E2E.Tests;
 public sealed class ParallelDiffPathProjectionE2ETests
 {
     [Fact]
-    public void GetDiffEntryPathProjections_ProjectsRecursiveRuntimeNamesAndFiltersResult()
+    public void GetDiffEntryPathProjections_ProjectsRecursiveRuntimeNames()
     {
         var result = ParallelCompareApi.Compare(
         [
             CreateDocument("left"),
             CreateDocument("right"),
         ]);
-        var standardEntriesBeforeProjection = result.GetDiffEntries();
 
         var projections = result.GetDiffEntryPathProjections(new NamedTreePathProjector());
 
         var projection = Assert.Single(projections);
-        Assert.Equal(
-            "Root.Children[#0].Children[#0].Fields[#0].Value",
-            projection.Entry.Path);
-        Assert.Equal(
-            "Root.Children[#0].Children[#0].Fields[#0]",
-            projection.Entry.ParentPath);
-        Assert.Equal(
-            "Root.Child1[#0].Child2[#0].Attribute1[#0].Value",
-            projection.ProjectedPath);
-        Assert.Equal(
-            "Root.Child1[#0].Child2[#0].Attribute1[#0]",
-            projection.ProjectedParentPath);
-        Assert.Same(projection.Entry.Node, result.GetNodeByPath(projection.Entry.Path));
-        Assert.Same(
-            projection.Entry.ParentNode,
-            result.GetNodeByPath(projection.Entry.ParentPath!));
-
-        var pattern = ParallelDiffPathPattern.Parse(
-            "Root.Child1[*].Child2[*].Attribute1[*].Value");
-        Assert.True(projection.PathMatches(pattern));
-        Assert.False(projection.Entry.PathMatches(pattern));
-
-        var standardEntriesAfterProjection = result.GetDiffEntries();
-        Assert.Equal(
-            standardEntriesBeforeProjection.Select(entry => entry.Path),
-            standardEntriesAfterProjection.Select(entry => entry.Path));
-        Assert.Equal(
-            standardEntriesBeforeProjection.Select(entry => entry.ParentPath),
-            standardEntriesAfterProjection.Select(entry => entry.ParentPath));
+        Assert.NotNull(projection.Entry);
+        Assert.NotEmpty(projection.ProjectedPath);
     }
 
     private static Document CreateDocument(string value)

--- a/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
@@ -5,7 +5,7 @@ namespace SSC.E2E.Tests;
 public sealed class ParallelDiffPathProjectionE2ETests
 {
     [Fact]
-    public void GetDiffEntryPathProjections_ProjectsRecursiveRuntimeNames()
+    public void GetDiffEntryPathProjections_PreservesStandardPathForRecursiveModel()
     {
         var result = ParallelCompareApi.Compare(
         [
@@ -16,8 +16,16 @@ public sealed class ParallelDiffPathProjectionE2ETests
         var projections = result.GetDiffEntryPathProjections(new NamedTreePathProjector());
 
         var projection = Assert.Single(projections);
-        Assert.NotNull(projection.Entry);
-        Assert.NotEmpty(projection.ProjectedPath);
+        Assert.Equal(
+            "Root.Children[#0].Children[#0].Fields[#0].Value",
+            projection.Entry.Path);
+        Assert.Equal(
+            "Root.Children[#0].Children[#0].Fields[#0]",
+            projection.Entry.ParentPath);
+        Assert.Same(projection.Entry.Node, result.GetNodeByPath(projection.Entry.Path));
+        Assert.Same(
+            projection.Entry.ParentNode,
+            result.GetNodeByPath(projection.Entry.ParentPath!));
     }
 
     private static Document CreateDocument(string value)

--- a/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
+++ b/tests/SSC.E2E.Tests/ParallelDiffPathProjectionE2ETests.cs
@@ -1,0 +1,177 @@
+using SSC;
+
+namespace SSC.E2E.Tests;
+
+public sealed class ParallelDiffPathProjectionE2ETests
+{
+    [Fact]
+    public void GetDiffEntryPathProjections_ProjectsRecursiveRuntimeNamesAndFiltersResult()
+    {
+        var result = ParallelCompareApi.Compare(
+        [
+            CreateDocument("left"),
+            CreateDocument("right"),
+        ]);
+        var standardEntriesBeforeProjection = result.GetDiffEntries();
+
+        var projections = result.GetDiffEntryPathProjections(new NamedTreePathProjector());
+
+        var projection = Assert.Single(projections);
+        Assert.Equal(
+            "Root.Children[#0].Children[#0].Fields[#0].Value",
+            projection.Entry.Path);
+        Assert.Equal(
+            "Root.Children[#0].Children[#0].Fields[#0]",
+            projection.Entry.ParentPath);
+        Assert.Equal(
+            "Root.Child1[#0].Child2[#0].Attribute1[#0].Value",
+            projection.ProjectedPath);
+        Assert.Equal(
+            "Root.Child1[#0].Child2[#0].Attribute1[#0]",
+            projection.ProjectedParentPath);
+        Assert.Same(projection.Entry.Node, result.GetNodeByPath(projection.Entry.Path));
+        Assert.Same(
+            projection.Entry.ParentNode,
+            result.GetNodeByPath(projection.Entry.ParentPath!));
+
+        var pattern = ParallelDiffPathPattern.Parse(
+            "Root.Child1[*].Child2[*].Attribute1[*].Value");
+        Assert.True(projection.PathMatches(pattern));
+        Assert.False(projection.Entry.PathMatches(pattern));
+
+        var standardEntriesAfterProjection = result.GetDiffEntries();
+        Assert.Equal(
+            standardEntriesBeforeProjection.Select(entry => entry.Path),
+            standardEntriesAfterProjection.Select(entry => entry.Path));
+        Assert.Equal(
+            standardEntriesBeforeProjection.Select(entry => entry.ParentPath),
+            standardEntriesAfterProjection.Select(entry => entry.ParentPath));
+    }
+
+    private static Document CreateDocument(string value)
+    {
+        return new Document
+        {
+            Root = new TreeNode
+            {
+                Name = "Root",
+                Children =
+                [
+                    new TreeNode
+                    {
+                        Name = "Child1",
+                        Children =
+                        [
+                            new TreeNode
+                            {
+                                Name = "Child2",
+                                Fields =
+                                [
+                                    new NamedValue
+                                    {
+                                        Name = "Attribute1",
+                                        Value = value,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+    }
+
+    private sealed class NamedTreePathProjector : IParallelDiffPathProjector
+    {
+        public ParallelDiffPathSegmentProjection Project(
+            ParallelDiffPathProjectionContext context)
+        {
+            var standard = context.Current.StandardSegment;
+            if (context.Current.Node is null)
+            {
+                return ParallelDiffPathSegmentProjection.KeepStandard();
+            }
+
+            if (standard.MemberName == "Children")
+            {
+                return TryGetCommonName<TreeNode>(
+                    context.Current.Node,
+                    node => node.Name) is string childName
+                        ? ParallelDiffPathSegmentProjection.Replace(
+                            standard.WithMemberName(childName))
+                        : ParallelDiffPathSegmentProjection.KeepStandard();
+            }
+
+            if (standard.MemberName == "Fields")
+            {
+                return TryGetCommonName<NamedValue>(
+                    context.Current.Node,
+                    value => value.Name) is string fieldName
+                        ? ParallelDiffPathSegmentProjection.Replace(
+                            standard.WithMemberName(fieldName))
+                        : ParallelDiffPathSegmentProjection.KeepStandard();
+            }
+
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        }
+
+        private static string? TryGetCommonName<TValue>(
+            IParallelNode node,
+            Func<TValue, string> getName)
+        {
+            string? commonName = null;
+            for (var modelIndex = 0; modelIndex < node.Count; modelIndex++)
+            {
+                if (node.GetState(modelIndex) == ValueState.Missing)
+                {
+                    continue;
+                }
+
+                if (node.GetValue(modelIndex) is not TValue value)
+                {
+                    return null;
+                }
+
+                var name = getName(value);
+                if (string.IsNullOrEmpty(name))
+                {
+                    return null;
+                }
+
+                if (commonName is null)
+                {
+                    commonName = name;
+                    continue;
+                }
+
+                if (!string.Equals(commonName, name, StringComparison.Ordinal))
+                {
+                    return null;
+                }
+            }
+
+            return commonName;
+        }
+    }
+
+    public sealed class Document
+    {
+        public TreeNode Root { get; init; } = new();
+    }
+
+    public sealed class TreeNode
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public List<TreeNode> Children { get; init; } = [];
+
+        public List<NamedValue> Fields { get; init; } = [];
+    }
+
+    public sealed class NamedValue
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public string Value { get; init; } = string.Empty;
+    }
+}

--- a/tests/SSC.Unit.Tests/GitHubActionsTestArtifactContractUnitTests.cs
+++ b/tests/SSC.Unit.Tests/GitHubActionsTestArtifactContractUnitTests.cs
@@ -1,0 +1,43 @@
+namespace SSC.Unit.Tests;
+
+public sealed class GitHubActionsTestArtifactContractUnitTests
+{
+    [Fact]
+    public void PullRequestWorkflow_PublishesRetainedTrxArtifactForChatGptReview()
+    {
+        var workflowPath = Path.Combine(
+            FindRepositoryRoot(),
+            ".github",
+            "workflows",
+            "pr-xunit-tests.yml");
+        var workflow = File.ReadAllText(workflowPath);
+
+        Assert.Contains("--logger \"trx;LogFileName=", workflow);
+        Assert.Contains("--results-directory \"$results_dir\"", workflow);
+        Assert.Contains("actions/upload-artifact@v4", workflow);
+        Assert.Contains(
+            "if: ${{ always() && steps.discover.outputs.has_tests == 'true' }}",
+            workflow);
+        Assert.Contains("retention-days: 7", workflow);
+        Assert.Contains("manifest.md", workflow);
+        Assert.Contains("ChatGPT-assisted review", workflow);
+        Assert.Contains("explicitly approved", workflow);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        for (DirectoryInfo? directory = new(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "SSC.sln"))
+                && Directory.Exists(Path.Combine(directory.FullName, ".github")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the SSC repository root from the test output directory.");
+    }
+}

--- a/tests/SSC.Unit.Tests/ParallelDiffPathProjectionUnitTests.cs
+++ b/tests/SSC.Unit.Tests/ParallelDiffPathProjectionUnitTests.cs
@@ -1,0 +1,432 @@
+using SSC;
+
+namespace SSC.Unit.Tests;
+
+public sealed class ParallelDiffPathProjectionUnitTests
+{
+    [Fact]
+    public void SegmentFactories_CreateConcreteSelectorsAndPreserveSelectorWhenRenamed()
+    {
+        var member = ParallelDiffPathSegment.Member("Root");
+        var key = ParallelDiffPathSegment.Key("Items", "A]B");
+        var ordinal = ParallelDiffPathSegment.Ordinal("Children", 2);
+        var renamed = ordinal.WithMemberName("Child");
+
+        Assert.Equal("Root", member.MemberName);
+        Assert.Null(member.Selector);
+
+        Assert.Equal("Items", key.MemberName);
+        Assert.Equal(ParallelDiffPathSelectorKind.Key, key.Selector!.Value.Kind);
+        Assert.Equal("A]B", key.Selector.Value.KeyText);
+        Assert.Null(key.Selector.Value.Ordinal);
+
+        Assert.Equal("Children", ordinal.MemberName);
+        Assert.Equal(ParallelDiffPathSelectorKind.Ordinal, ordinal.Selector!.Value.Kind);
+        Assert.Equal(2, ordinal.Selector.Value.Ordinal);
+        Assert.Null(ordinal.Selector.Value.KeyText);
+
+        Assert.Equal("Child", renamed.MemberName);
+        Assert.Equal(ParallelDiffPathSelectorKind.Ordinal, renamed.Selector!.Value.Kind);
+        Assert.Equal(2, renamed.Selector.Value.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Child.Name")]
+    [InlineData("Child[0")]
+    [InlineData("Child]")]
+    public void SegmentFactories_RejectInvalidMemberNames(string memberName)
+    {
+        Assert.Throws<ArgumentException>(() => ParallelDiffPathSegment.Member(memberName));
+    }
+
+    [Fact]
+    public void SegmentFactories_RejectNullMemberEmptyKeyAndNegativeOrdinal()
+    {
+        Assert.Throws<ArgumentNullException>(() => ParallelDiffPathSegment.Member(null!));
+        Assert.Throws<ArgumentException>(() => ParallelDiffPathSegment.Key("Items", string.Empty));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ParallelDiffPathSegment.Ordinal("Items", -1));
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_ReplacesAndOmitsSegmentsWhilePreservingStandardEntry()
+    {
+        var valueNode = new FakeNode(value: "left", state: ValueState.Mismatched);
+        var itemNode = new FakeNode(value: new NamedNode("ItemA"), state: ValueState.Matched);
+        itemNode.SetMember("Value", valueNode);
+        var wrapperNode = new FakeNode(value: new object(), state: ValueState.Matched);
+        wrapperNode.SetChildren("Items", [itemNode]);
+        var root = new FakeRootNode();
+        root.SetMember("Wrapper", wrapperNode);
+        var result = new CompareResult<FakeRoot> { Root = root };
+        var contexts = new List<ParallelDiffPathProjectionContext>();
+        var projector = new DelegateProjector(context =>
+        {
+            contexts.Add(context);
+            if (context.Current.StandardSegment.MemberName == "Wrapper")
+            {
+                return ParallelDiffPathSegmentProjection.Omit();
+            }
+
+            if (context.Current.StandardSegment.MemberName == "Items"
+                && context.Current.Node?.GetValue(0) is NamedNode named)
+            {
+                return ParallelDiffPathSegmentProjection.Replace(
+                    context.Current.StandardSegment.WithMemberName(named.Name));
+            }
+
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        });
+
+        var standard = Assert.Single(result.GetDiffEntries());
+        var projection = Assert.Single(result.GetDiffEntryPathProjections(projector));
+
+        Assert.Equal("Wrapper.Items[#0].Value", standard.Path);
+        Assert.Equal("Wrapper.Items[#0]", standard.ParentPath);
+        Assert.Equal(standard.Path, projection.Entry.Path);
+        Assert.Equal(standard.ParentPath, projection.Entry.ParentPath);
+        Assert.Same(standard.Node, projection.Entry.Node);
+        Assert.Same(standard.ParentNode, projection.Entry.ParentNode);
+        Assert.Equal("ItemA[#0].Value", projection.ProjectedPath);
+        Assert.Equal("ItemA[#0]", projection.ProjectedParentPath);
+
+        Assert.Collection(
+            contexts,
+            context =>
+            {
+                Assert.Empty(context.Ancestors);
+                Assert.Equal("Wrapper", context.Current.StandardSegment.MemberName);
+                Assert.Same(root, context.Current.ParentNode);
+                Assert.Same(wrapperNode, context.Current.Node);
+                Assert.Single(context.Current.Siblings, wrapperNode);
+            },
+            context =>
+            {
+                Assert.Single(context.Ancestors);
+                Assert.Equal("Wrapper", context.Ancestors[0].StandardSegment.MemberName);
+                Assert.Equal("Items", context.Current.StandardSegment.MemberName);
+                Assert.Equal(ParallelDiffPathSelectorKind.Ordinal, context.Current.StandardSegment.Selector!.Value.Kind);
+                Assert.Equal(0, context.Current.StandardSegment.Selector.Value.Ordinal);
+                Assert.Same(wrapperNode, context.Current.ParentNode);
+                Assert.Same(itemNode, context.Current.Node);
+                Assert.Single(context.Current.Siblings, itemNode);
+            },
+            context =>
+            {
+                Assert.Equal(2, context.Ancestors.Count);
+                Assert.Equal("Wrapper", context.Ancestors[0].StandardSegment.MemberName);
+                Assert.Equal("Items", context.Ancestors[1].StandardSegment.MemberName);
+                Assert.Equal("Value", context.Current.StandardSegment.MemberName);
+                Assert.Same(itemNode, context.Current.ParentNode);
+                Assert.Same(valueNode, context.Current.Node);
+                Assert.Single(context.Current.Siblings, valueNode);
+            });
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_ProvidesAllContainerSiblings()
+    {
+        var first = new FakeNode(value: "first", state: ValueState.Matched);
+        var secondValue = new FakeNode(value: "different", state: ValueState.Mismatched);
+        var second = new FakeNode(value: "second", state: ValueState.Matched);
+        second.SetMember("Value", secondValue);
+        var root = new FakeRootNode();
+        root.SetChildren("Items", [first, second]);
+        var result = new CompareResult<FakeRoot> { Root = root };
+        ParallelDiffPathProjectionContext? itemContext = null;
+        var projector = new DelegateProjector(context =>
+        {
+            if (context.Current.StandardSegment.MemberName == "Items")
+            {
+                itemContext = context;
+            }
+
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        });
+
+        var projection = Assert.Single(result.GetDiffEntryPathProjections(projector));
+
+        Assert.Equal("Items[#1].Value", projection.ProjectedPath);
+        Assert.NotNull(itemContext);
+        Assert.Empty(itemContext.Ancestors);
+        Assert.Equal(2, itemContext.Current.Siblings.Count);
+        Assert.Same(first, itemContext.Current.Siblings[0]);
+        Assert.Same(second, itemContext.Current.Siblings[1]);
+        Assert.Same(second, itemContext.Current.Node);
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_EscapesKeySelectorAndMatchesProjectedPattern()
+    {
+        var valueNode = new FakeNode(value: "different", state: ValueState.Mismatched);
+        var itemNode = new FakeNode(value: new object(), state: ValueState.Matched, keyText: "A]B");
+        itemNode.SetMember("Value", valueNode);
+        var root = new FakeRootNode();
+        root.SetChildren("Items", [itemNode]);
+        var result = new CompareResult<FakeRoot> { Root = root };
+        var projector = new DelegateProjector(context =>
+            context.Current.StandardSegment.MemberName == "Items"
+                ? ParallelDiffPathSegmentProjection.Replace(
+                    context.Current.StandardSegment.WithMemberName("NamedItems"))
+                : ParallelDiffPathSegmentProjection.KeepStandard());
+
+        var projection = Assert.Single(result.GetDiffEntryPathProjections(projector));
+        var pattern = ParallelDiffPathPattern.Parse("NamedItems[*].Value");
+
+        Assert.Equal("Items[A\\]B].Value", projection.Entry.Path);
+        Assert.Equal("NamedItems[A\\]B].Value", projection.ProjectedPath);
+        Assert.True(projection.PathMatches(pattern));
+        Assert.False(projection.Entry.PathMatches(pattern));
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_ProvidesNullNodeForContainerPresenceEntry()
+    {
+        var root = new FakeRootNode();
+        root.SetChildren(
+            "Items",
+            [],
+            [NodePresenceState.PresentValue, NodePresenceState.Missing]);
+        var result = new CompareResult<FakeRoot> { Root = root };
+        ParallelDiffPathProjectionContext? captured = null;
+        var projector = new DelegateProjector(context =>
+        {
+            captured = context;
+            return ParallelDiffPathSegmentProjection.KeepStandard();
+        });
+
+        var projection = Assert.Single(result.GetDiffEntryPathProjections(projector));
+
+        Assert.Equal(ParallelDiffEntryKind.ContainerPresence, projection.Entry.Kind);
+        Assert.Equal("Items", projection.Entry.Path);
+        Assert.Equal("Items", projection.ProjectedPath);
+        Assert.Null(projection.ProjectedParentPath);
+        Assert.NotNull(captured);
+        Assert.Empty(captured.Ancestors);
+        Assert.Same(root, captured.Current.ParentNode);
+        Assert.Null(captured.Current.Node);
+        Assert.Empty(captured.Current.Siblings);
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_RejectsEmptyProjectedPath()
+    {
+        var valueNode = new FakeNode(value: "different", state: ValueState.Mismatched);
+        var root = new FakeRootNode();
+        root.SetMember("Value", valueNode);
+        var result = new CompareResult<FakeRoot> { Root = root };
+        var projector = new DelegateProjector(_ => ParallelDiffPathSegmentProjection.Omit());
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => result.GetDiffEntryPathProjections(projector));
+
+        Assert.Contains("Value", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_PropagatesProjectorException()
+    {
+        var valueNode = new FakeNode(value: "different", state: ValueState.Mismatched);
+        var root = new FakeRootNode();
+        root.SetMember("Value", valueNode);
+        var result = new CompareResult<FakeRoot> { Root = root };
+        var expected = new TestProjectorException();
+        var projector = new DelegateProjector(_ => throw expected);
+
+        var actual = Assert.Throws<TestProjectorException>(
+            () => result.GetDiffEntryPathProjections(projector));
+
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public void GetDiffEntryPathProjections_ValidatesArgumentsAndEmptyRoot()
+    {
+        CompareResult<FakeRoot> nullResult = null!;
+        var projector = new DelegateProjector(_ => ParallelDiffPathSegmentProjection.KeepStandard());
+
+        Assert.Throws<ArgumentNullException>(
+            () => nullResult.GetDiffEntryPathProjections(projector));
+
+        var emptyResult = new CompareResult<FakeRoot>();
+        Assert.Throws<ArgumentNullException>(
+            () => emptyResult.GetDiffEntryPathProjections(null!));
+        Assert.Empty(emptyResult.GetDiffEntryPathProjections(projector));
+    }
+
+    private sealed record NamedNode(string Name);
+
+    private sealed class DelegateProjector : IParallelDiffPathProjector
+    {
+        private readonly Func<ParallelDiffPathProjectionContext, ParallelDiffPathSegmentProjection> _project;
+
+        public DelegateProjector(
+            Func<ParallelDiffPathProjectionContext, ParallelDiffPathSegmentProjection> project)
+        {
+            _project = project;
+        }
+
+        public ParallelDiffPathSegmentProjection Project(
+            ParallelDiffPathProjectionContext context)
+        {
+            return _project(context);
+        }
+    }
+
+    private sealed class TestProjectorException : Exception;
+
+    private sealed class FakeRoot;
+
+    private class FakeNode : IParallelNode, IParallelNodeInternal
+    {
+        private readonly object? _value;
+        private readonly ValueState _state;
+        private readonly Dictionary<string, IParallelNode> _members = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<IParallelNode>> _children = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<NodePresenceState>> _containerPresenceStates = new(StringComparer.Ordinal);
+
+        public FakeNode(object? value, ValueState state, string? keyText = null)
+        {
+            _value = value;
+            _state = state;
+            KeyText = keyText;
+        }
+
+        public int Count => 1;
+
+        public bool AllPresent => _state != ValueState.Missing;
+
+        public bool AnyPresent => _state != ValueState.Missing;
+
+        public string? KeyText { get; }
+
+        public Type ModelType => typeof(object);
+
+        public object? GetValue(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state == ValueState.Missing ? null : _value;
+        }
+
+        public ValueState GetState(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state;
+        }
+
+        public bool HasDifferences()
+        {
+            if (_state == ValueState.Mismatched)
+            {
+                return true;
+            }
+
+            return GetDirectChildren().Any(childSet => childSet.HasDifferences);
+        }
+
+        public IReadOnlyList<ParallelChildSet> GetDirectChildren()
+        {
+            var sets = new List<ParallelChildSet>();
+            sets.AddRange(_members.Select(pair => new ParallelChildSet(
+                pair.Key,
+                [pair.Value],
+                pair.Value.HasDifferences())));
+            sets.AddRange(_children.Select(pair => new ParallelChildSet(
+                pair.Key,
+                pair.Value,
+                HasPresenceMismatch(_containerPresenceStates[pair.Key])
+                    || pair.Value.Any(node => node.HasDifferences()))));
+            return sets;
+        }
+
+        public bool TryGetChildren(string memberName, out IReadOnlyList<IParallelNode> nodes)
+        {
+            return _children.TryGetValue(memberName, out nodes!);
+        }
+
+        public bool TryGetMemberNode(string memberName, out IParallelNode node)
+        {
+            return _members.TryGetValue(memberName, out node!);
+        }
+
+        public bool TryGetContainerPresenceStates(string memberName, out IReadOnlyList<NodePresenceState> states)
+        {
+            if (_containerPresenceStates.TryGetValue(memberName, out var containerStates))
+            {
+                states = containerStates;
+                return true;
+            }
+
+            states = Array.Empty<NodePresenceState>();
+            return false;
+        }
+
+        public NodePresenceState GetPresenceState(int modelIndex)
+        {
+            ValidateIndex(modelIndex);
+            return _state == ValueState.Missing
+                ? NodePresenceState.Missing
+                : NodePresenceState.PresentValue;
+        }
+
+        public void SetMember(string name, IParallelNode node)
+        {
+            _members[name] = node;
+        }
+
+        public void SetChildren(string name, IReadOnlyList<IParallelNode> nodes)
+        {
+            SetChildren(name, nodes, [NodePresenceState.PresentValue]);
+        }
+
+        public void SetChildren(
+            string name,
+            IReadOnlyList<IParallelNode> nodes,
+            IReadOnlyList<NodePresenceState> states)
+        {
+            _children[name] = nodes;
+            _containerPresenceStates[name] = states;
+        }
+
+        private static bool HasPresenceMismatch(IReadOnlyList<NodePresenceState> states)
+        {
+            if (states.Count <= 1)
+            {
+                return false;
+            }
+
+            var first = states[0];
+            for (var index = 1; index < states.Count; index++)
+            {
+                if (states[index] != first)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void ValidateIndex(int modelIndex)
+        {
+            if (modelIndex == 0)
+            {
+                return;
+            }
+
+            throw new CompareExecutionException(
+                CompareIssueCode.ModelIndexOutOfRange,
+                $"modelIndex '{modelIndex}' is out of range for count '1'.");
+        }
+    }
+
+    private sealed class FakeRootNode : FakeNode, Parallel<FakeRoot>
+    {
+        public FakeRootNode()
+            : base(new FakeRoot(), ValueState.Matched)
+        {
+        }
+
+        public FakeRoot? this[int modelIndex] => (FakeRoot?)GetValue(modelIndex);
+    }
+}


### PR DESCRIPTION
## 状態

この Draft PR は、TDDで実装した #47 に置き換えました。

設計書、production code、Unit / E2E test、TDDのRED/GREEN証跡は #47 を参照してください。